### PR TITLE
Allow other hosts in renewal redirect

### DIFF
--- a/app/controllers/renewal/payments_controller.rb
+++ b/app/controllers/renewal/payments_controller.rb
@@ -20,7 +20,7 @@ module Renewal
 
       result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_renewal_payments_url, member_id: @member.id, date: Date.current)
       if result.success?
-        redirect_to result.value
+        redirect_to result.value, allow_other_host: true
       else
         errors = result.error
         Rails.logger.error(errors)


### PR DESCRIPTION
# What it does

This fixes an exception we're seeing in production:

```
Unsafe redirect to "https://connect.squareup.com/v2/checkout?c=CLIPPED", pass allow_other_host: true to redirect anyway.
```

`app/controllers/renewal/payments_controller.rb:24 create`