### PR TITLE
Fix Capybara log fetching in Chrome 120

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -19,6 +19,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -34,31 +52,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696983906,
-        "narHash": "sha256-L7GyeErguS7Pg4h8nK0wGlcUTbfUMDu+HMf1UcyP72k=",
+        "lastModified": 1702350026,
+        "narHash": "sha256-A+GNZFZdfl4JdDphYKBJ5Ef1HOiFsP18vQe9mqjmUis=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd1cde45c77891214131cbbea5b1203e485a9d51",
+        "rev": "9463103069725474698139ab10f17a9d125da859",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695879717,
-        "narHash": "sha256-r7q/6XOYptP1TbPR09p2olGKJEa9DKqsMCX5o6Myrtk=",
+        "lastModified": 1702359589,
+        "narHash": "sha256-G7BVoQ19NLGuKUFpYJkJiRqIrIsgsBgaZfvfyaz85o8=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "a8612cd33ac2944cae93894bd0077e30c6b0f6e9",
+        "rev": "03f54ae2ec556dd5b3f533c75534d87da12ce770",
         "type": "github"
       },
       "original": {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -25,7 +25,7 @@ Capybara.register_driver :headless_chrome do |app|
     app,
     browser: :chrome,
     options: Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-      opts.add_argument "--headless"
+      opts.add_argument "--headless=new"
       opts.add_argument "--no-sandbox"
       opts.add_argument "--disable-gpu"
       opts.add_argument "--disable-dev-shm-usage"
@@ -46,7 +46,7 @@ Capybara.register_driver :headless_chrome_in_container do |app|
     browser: :remote,
     url: "http://selenium_chrome:4444/wd/hub",
     options: Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-      opts.add_argument "--headless"
+      opts.add_argument "--headless=new"
       opts.add_argument "--disable-gpu"
       opts.add_argument "--window-size=1400x1800"
     end


### PR DESCRIPTION
# What it does

System tests started failing at https://github.com/chicago-tool-library/circulate/actions/runs/7199427363/job/19648174580

This looks to be because selenium-webdriver started fetching Chrome 120 which ran us into this issue: https://github.com/SeleniumHQ/selenium/issues/13112

The recommended workaround there is to change the `--headless` argument in Chrome to `--headless=new` which seems to work locally.

# Why it is important

Build's gotta pass!

# Implementation notes

* The `flake.lock` changes are a result of running `nix flake update` which I did to update to Chrome 120 in the nix dev environment.