### PR TITLE
require yarn succeed in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  system('bin/yarn')
+  system! 'bin/yarn'
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
# What it does

Changes the `bin/setup` script to fail if `yarn` does not work.

# Why it is important

This makes `bin/setup` halt with an error message saying to install Yarn before continuing, which should help folks getting started know they need to install that prerequisite.