### PR TITLE
Available now item filtering

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -14,6 +14,10 @@ module Admin
         item_scope = @category.items
       end
 
+      if params[:available]
+        item_scope = item_scope.available_now
+      end
+
       item_scope = item_scope.includes(:categories, :borrow_policy, :active_holds).with_attached_image.order(index_order)
 
       @pagy, @items = pagy(item_scope)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
 
     item_scope = filter_by_category(item_scope) if filter_params[:category].present?
     item_scope = filter_by_query(item_scope) if filter_params[:query].present?
+    item_scope = filter_by_available(item_scope) if filter_params[:available].present?
 
     # One of the filtering methods above may have already redirected
     return if performed?
@@ -32,7 +33,7 @@ class ItemsController < ApplicationController
   private
 
   def filter_params
-    @filter_params ||= params.permit(:sort, :category, :query).to_h.each_with_object({}) do |(k, v), filtered|
+    @filter_params ||= params.permit(:sort, :category, :query, :available).to_h.each_with_object({}) do |(k, v), filtered|
       value = v&.to_s&.strip&.presence
 
       next unless value
@@ -75,6 +76,10 @@ class ItemsController < ApplicationController
 
     scope = item_scope.search_by_anything(@query)
     scope.select("#{scope.pg_search_rank_table_alias}.rank", "items.*")
+  end
+
+  def filter_by_available(item_scope)
+    item_scope.available_now
   end
 
   def filter_failed(failed_param, error_message)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -29,6 +29,9 @@ Stimulus.register('find-tool', FindToolController)
 import ImageEditorController from './image_editor_controller'
 Stimulus.register('image-editor', ImageEditorController)
 
+import ItemFilterController from './item_filter_controller'
+Stimulus.register('item-filter', ItemFilterController)
+
 import ModalController from './modal_controller'
 Stimulus.register('modal', ModalController)
 

--- a/app/javascript/controllers/item_filter_controller.js
+++ b/app/javascript/controllers/item_filter_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "form" ];
+
+  toggleAvailable() {
+    this.formTarget.submit();
+  }
+}

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -9,7 +9,11 @@ class Hold < ApplicationRecord
   belongs_to :creator, class_name: "User"
   belongs_to :loan, required: false
 
-  scope :active, ->(now = Time.current) { where("ended_at IS NULL AND (started_at IS NULL OR expires_at >= ?)", now) }
+  scope :active, ->(now = Time.current) {
+    where(ended_at: nil).and(
+      where(started_at: nil).or(where(expires_at: now..))
+    )
+  }
   scope :inactive, ->(now = Time.current) { ended.or(expired(now)) }
   scope :ended, -> { where("ended_at IS NOT NULL") }
   scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -85,6 +85,8 @@ class Item < ApplicationRecord
   scope :available, -> { left_outer_joins(:checked_out_exclusive_loan).where(loans: {id: nil}) }
   scope :without_attached_image, -> { left_joins(:image_attachment).where(active_storage_attachments: {record_id: nil}) }
   scope :in_maintenance, -> { where(status: Item.statuses.values_at(:maintenance)) }
+  scope :without_active_holds, -> { left_outer_joins(:active_holds).where(active_holds: {id: nil}) }
+  scope :available_now, -> { available.without_active_holds.where(status: Item.statuses[:active]) }
 
   scope :by_name, -> { order(name: :asc) }
 

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -15,6 +15,7 @@
     </div>
 
     <div class="column col-9-sm col-12-xs">
+      <%= render partial: "items/available_now_filter", locals: {url: admin_items_path, params: params} %>
       <div class="items-summary">
         <div>
           Viewing

--- a/app/views/items/_available_now_filter.html.erb
+++ b/app/views/items/_available_now_filter.html.erb
@@ -1,0 +1,13 @@
+<div data-controller="item-filter">
+  <%= form_with url: url, method: :get, local: true, html: {"data-target": "item-filter.form"} do |form| %>
+    <label class="form-switch">
+      <%= check_box_tag :available, "1", params[:available], data: {
+            action: "click->item-filter#toggleAvailable"
+          } %>
+      <i class="form-icon"></i> Only show items available now
+    </label>
+    <%= hidden_field_tag :category, params[:category] if params&.[](:category) %>
+    <%= hidden_field_tag :query, params[:query] if params&.[](:query) %>
+    <%= hidden_field_tag :sort, params[:sort] if params&.[](:sort) %>
+  <% end %>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -44,6 +44,8 @@
           </div>
         <% end %>
 
