### PR TITLE
Update the open days

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -64,10 +64,9 @@ class Loan < ApplicationRecord
 
   def self.open_days
     [
-      0, # Sunday
-      3, # Wednesday
       4, # Thursday
-      6 # Saturday
+      5, # Friday
+      6  # Saturday
     ]
   end
 


### PR DESCRIPTION
# What it does

As of December 1, 2023, CTL will be open Thursday, Friday, and Saturday. This PR updates the return value of `Loan#open_days`, which is used by `Loan#next_open_day` when calculating when a loan (or renewal) should be due. 

# Why it is important

* Without this change, the app will create loans that are due on days we're not open. This is confusing and creates more communication overhead for everyone.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
