### PR TITLE
Fix appointment titles

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -65,9 +65,9 @@ module Admin
     end
 
     helper_method def current_day_label
-      if @current_day == Date.today
+      if @current_day == Date.current
         "Today"
-      elsif @current_day == Date.tomorrow
+      elsif @current_day == 1.day.from_now.to_date
         "Tomorrow"
       else
         l @current_day, format: :with_weekday

--- a/app/controllers/admin/settings/exports_controller.rb
+++ b/app/controllers/admin/settings/exports_controller.rb
@@ -26,7 +26,7 @@ class Admin::Settings::ExportsController < Admin::BaseController
       disposition: "attachment",
       filename: filename
     )
-    response.headers["Last-Modified"] = Time.now.httpdate
+    response.headers["Last-Modified"] = Time.current.httpdate
     exporter.export(response.stream)
   ensure
     response.stream.close

--- a/app/views/account/appointments/_form.html.erb
+++ b/app/views/account/appointments/_form.html.erb
@@ -34,7 +34,7 @@
                       </label>
                     </div>
                     <span class="status">
-                      <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning text-bold" if loan.due_at - Time.now < 3.days) %>
+                      <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning text-bold" if loan.due_at - Time.current < 3.days) %>
                       <span class="pickup">
                         <%= loan_pickup_status(loan) %>
                       </span>

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -43,7 +43,7 @@
                             <%= link_to loan.item.name, item_path(loan.item) %> (<%= loan.item.complete_number %>)
                           </span>
                           <span class="status">
-                            <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning" if loan.due_at - Time.now < 3.days) %>
+                            <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning" if loan.due_at - Time.current < 3.days) %>
                             <br>
                           </span>
                         </div>

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -31,7 +31,7 @@
                 </span>
                 <span class="status">
                   <%= tag.span "Due #{humanize_due_date(loan)}",
-                        class: ("warning text-bold" if loan.due_at - Time.now < 3.days) %>
+                        class: ("warning text-bold" if loan.due_at - Time.current < 3.days) %>
                   <% if loan.renewal? %>(renewed <%= pluralize(loan.renewal_count, "time") %>)<% end %>
                   <% if @current_library.allow_appointments? %>
                     <span class="pickup"><%= loan_pickup_status(loan) %></span>

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -29,7 +29,7 @@ namespace :email do
 
   desc "Send membership renewal reminder emails"
   task send_membership_renewal_reminders: :environment do
-    Membership.where(ended_at: (Date.today + 30.days).all_day).each do |membership|
+    Membership.where(ended_at: (Date.current + 30.days).all_day).each do |membership|
       member = membership.member
       amount = member.last_membership&.amount || Money.new(0)
       MemberMailer.with(member: member, amount: amount).membership_renewal_reminder.deliver_now


### PR DESCRIPTION
# What it does

Fixes an issue where, after 6pm CST, the appointments page would show incorrect labels for the day. It would show 'Today' for tomorrow and 'Tomorrow' for the day after tomorrow. 

In application_controller.rb, we attempt to manually set the time zone in the around_action to use Chicago time. However, there are a few places where we were using time/day functions that don't take time zone into account. See this article [here](https://thoughtbot.com/blog/its-about-time-zones#a-summary-of-do39s-and-don39ts-with-time-zones) for more info on this. Switching to use suggested functions should resolve the issue and we will apply the correct labels. 

Note: wasn't able to reproduce the exact issue locally, possibly because my local machine is already in Chicago time, but the changes seem low risk enough. 

# Why it is important

#1215 

# UI Change Screenshot

NA

# Implementation notes

* _Anything notable about the technical approach you took.

* _Any open questions you have about the PR or areas where you'd like specific feedback.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
