### PR TITLE
Configure Solargraph with Standard Ruby

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -8,8 +8,10 @@ exclude:
 - ".bundle/**/*"
 require: []
 domains: []
+plugins:
+- solargraph-standardrb
 reporters:
-- rubocop
 - require_not_found
+- standardrb
 require_paths: []
 max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
   gem "listen"
   gem "solargraph"
+  gem "solargraph-standardrb"
   gem "active_storage_log_suppressor", path: "gems/active_storage_log_suppressor"
   gem "lefthook"
   gem "erb_lint", "~> 0.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,9 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    solargraph-standardrb (0.0.4)
+      solargraph (>= 0.39.1)
+      standard (>= 0.4.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -536,6 +539,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   solargraph
+  solargraph-standardrb
   spy
   square.rb
   standard


### PR DESCRIPTION
# What it does

The current checked-in configuration runs Solargraph with a default Rubocop config which goes a bit wild with suggestions. This should make the LSP only suggest things that match the rules from Standard Ruby.

# Why it is important

Having the LSP config match the linter makes it a bit faster to write complaint code since you'll get suggestions in-line when using an LSP-supporting editor.