### PR TITLE
Don't show references to payments when allow_payments is false

### DIFF
--- a/app/views/renewal/home/index.html.erb
+++ b/app/views/renewal/home/index.html.erb
@@ -9,7 +9,9 @@
       <ul>
         <li>Read and agree to our updated terms.</li>
         <li>Update your address and contact information if necessary.</li>
-        <li>Pay your annual membership fee.</li>
+        <% if @current_library.allow_payments? %>
+          <li>Pay your annual membership fee.</li>
+        <% end %>
       </ul>
     </div>
 


### PR DESCRIPTION
# What it does

This PR removes the reference to making payments on the renewals home page when payments are disabled by the library.

# Why it is important

[Disable online payments using Library setting#1146](https://github.com/chicago-tool-library/circulate/issues/1146)

# UI Change Screenshot

Before (with payments disabled by the library): 
![image](https://github.com/chicago-tool-library/circulate/assets/33966989/eb1190d9-80e6-412d-ac97-a0b063bba65e)

After (with payments disabled):
![image](https://github.com/chicago-tool-library/circulate/assets/33966989/2868d794-09d3-47c1-b64c-cc578856742a)

After (with payments enabled):
![image](https://github.com/chicago-tool-library/circulate/assets/33966989/43147a99-a05b-4fa3-b04f-06fa79980337)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
