### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,24 @@
-## Contributing
+# HOWTO Contribute to Circulate
+
+{% note %}
 
 We ♥ contributors! By participating in this project, you agree to abide by our [code of conduct](./CODE_OF_CONDUCT.md).
 
-If you're unsure about an issue or have any questions or concerns, just ask in an *existing issue* or *open a new issue*. If you would like to talk to other contributors and get more context about the project before jumping in, you can request to join [RubyForGood Slack](https://rubyforgood.herokuapp.com/). Once you are in Slack, come by `#circulate` channel, introduce yourself, and ask us questions!
+{% endnote %}
 
-If you don't have any questions, the issue is clear, and no one has commented saying they are working on the isssue, you can work on it! If you are so inclined, you can open a draft PR as you continue to work; we encourage this as it can make discussing in-progress work a lot easier. You won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contribution and will do our best to guide all contributors toward productive solutions.
+Thanks for wanting to help out with this project! Circulate helps hundreds of people borrow all kinds of items from The Chicago Tool Library every month.
 
-Here are the basic steps to submit a pull request:
+## How to submit a Pull Request
 
-1. Claim an issue on [our issue tracker](https://github.com/rubyforgood/circulate/issues) by commenting on the issue saying you are working on it. The issues that are listed on [the project board in the _Ready to be worked on_ column](https://github.com/rubyforgood/circulate/projects/4#column-10622874) are the highest priority based on input from our stakeholders.
+1. Look for a task that you’d like to work on in our Project. We have [a list of good tasks for new volunteers](https://github.com/orgs/chicago-tool-library/projects/1/views/8). Only the tasks with the “Backlog” status are ready to be worked on.
+2. Please claim all tasks that you are working on. If you don’t have access to do so yet, you can comment on the issue to say you want to start working on it and someone will assign it to you.
+3. Open a Pull Request on GitHub when you’re done with your work or want to get feedback on it. If you get stuck, this is a good way to share the code you have so far and get additional eyes on it.
+4. Within a few days, someone else from the project will review your pull request. In general, at least one other person should look at all changes before they are merged into main. We do our best to respond quickly, but please be patient if it takes a few days for someone to review your code. We’re all here on a volunteer basis!
+5. If changes are requested on your PR, go ahead and make them. If you aren’t going to be able to make any additional changes, please comment on the PR so we know that the work can be picked up by someone else 😀.
+6. We merge your PR, and you’re done! At this point you can go back to step 2 and look for something else to work on.
 
-If the issue you want to work on doesn't exist yet, feel free to open it. Please only claim one issue at a time unless you are waiting on us to review work.
+## Pointers for making a great PR
 
-1. Fork [the repo](https://github.com/rubyforgood/circulate) and clone your forked repo locally on your machine.
-
-1. Follow [the project setup documentation](https://github.com/rubyforgood/circulate#developing) to get the project up and running on your machine.
-
-1. Run the tests. We only take pull requests with passing tests, and it's great to know that you have a clean slate: `bundle exec rails test`
-
-1. Add a test for your change. If you are adding functionality or fixing a bug, you should add a test!
-
-1. Make the test pass by making changes to models, views, controllers, etc.
-
-1. We try to keep the main user flows covered by [system tests](https://guides.rubyonrails.org/testing.html#system-testing).
-
-1. Run linters and fix any linting errors they brings up.
-   1. `bundle exec standardrb --fix` is required by CI
-
-1. Push to your fork and submit a pull request. Include the issue number (ex. `Resolves #1`) in the PR description.
-
-1. For any changes, please create a feature branch and open a PR for it when you feel it's ready to merge. Even if there's no real disagreement about a PR, at least one other person on the team needs to look over a PR before merging. The purpose of this review requirement is to ensure shared knowledge of the app and its changes and to take advantage of the benefits of working together changes without any single person being a bottleneck to making progress.
-
-At this point you're waiting on us–we'll try to respond to your PR quickly. We may suggest some changes or improvements or alternatives.
-
-Some things that will increase the chance that your pull request is accepted:
-
-* Use Rails idioms and helpers
-* Include tests that fail without your changes and pass with them.
-* Update the documentation, surrounding code, or anything else affected by your contribution.
-* Ensure that the following all pass locally:
-
-  ```
-  bundle exec rails test
-  bundle exec rails test:system
-  bundle exec standardrb
-  ```
-
-If you are wondering how to keep your fork in sync with the main [repo], follow this [github guide](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
+1. Include the issue number (ex. `Resolves #1`) in the PR description. 
+2. Please [run the tests](./README.md#running-tests) and the [linting](./README.md#code-formatting-and-linting) checks on your code and fix any issues that arise. CI will check this for you on PRs 🤖.
+3. Check one of the boxes at the bottom of the PR template to indicate how involved you want to be in making additional changes to the code you're submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,7 @@
 # HOWTO Contribute to Circulate
 
-{% note %}
-
-We ♥ contributors! By participating in this project, you agree to abide by our [code of conduct](./CODE_OF_CONDUCT.md).
-
-{% endnote %}
+> [!IMPORTANT]
+> We ♥ contributors! By participating in this project, you agree to abide by our [code of conduct](./CODE_OF_CONDUCT.md).
 
 Thanks for wanting to help out with this project! Circulate helps hundreds of people borrow all kinds of items from The Chicago Tool Library every month.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@
 
 <!-- tocstop -->
 
-{% note %}
-
-** Welcome contributors! ** Please see [our guide for how to contribute to the project](./CONTRIBUTING.md). 💖
-
-{% endnote %}
+> [!NOTE]
+> ** Welcome contributors! ** Please see [our guide for how to contribute to the project](./CONTRIBUTING.md). 💖
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -4,44 +4,34 @@
 
 <!-- toc -->
 
-- [Circulate](#circulate)
-  - [About](#about)
-    - [Project Considerations](#project-considerations)
-  - [Requirements](#requirements)
-  - [Integrations](#integrations)
-  - [Development](#development)
-    - [Setting up Circulate on your machine](#setting-up-circulate-on-your-machine)
-    - [Multi-tenancy](#multi-tenancy)
-    - [Configuring your database](#configuring-your-database)
-    - [Resetting the application](#resetting-the-application)
-    - [Running tests](#running-tests)
-    - [Code formatting and linting](#code-formatting-and-linting)
-    - [Setup pre-commit checks](#setup-pre-commit-checks)
-    - [Documentation](#documentation)
-    - [Who to log in as](#who-to-log-in-as)
-  - [Deployment](#deployment)
-    - [Buildpacks](#buildpacks)
-    - [Release Command](#release-command)
-    - [Daily Summary Emails](#daily-summary-emails)
-  - [Alternatives](#alternatives)
+- [About](#about)
+  - [Project Considerations](#project-considerations)
+- [Requirements](#requirements)
+- [Integrations](#integrations)
+- [Development](#development)
+  - [Setting up Circulate on your machine](#setting-up-circulate-on-your-machine)
+  - [Multi-tenancy](#multi-tenancy)
+  - [Configuring your database](#configuring-your-database)
+  - [Resetting the application](#resetting-the-application)
+  - [Running tests](#running-tests)
+  - [Code formatting and linting](#code-formatting-and-linting)
+  - [Setup pre-commit checks](#setup-pre-commit-checks)
+  - [Documentation](#documentation)
+  - [Who to log in as](#who-to-log-in-as)
+  - [Alternative Development Setups](#alternative-development-setups)
+- [Deployment](#deployment)
+  - [Buildpacks](#buildpacks)
+  - [Release Command](#release-command)
+  - [Daily Summary Emails](#daily-summary-emails)
+- [Alternatives](#alternatives)
 
 <!-- tocstop -->
 
-<!---
+{% note %}
 
-## Welcome contributors!
+** Welcome contributors! ** Please see [our guide for how to contribute to the project](./CONTRIBUTING.md). 💖
 
-We are very happy to have you! Circulate and Ruby for Good are committed to welcoming new contributors of all skill levels. We have plenty of tiny, small, and medium issues.
-
-We highly recommend that you join us in [the Ruby For Good Slack](https://rubyforgood.herokuapp.com/) in the #circulate channel to ask questions, coordinate on work, hear about office hours (on hold for the moment, but occasionally on Tuesdays at 7pm CT), stakeholder news, and upcoming new issues.
-
-Issues on [the project board in the _Ready to be worked on_ column](https://github.com/rubyforgood/circulate/projects/4#column-10622874) are fair game. To claim an issue, comment on it with something like "I am working on this issue." Feel free to assign to yourself and move the Issue to the "In Progress" column if you have Project permissions.
-
-Pull requests which are not for an issue but which improve the codebase by adding a test or improving the code are also welcome! Feel free to make GitHub issues when you notice issues. A maintainer will be keeping an eye on issues and PRs every day or three.
-
-See also our [contributing guide](./CONTRIBUTING.md) 💖
-
---->
+{% endnote %}
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <!-- tocstop -->
 
 > [!NOTE]
-> ** Welcome contributors! ** Please see [our guide for how to contribute to the project](./CONTRIBUTING.md). 💖
+> Welcome, contributors! Please see [our guide for how to contribute to the project](./CONTRIBUTING.md). 💖
 
 ## About
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,4 +24,4 @@ pre-commit:
       run: bundle exec standardrb --parallel --fix {staged_files} && git add {staged_files}
     readme:
       tags: lint
-      run: ./node_modules/.bin/markdown-toc -i README.md && git add README.md
+      run: ./node_modules/.bin/markdown-toc --bullets="-" -i README.md && git add README.md


### PR DESCRIPTION
# What it does

Replaces the contents of the current contributing guide with a shorter and up to date list of steps.

# Why it is important

This content is in a Google Doc currently, but we may as well keep it with the code.

# Implementation notes

* I also updated the `lefthook` config that auto-generates the README table of contents. There has been some churn due to different tooling formatting nested lists with different syntax; hopefully this resolves that.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
