### PR TITLE
Update Dockerfile version to match Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.3-alpine3.15 AS builder
+FROM ruby:3.1.4-alpine3.18 AS builder
 
 LABEL maintainer="jeanine@littleforestconsulting.com"
 
@@ -26,13 +26,14 @@ COPY . .
 
 ### BUILD STEP DONE ###
 
-FROM ruby:3.0.3-alpine3.15
+FROM ruby:3.1.4-alpine3.18
 
 ARG RAILS_ROOT=/usr/src/app/
 ARG USER_ID
 
 RUN apk update && apk upgrade && apk add --update --no-cache \
   bash \
+  gcompat \
   imagemagick \
   nodejs \
   postgresql-client \


### PR DESCRIPTION
# What it does

Looks like the version was bumped in
6e9d34f0c40cc0bb3566ceed0b936c46f40dd269 but the Docker build hasn't caught up. Easy fix!

# Why it is important

This fixes `docker-build.sh` bailing out with Ruby version mismatch errors.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
