### PR TITLE
Remove weglot references. Fixes #1199

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,17 +11,6 @@
     <% end %>
     <%= javascript_include_tag "application", "data-turbolinks-track": "reload", defer: true %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
-
-    <% if Rails.env.production? %>
-      <script type="text/javascript" src="https://cdn.weglot.com/weglot.min.js"></script>
-      <script>
-          document.addEventListener("turbolinks:load", function() {
-              Weglot.initialize({
-                  api_key: '<%= ENV.fetch("WEGLOT_API_KEY", "weglot key").to_json %>'
-              });
-          });
-      </script>
-    <% end %>
   </head>
 
   <%= tag.body class: "public #{@body_class}" do %>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -11,16 +11,6 @@
     <% end %>
     <%= javascript_include_tag "application", "data-turbolinks-track": "reload" %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
-    <% if Rails.env.production? %>
-      <script type="text/javascript" src="https://cdn.weglot.com/weglot.min.js"></script>
-      <script>
-          document.addEventListener("turbolinks:load", function() {
-              Weglot.initialize({
-                  api_key: '<%= ENV.fetch("WEGLOT_API_KEY", "weglot key").to_json %>'
-              });
-          });
-      </script>
-    <% end %>
   </head>
 
   <body>


### PR DESCRIPTION
# What it does

We aren't using the Weglot service to translate UI text, but the app still attempts to load it. This removes references to that service from the app.

Fixes [#1199](https://github.com/chicago-tool-library/circulate/issues/1199).

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