+        <%= render partial: "available_now_filter", locals: {url: items_path, params: @filter_params} %>
+
         Found <strong><%= pluralize @pagy.count, "item" %></strong>.
       </div>
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -264,4 +264,25 @@ class ItemTest < ActiveSupport::TestCase
     refute item.valid?
     assert_equal ["is not a number"], item.errors[:quantity]
   end
+
+  test "the available_now scope returns items without active loans or holds" do
+    item_with_hold = create(:item)
+    create(:hold, item: item_with_hold)
+
+    assert_not_includes(Item.available_now, item_with_hold)
+
+    item_with_expired_hold = create(:item)
+    create(:expired_hold, item: item_with_expired_hold)
+
+    assert_includes(Item.available_now, item_with_expired_hold)
+
+    item_with_loan = create(:item)
+    create(:loan, item: item_with_loan)
+
+    assert_not_includes(Item.available_now, item_with_loan)
+
+    item_in_maintenance = create(:item, status: Item.statuses[:maintenance])
+
+    assert_not_includes(Item.available_now, item_in_maintenance)
+  end
 end

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -177,4 +177,33 @@ class ItemsTest < ApplicationSystemTestCase
     click_on "Ended"
     find("[data-hold-id='#{@inactive_hold.id}']")
   end
+
+  test "listing items" do
+    @category1 = create(:category, name: "Nailguns")
+    @category1_subcategory = create(:category, parent: @category1, name: "Pneumatic")
+    @category2 = create(:category, name: "Drills")
+
+    @item1 = create(:item, categories: [@category1_subcategory], name: "Nine-Inch Nailgun")
+    @item2 = create(:item, categories: [@category2], name: "Boring Borer")
+    @item3 = create(:item, categories: [@category2], name: "Droll Drill")
+
+    @member = create(:verified_member_with_membership)
+    @user = @member.user
+    @hold = create(:hold, member: @member, item: @item3, creator: @user)
+
+    visit admin_items_url
+    within(".items-summary") do
+      assert_text "Viewing all 3 items"
+    end
+
+    click_on "Drills"
+    within(".items-summary") do
+      assert_text "Viewing 2 items assigned to Drills", normalize_ws: true
+    end
+
+    find("label", text: "Only show items available now").click
+    within(".items-summary") do
+      assert_text "Viewing 1 item assigned to Drills", normalize_ws: true
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1166

# What it does

Allows item search results on both the public facing and admin tool inventories to be filtered by items "available now," meaning they have no holds or loans and aren't in maintenance.

# Why it is important

This is useful for people who want a tool they can pick up immediately.

# UI Change Screenshot

## Member side:

https://github.com/chicago-tool-library/circulate/assets/37534/d4e7231d-1b60-4167-9341-bef37d99adb1

## Admin side:

<img width="1453" alt="Screenshot 2023-10-28 at 9 25 27 AM" src="https://github.com/chicago-tool-library/circulate/assets/37534/2cc4efed-c129-4233-bdc0-9560d72e8824">

# Implementation notes

* I needed to convert the `Hold.active` scope to ActiveRecord so that `Item.active_holds` would be able to chain properly in the `Item.available_now` scope.
  * With the plain string version, the queries were failing with "ambiguous column" errors on `ended_at`.
  * The unit tests on that query were pretty good (as I learned when I mixed up the `>` and got a million failures 😂) so I'm reasonably confident this is a one-for-one swap out.
* Getting the toggle to trigger behavior was my first foray into Hotwire/Stimulus/Turbo land, so please feel free to nitpick my implementation there.
* (For later) I suspect we're not taking advantage of the full partial-page-swap ability of the Hotwire stack on the search pages, and I'd love to discuss that further as an opportunity to learn more.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.