### PR TITLE
Add member with appointment to devdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ During development, you will probably want to log into the app as various users 
 - Member for 18 months `member_for_18_months@example.com`
 - Expired Member `expired_member@example.com`
 - Membership expiring in one week `expires_soon@example.com`
+- Member with loans `member_with_loans@example.com`
+- Member with holds and loans `member_with_holds_and_loans@example.com`
+- Member with an upcoming appointment `member_with_appointment@example.com`
 
 These users are associated with the first seed library, Chicago Tool Library. A similar set of users can be used to log in to
 the second seed library, Denver Tool Library, by appending `.denver` to the username portion of the email address (for example, `admin.denver@example.com`).

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,7 +66,7 @@ seed_library(chicago_tool_library)
 denver_tool_library = Library.create!(
   name: "Denver Tool Library",
   hostname: "denver.circulate.local",
-  city: "DEnver",
+  city: "Denver",
   email: "team@denvertoollibrary.org",
   address: <<~ADDRESS.strip,
     Denver Tool Library


### PR DESCRIPTION
# What it does

This PR renames the devdata members so that their emails are more representative (e.g. `member_with_holds@example.com` instead of `member1@example.com`). It also adds a new member to that dataset with an upcoming appointment.

# Why it is important

I'm hopeful this will make it easier to know what devdata member has which attributes, and that having one with an appointment will reduce how much work someone has to do if they are going to work on something related to appointments.

# Implementation notes

* I also tweaked the script to add pronouns and a member number to these members so that they were more similar to our real members.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
