### PR TITLE
nix: add heroku

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,9 @@
 
               # for linters and git hooks
               lefthook
+
+              # for deployment
+              heroku
             ];
 
             # Keep gems installed in a subdirectory


### PR DESCRIPTION
# What it does

Adds the Heroku CLI to the Nix Development environment

# Why it is important

Need the Heroku CLI in scope for anybody doing deployments