### PR TITLE
Add report to list items that have active holds (and how many).

### DIFF
--- a/app/controllers/admin/reports/items_with_holds_controller.rb
+++ b/app/controllers/admin/reports/items_with_holds_controller.rb
@@ -1,0 +1,17 @@
+module Admin
+  module Reports
+    class ItemsWithHoldsController < BaseController
+      include Pagy::Backend
+
+      def index
+        items_scope = Item.joins(:active_holds).where.not(active_holds: {id: nil})
+          .includes(:borrow_policy)
+          .select("items.*, COUNT(active_holds.id) AS active_holds_count")
+          .group("items.id")
+          .order("COUNT(active_holds.id) DESC")
+          .distinct
+        @pagy, @items_with_active_holds = pagy(items_scope, items: 100)
+      end
+    end
+  end
+end

--- a/app/views/admin/reports/items_with_holds/index.html.erb
+++ b/app/views/admin/reports/items_with_holds/index.html.erb
@@ -1,0 +1,37 @@
+<% content_for :header do %>
+  <%= index_header "Items with holds" %>
+<% end %>
+
+<div class="columns">
+  <div class="column col-12">
+
+    <% if @items_with_active_holds.any? %>
+
+      <table class="table table-scroll">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Number</th>
+            <th>Holds</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @items_with_active_holds.each do |item| %>
+            <tr data-item-id="<%= item.id %>">
+              <td><%= link_to item.name, [:admin, item] %></td>
+              <td><%= link_to full_item_number(item), [:admin, item] %></td>
+              <td><%= item.active_holds_count %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%== pagy_bootstrap_nav(@pagy) %>
+
+    <% else %>
+      <%= empty_state "No matching items" %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -46,6 +46,7 @@
               <li class="nav-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>
               <li class="nav-item"><%= link_to "Potential Volunteers", admin_reports_potential_volunteers_path %></li>
               <li class="nav-item"><%= link_to "Volunteer Shifts", admin_reports_shifts_path %></li>
+              <li class="nav-item"><%= link_to "Items with Holds", admin_reports_items_with_holds_path %></li>
               <li class="nav-item"><%= link_to "Items without Image", admin_reports_items_without_image_index_path %></li>
               <li class="nav-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %>
               <li class="nav-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %>
@@ -137,6 +138,7 @@
                 <li class="menu-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>
                 <li class="menu-item"><%= link_to "Potential Volunteers", admin_reports_potential_volunteers_path %></li>
                 <li class="menu-item"><%= link_to "Volunteer Shifts", admin_reports_shifts_path %></li>
+                <li class="menu-item"><%= link_to "Items with Holds", admin_reports_items_with_holds_path %></li>
                 <li class="menu-item"><%= link_to "Items without Image", admin_reports_items_without_image_index_path %></li>
                 <li class="menu-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %>
                 <li class="menu-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
       resources :potential_volunteers, only: :index
       resources :shifts, only: :index
       resources :items_without_image, only: :index
+      resources :items_with_holds, only: :index
       resources :zipcodes, only: :index
       get "money", to: "money#index"
     end

--- a/test/controllers/admin/reports/items_with_holds_controller_test.rb
+++ b/test/controllers/admin/reports/items_with_holds_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module Admin
+  module Reports
+    class ItemsWithHoldsControllerTest < ActionDispatch::IntegrationTest
+      include Devise::Test::IntegrationHelpers
+
+      setup do
+        @user = create(:admin_user)
+        sign_in @user
+
+        @item_with_holds = create(:item)
+        3.times do
+          create(:hold, item: @item_with_holds)
+        end
+
+        @item_without_holds = create(:item)
+      end
+
+      test "should get index" do
+        get admin_reports_items_with_holds_url
+        assert_response :success
+
+        assert_select "tr[data-item-id=#{@item_with_holds.id}]"
+        assert_select "tr[data-item-id=#{@item_without_holds.id}]", false, "item without holds should not appear"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What it does

Adds a new report that lists items with holds and how many holds they each have.

# Why it is important

I think this is likely generally useful for folks to know what has the most holds. I wanted it to help keep an eye on the other hold changes that I rolled out as well.

# UI Change Screenshot
![Screenshot 2023-11-06 at 8 05 21 PM](https://github.com/chicago-tool-library/circulate/assets/3331/a37fe534-2976-44c4-93ef-6f54cd25b284)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
