### PR TITLE
Fix error when logged out user views membership page

### DIFF
--- a/app/controllers/account/members_controller.rb
+++ b/app/controllers/account/members_controller.rb
@@ -1,5 +1,5 @@
 module Account
-  class MembersController < ApplicationController
+  class MembersController < BaseController
     def show
       @member = current_member
     end

--- a/test/controllers/account/members_controller_test.rb
+++ b/test/controllers/account/members_controller_test.rb
@@ -10,6 +10,12 @@ module Account
       sign_in @user
     end
 
+    test "redirects logged out users to sign in page" do
+      sign_out @user
+      get account_member_url
+      assert_redirected_to new_user_session_path
+    end
+
     test "member views profile" do
       get account_member_url
       assert_response :success


### PR DESCRIPTION
# What it does

Fixes error seen here https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/144

# Why it is important

Prevents logged out users from seeing an error page if they pull up membership page somehow.

# Implementation Notes

I found `BaseController` in the `account` directory which requires auth for all actions. It seemed like the best fix was to inherit from that.