### PR TITLE
Remove ImageKit

### DIFF
--- a/.env
+++ b/.env
@@ -33,10 +33,6 @@ BUCKETEER_BUCKET_NAME=
 # Require basic authentication (useful for staging sites)
 HTTP_BASIC_USERS=
 
-# Imagekit.io proxy for resizing imges on the fly
-# Only set this if you have a working proxy setup!
-# IMAGEKIT_URL=https://ik.imagekit.io/proxyid/
-
 # Sendgrid is used to send email
 SENDGRID_USERNAME=
 SENDGRID_PASSWORD=

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -118,32 +118,7 @@ module ItemsHelper
   end
 
   def item_image_url(image, options = {})
-    if ENV["IMAGEKIT_URL"].present?
-      transforms = if options[:resize_to_limit]
-        width, height = options[:resize_to_limit]
-        ["tr=w-#{width}", "h-#{height}", "c-at_max"]
-      else
-        []
-      end
-
-      if image.metadata.key? "rotation"
-        transforms << "rt-#{image.metadata["rotation"]}"
-      end
-
-      parts = [
-        ENV["IMAGEKIT_URL"],
-        image.blob.key
-      ]
-      unless transforms.empty?
-        parts << "?"
-        parts << transforms.join(",")
-      end
-
-      parts.join
-    else
-      # fallback when there isn't an image proxy in place
-      url_for(rotated_variant(image, options))
-    end
+    url_for(rotated_variant(image, options))
   end
 
   def full_item_number(item)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Circulate
     config.active_record.has_many_inversing = false
     config.active_record.legacy_connection_handling = true
 
-    config.active_storage.track_variants = false
+    config.active_storage.track_variants = true
     config.active_storage.queues.analysis = :active_storage_analysis
 
     # config.active_storage.variant_processor = :vips

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -2,19 +2,12 @@ require "test_helper"
 
 class ItemsHelperTest < ActionView::TestCase
   class ItemImageURLTest < ItemsHelperTest
-    def stub_imagekit_url(&block)
-      ENV["IMAGEKIT_URL"] = "https://ik.example.com/example/"
-      block.call
-    ensure
-      ENV.delete "IMAGEKIT_URL"
-    end
-
     setup do
       @item = create(:item, :with_image)
       @image = @item.image
     end
 
-    test "returns the URL for an image without ImageKit" do
+    test "returns the URL for an image" do
       def @image.variant(options)
         "#{filename}?#{options.to_query}"
       end
@@ -22,7 +15,7 @@ class ItemsHelperTest < ActionView::TestCase
       assert_equal "tool-image.jpg?", item_image_url(@image)
     end
 
-    test "returns the URL for a rotated image without ImageKit" do
+    test "returns the URL for a rotated image" do
       @image.metadata["rotation"] = "90"
       @image.save!
 
@@ -33,7 +26,7 @@ class ItemsHelperTest < ActionView::TestCase
       assert_equal "tool-image.jpg?rotate=90", item_image_url(@image)
     end
 
-    test "returns the URL for a resized rotated image without ImageKit" do
+    test "returns the URL for a resized rotated image" do
       @image.metadata["rotation"] = "90"
       @image.save!
 
@@ -43,39 +36,6 @@ class ItemsHelperTest < ActionView::TestCase
 
       assert_equal "tool-image.jpg?#{{resize_to_limit: [80, 90], rotate: 90}.to_query}",
         item_image_url(@image, resize_to_limit: [80, 90])
-    end
-
-    test "returns the URL for an image given dimensions with ImageKit" do
-      stub_imagekit_url do
-        assert_equal "https://ik.example.com/example/#{@image.key}?tr=w-100,h-100,c-at_max",
-          item_image_url(@image, resize_to_limit: [100, 100])
-      end
-    end
-
-    test "returns the URL for a rotated image with ImageKit" do
-      @image.metadata["rotation"] = "90"
-      @image.save!
-
-      stub_imagekit_url do
-        assert_equal "https://ik.example.com/example/#{@image.key}?rt-90", item_image_url(@image)
-      end
-    end
-
-    test "returns the URL for a rotated image given dimensions with ImageKit" do
-      @image.metadata["rotation"] = "90"
-      @image.save!
-
-      stub_imagekit_url do
-        assert_equal "https://ik.example.com/example/#{@image.key}?tr=w-100,h-100,c-at_max,rt-90",
-          item_image_url(@image, resize_to_limit: [100, 100])
-      end
-    end
-
-    test "returns the URL for an image with ImageKit" do
-      stub_imagekit_url do
-        assert_equal "https://ik.example.com/example/#{@image.key}",
-          item_image_url(@image)
-      end
     end
   end
 


### PR DESCRIPTION
# What it does

This changes the app to only rely on ActiveStorage and removes the third party dependency on ImageKit.

# Why it is important

Modern versions of Rails should be perfectly capable of serving thumbnails directly out of S3 without the help of a 3rd party service.

Resolves #1150 

# Implementation notes

* This turns ActiveStorage variant tracking on which removes the need for extra checks in S3 for variants. There's no need for an additional DB migration to turn this on as [we already have the tables from the Rails 6.1 upgrade](https://github.com/chicago-tool-library/circulate/blob/remove-imagekit/db/migrate/20210216165140_create_active_storage_variant_records.active_storage.rb).
* Since this change is messing with a dependency I'd recommend immediately testing image views, uploads, and editing after we deploy, which should let us revert if anything seems off.
