### PR TITLE
Fix permissions issue and missing assets in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ WORKDIR $RAILS_ROOT
 COPY --from=builder $RAILS_ROOT $RAILS_ROOT
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+RUN rails assets:precompile
+
 EXPOSE 3000
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ COPY . .
 FROM ruby:3.1.4-alpine3.18
 
 ARG RAILS_ROOT=/usr/src/app/
-ARG USER_ID
 
 RUN apk update && apk upgrade && apk add --update --no-cache \
   bash \
@@ -53,13 +52,10 @@ RUN apk add --update --no-cache --virtual .ms-fonts msttcorefonts-installer && \
 RUN yarn global add node-gyp
 RUN yarn global add heroku
 
-RUN adduser --disabled-password --gecos '' --uid $USER_ID user
-USER user
-
 WORKDIR $RAILS_ROOT
 
-COPY --from=builder --chown=user:user $RAILS_ROOT $RAILS_ROOT
-COPY --from=builder --chown=user:user /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder $RAILS_ROOT $RAILS_ROOT
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
 


### PR DESCRIPTION
# What it does

This fixes a permissions issue I was experiencing on WSL2 + Docker. It also fixes missing assets by baking them into the image.

# Why it is important

Improves on boarding

# Implementation notes

Assuming docker-compose is being used in a dev environment, there's another service that should be running for webpack with the dev reload enabled. I left this out as we're moving to esbuild anyways. I can implement that service once that PR is merged.

# Your bandwidth for additional changes to this PR

* I have the time and interest to make additional changes to this PR based on feedback.
