### PR TITLE
Ignore RecordNotFound errors in AppSignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,24 @@
+default: &defaults
+  push_api_key: "<%= ENV["APPSIGNAL_PUSH_API_KEY"] %>"
+  name: "Circulate"
+
+  # Errors that should not be recorded by AppSignal
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  ignore_errors:
+    # We do error page rendering via Rails config.exceptions_app, which means
+    # that RecordNotFound exceptions coming from controller actions are ok.
+    - ActiveRecord::RecordNotFound
+
+  # See https://docs.appsignal.com/ruby/configuration/options.html for
+  # all configuration options.
+
+# Configuration per environment, leave out an environment or set active
+# to false to not push metrics for that environment.
+development:
+  <<: *defaults
+  active: false
+
+production:
+  <<: *defaults
+  active: true


### PR DESCRIPTION
Resolves #1174

# What it does

Prevents AppSignal from treating RecordNotFound errors as reportable exceptions.

# Why it is important

It's important for us to only alert on real errors or we're more likely to suffer alert fatigue and miss a true problem.

# Implementation notes

* My first stab at this was reworking `ItemsController#show` to not raise an exception, but my research suggests that letting an exception generate the 404 is a normal setup for Rails. We already have [routes](https://github.com/chicago-tool-library/circulate/blob/ab0a397598cb1d454ea3b495b5d35eab7ad26210/config/routes.rb#L188-L190) and [`exception_app`](https://github.com/chicago-tool-library/circulate/blob/main/config/application.rb#L47-L48) set up to do this.
* I looked into other mechanisms for handling exceptions like [`rescue_from`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from) and [`Rails.error.handle`](https://guides.rubyonrails.org/error_reporting.html), but I didn't see any obvious advantage to switching everything to either of these.
* The AppSignal gem can be configured using env vars or a config file. We currently set only `APPSIGNAL_PUSH_API_KEY` in Heroku, but since we're expanding our options here it seemed worth switching to file-based config so we can have comments. This config is based on the one generated by the `appsignal install` command.

