### PR TITLE
nix: add lefthook

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -87,3 +87,13 @@ $ bin/rails test:system
 The Selenium tests are run by having Nix install Chromium and ChromeDriver and
 set a `SELENIUM_CHROME_BINARY` environment variable to point Selenium at
 Chromium in `test/application_system_test_case.rb`.
+
+## Precommit Hooks
+ 
+Precommit hooks are managed by `lefthook`, which is automatically installed
+into the Nix development shell. Install the hooks to get them to run on every
+commit:
+
+```shell-session
+$ lefthook install
+```

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
           mkShell {
             buildInputs = [
               ruby
+              nodejs
               yarn
               foreman
 
@@ -38,6 +39,9 @@
               # for selenium tests
               chromium
               chromedriver
+
+              # for linters and git hooks
+              lefthook
             ];
 
             # Keep gems installed in a subdirectory


### PR DESCRIPTION
# What it does

Allows pre-commit linters to run in Nix development environments.

# Why it is important

Reduces likelihood of back-and-forth based on formatting issues.

# Implementation notes

Lefthook needs to be able to invoke `node` directly so explicitly add `nodejs` to dependencies as well. This is probably worthwhile for asset generation stuff anyways.