### PR TITLE
return true when undo_loan is successful

### DIFF
--- a/app/controllers/concerns/lending.rb
+++ b/app/controllers/concerns/lending.rb
@@ -54,6 +54,7 @@ module Lending
         loan.item.increment_quantity
       end
     end
+    return true
   end
 
   def restore_loan(loan)

--- a/app/controllers/concerns/lending.rb
+++ b/app/controllers/concerns/lending.rb
@@ -54,7 +54,7 @@ module Lending
         loan.item.increment_quantity
       end
     end
-    return true
+    true
   end
 
   def restore_loan(loan)

--- a/test/controllers/concerns/lending_test.rb
+++ b/test/controllers/concerns/lending_test.rb
@@ -234,6 +234,18 @@ class LendingTest < ActiveSupport::TestCase
     assert_equal 10, item.quantity
   end
 
+  test "destroy loan after undoing" do
+    borrow_policy = create(:default_borrow_policy)
+    item = create(:item, quantity: 1, borrow_policy: borrow_policy)
+    member = create(:verified_member)
+
+    loan = create_loan(item, member)
+    assert !member.checked_out_loans.empty?
+
+    assert undo_loan(loan)
+    assert member.checked_out_loans.empty?
+  end
+
   test "marks the item as retired when the quantity hits 0" do
     borrow_policy = create(:consumable_borrow_policy)
     item = create(:item, quantity: 1, borrow_policy: borrow_policy)

--- a/test/controllers/concerns/lending_test.rb
+++ b/test/controllers/concerns/lending_test.rb
@@ -228,8 +228,9 @@ class LendingTest < ActiveSupport::TestCase
     member = create(:verified_member)
 
     loan = create_loan(item, member)
-    assert undo_loan(loan)
+    assert_equal 9, item.quantity
 
+    assert undo_loan(loan)
     assert_equal 10, item.quantity
   end
 


### PR DESCRIPTION
# What it does

`undo_loan` returns true when loan is successfully destroyed.

# Why it is important

Fixes bug where error message is displayed even if loan was successfully undone described [here](https://github.com/chicago-tool-library/circulate/issues/1149)

# UI Change Screenshot

Old:
![image](https://github.com/chicago-tool-library/circulate/assets/42463820/d5760982-e4db-477f-b25c-8dcc8ff25944)
New:
![image](https://github.com/chicago-tool-library/circulate/assets/42463820/2493d8c8-0447-4ab5-83b7-9d3f5b7594eb)

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
