### PR TITLE
Fix "missing keyword: :enum_type" in migrations

### DIFF
--- a/db/migrate/20190807020247_add_payment_info_to_adjustments.rb
+++ b/db/migrate/20190807020247_add_payment_info_to_adjustments.rb
@@ -3,7 +3,7 @@ class AddPaymentInfoToAdjustments < ActiveRecord::Migration[6.0]
     create_enum :adjustment_source, ["cash", "square"]
 
     change_table :adjustments do |t|
-      t.enum :payment_source, enum_name: :adjustment_source
+      t.enum :payment_source, enum_type: :adjustment_source
       t.column :square_transaction_id, :string
       t.change :adjustable_type, :string, null: true
       t.change :adjustable_id, :bigint, null: true

--- a/db/migrate/20190911020605_add_kind_to_adjustments.rb
+++ b/db/migrate/20190911020605_add_kind_to_adjustments.rb
@@ -3,7 +3,7 @@ class AddKindToAdjustments < ActiveRecord::Migration[6.0]
     create_enum :adjustment_kind, ["fine", "membership", "donation", "payment"]
 
     change_table :adjustments do |t|
-      t.enum :kind, enum_name: :adjustment_kind
+      t.enum :kind, enum_type: :adjustment_kind
     end
 
     reversible do |dir|

--- a/db/migrate/20191102002601_create_notifications.rb
+++ b/db/migrate/20191102002601_create_notifications.rb
@@ -7,7 +7,7 @@ class CreateNotifications < ActiveRecord::Migration[6.0]
       t.string :action, null: false
       t.references :member, null: false, foreign_key: true
       t.uuid :uuid, null: false
-      t.enum :status, enum_name: :notification_status, default: "pending", null: false
+      t.enum :status, enum_type: :notification_status, default: "pending", null: false
       t.string :subject, null: false
 
       t.timestamps

--- a/db/migrate/20200621211015_add_roles_to_users.rb
+++ b/db/migrate/20200621211015_add_roles_to_users.rb
@@ -3,7 +3,7 @@ class AddRolesToUsers < ActiveRecord::Migration[6.0]
     create_enum :user_role, ["staff", "admin"]
 
     change_table :users do |t|
-      t.enum :role, enum_name: :user_role, default: "staff", null: false
+      t.enum :role, enum_type: :user_role, default: "staff", null: false
     end
   end
 end

--- a/db/migrate/20200710004507_create_hold_requests.rb
+++ b/db/migrate/20200710004507_create_hold_requests.rb
@@ -11,7 +11,7 @@ class CreateHoldRequests < ActiveRecord::Migration[6.0]
       t.string :email
       t.references :member
       t.string :notes
-      t.enum :status, enum_name: :hold_request_status, null: false, default: "new"
+      t.enum :status, enum_type: :hold_request_status, null: false, default: "new"
       t.timestamps
     end
   end

--- a/db/migrate/20201002020141_add_power_source_to_items.rb
+++ b/db/migrate/20201002020141_add_power_source_to_items.rb
@@ -3,7 +3,7 @@ class AddPowerSourceToItems < ActiveRecord::Migration[6.0]
     create_enum :power_source, ["solar", "gas", "air", "electric (corded)", "electric (battery)"]
 
     change_table :items do |t|
-      t.enum :power_source, enum_name: :power_source
+      t.enum :power_source, enum_type: :power_source
     end
   end
 end

--- a/db/migrate/20201112012007_create_item_attachments.rb
+++ b/db/migrate/20201112012007_create_item_attachments.rb
@@ -5,7 +5,7 @@ class CreateItemAttachments < ActiveRecord::Migration[6.0]
     create_table :item_attachments do |t|
       t.belongs_to :item, null: false, foreign_key: true
       t.belongs_to :creator, null: false, foreign_key: {to_table: :users}
-      t.enum :kind, enum_name: :item_attachment_kind
+      t.enum :kind, enum_type: :item_attachment_kind
       t.string :other_kind
       t.string :notes
 

--- a/db/migrate/20210204025839_create_renewal_requests.rb
+++ b/db/migrate/20210204025839_create_renewal_requests.rb
@@ -3,7 +3,7 @@ class CreateRenewalRequests < ActiveRecord::Migration[6.0]
     create_enum :renewal_request_status, ["requested", "approved", "rejected"]
 
     create_table :renewal_requests do |t|
-      t.enum :status, enum_name: :renewal_request_status, null: false, default: "requested"
+      t.enum :status, enum_type: :renewal_request_status, null: false, default: "requested"
       t.belongs_to :loan, foreign_key: true
       t.timestamps
     end


### PR DESCRIPTION
# What it does

I think this makes migrations work!

The `activerecord-postgres_enum` gem was updated across a major version bump in https://github.com/chicago-tool-library/circulate/pull/928

The 2.0.0 gem release notes include the change:

> BREAKING Renamed enum_name to enum_type because Rails 7 added basic support for enums

# Why it is important

I believe this is necessary for `db:migrate` to work.

# Implementation notes

The `schema.rb` changes look to be cosmetic reordering _except_ the dropping of this line:

```
enable_extension "pg_stat_statements"
```

It looks like this is never added via a migration. From some history spelunking I see it was:

 1. Added in ba23291c7594c429aec32226c54ed8c48514c905
 2. Removed explicitly in 6b2e1d2467079609a7324d015e8bed312d7fab86
 3. Added back in 8e35c8f46ef63621b051b95f5860f926b308abdb

Do we know if we want this included or not? If so it looks like we can [enable it in a migration](https://stackoverflow.com/questions/35180280/rebuild-database-enable-extension-pg-stat-statements-line-got-removed-in-schema) to get it to stick in the schema.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
