### PR TITLE
Configure production logs to go to appsignal.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "reverse_markdown"
 gem "http"
 gem "translation"
 gem "store_model"
+gem "lograge"
 
 gem "square.rb"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       request_store (>= 1.0.5)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
-    appsignal (3.0.26)
+    appsignal (3.4.12)
       rack
     ast (2.4.2)
     aws-eventstream (1.2.0)
@@ -244,6 +244,11 @@ GEM
     logging (2.3.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
+    lograge (0.13.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -511,6 +516,7 @@ DEPENDENCIES
   lefthook
   letter_opener
   listen
+  lograge
   mini_magick
   minitest (= 5.15.0)
   minitest-ci

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,11 +49,9 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -101,6 +99,21 @@ Rails.application.configure do
     logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  config.lograge.enabled = true
+  config.lograge.keep_original_rails_log = true
+
+  config.lograge.logger = Appsignal::Logger.new(
+    "rails",
+    format: Appsignal::Logger::LOGFMT
+  )
+
+  config.lograge.custom_payload do |controller|
+    {
+      user_id: controller.current_user.try(:id),
+      request_id: controller.request.request_id,
+    }
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,7 +112,7 @@ Rails.application.configure do
   config.lograge.custom_payload do |controller|
     {
       user_id: controller.current_user.try(:id),
-      request_id: controller.request.request_id,
+      request_id: controller.request.request_id
     }
   end
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [
+  :password, :email, :phone_number, :name, :pronouns,
+  :address1, :address2, :postal_code
+]


### PR DESCRIPTION
# What it does

* Configures the production logs to log in a single-line format to appsignal

# Why it is important

This will make our logs more searchable and also adds a `user_id` property so we can see what actions a given user takes.  A few times now we've needed to understand a bug report from a user and didn't have this as a diagnostic tool.

# Implementation notes

* Added the `lograge` gem.
* In production, configured logs to go to appsignal using the logfmt format.
* The development logs and normal Rails logs that go to Heroku should remain unchanged.=

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.