### PR TITLE
Add note about adding library email to contacts to welcome messages

### DIFF
--- a/app/views/member_mailer/membership_reminder.text.erb
+++ b/app/views/member_mailer/membership_reminder.text.erb
@@ -3,7 +3,7 @@ We'd love to see you!
 <%= HTMLToMarkdown.new.convert(render(partial: "member_mailer/reminder")) %>
 ---------------------
 
-<%= HTMLToMarkdown.new.convert(render(partial: "signup/confirmations/instructions.html")) %>
+<%= HTMLToMarkdown.new.convert(render(partial: "signup/confirmations/instructions", formats: ["html"])) %>
 
 ---
 

--- a/app/views/member_mailer/welcome_message.text.erb
+++ b/app/views/member_mailer/welcome_message.text.erb
@@ -1,10 +1,3 @@
 Thank you for signing up as a member of The <%= @library.name %>. We are excited to have you!
 
 <%= HTMLToMarkdown.new.convert(render(partial: "signup/confirmations/instructions", formats: [:html], locals: {library: @library})) %>
-If you have any questions, please email us at team@chicagotoollibrary.org.
-
-See you at the library!
-
----
-
-<%= @library.address %>

--- a/app/views/signup/confirmations/_instructions.html.erb
+++ b/app/views/signup/confirmations/_instructions.html.erb
@@ -1,11 +1,16 @@
+<%# Library can come from local or instance variable. %>
+<% library ||= @library %>
+
 <% if @amount %>
   <p><strong>Your payment of <%= @amount.format %> has been processed and applied to your account.</strong></p>
 <% end %>
 <p>To activate your membership, please bring the following with you to the library the first time you visit:</p>
 <ul>
-  <li><strong>Proof of your address</strong><br>This needs to include your name and current address in <%= @library ? @library.city : library.city %>. Utility bills, leases, and other official mail work well for this.</li>
+  <li><strong>Proof of your address</strong><br>This needs to include your name and current address in <%= library.city %>. Utility bills, leases, and other official mail work well for this.</li>
   <li><strong>A photo ID</strong><br>This needs to show your name and a photo and can be from the state, your job, school, etc.</li>
 </ul>
 <p>We're located at:<br>
 4015 W. Carroll Ave, Suite 101<br>
 Chicago, IL 60624</p>
+
+<p>Please consider adding <strong><%= library.email %></strong> to your contacts to ensure our emails make it to your inbox!</p>

--- a/test/controllers/signup/confirmations_controller_test.rb
+++ b/test/controllers/signup/confirmations_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+module Signup
+  class ConfirmationsControllerTest < ActionDispatch::IntegrationTest
+    test "shows confirmation message including add to contacts line" do
+      create(:agreement_document)
+
+      get signup_confirmation_url
+
+      library = assigns(:current_library)
+      add_to_contacts_regexp = /Please consider adding.*#{library.email}.*to your contacts/
+
+      assert_match add_to_contacts_regexp, response.body
+    end
+  end
+end

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -31,4 +31,51 @@ class MemberMailerTest < ActionMailer::TestCase
       end
     end
   end
+
+  test "can deliver welcome email" do
+    member = create(:member)
+    email = MemberMailer.with(member: member).welcome_message
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+  end
+
+  test "welcome email only renders footer once" do
+    member = create(:member)
+    email = MemberMailer.with(member: member).welcome_message
+
+    footer_regexp = /See you at the library!/
+
+    assert_equal 1, email.text_part.body.to_s.scan(footer_regexp).size
+    assert_equal 1, email.html_part.body.to_s.scan(footer_regexp).size
+  end
+
+  test "welcome email recommends adding sender to contacts" do
+    member = create(:member)
+    email = MemberMailer.with(member: member).welcome_message
+
+    add_to_contacts_regexp = /Please consider adding.*#{member.library.email}.*to your contacts/
+
+    assert_match add_to_contacts_regexp, email.text_part.body.to_s
+    assert_match add_to_contacts_regexp, email.html_part.body.to_s
+  end
+
+  test "can deliver membership reminder email" do
+    member = create(:member)
+    email = MemberMailer.with(member: member).membership_reminder
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+  end
+
+  test "can deliver renewal email" do
+    member = create(:member)
+    email = MemberMailer.with(member: member).renewal_message
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+  end
 end


### PR DESCRIPTION
# What it does

Resolves #1145 

# Why it is important

This could help with email deliverability!

# UI Change Screenshot

![2023-10-14 at 12 49 05@2x](https://github.com/chicago-tool-library/circulate/assets/37534/2d53ac31-81ef-4bba-b704-f8eb507f981c)

# Implementation notes

- Caught some duplication in the text version of the welcome email - added a covering test and fixed it.
- Some callers of the `instructions` partial use locals to pass `library` and others use instance variables. I think ideally moving to explicit locals is a bit cleaner, but I decided to continue to handle both in the partial for now rather than taking on the larger task of changing all the callers.
- Added basic unit tests for a couple other member emails which caught a deprecation warning on rendering a partial with a filename suffix.