### PR TITLE
Remove special case for numbering A tools. Fixes #1223.

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -123,11 +123,7 @@ class Item < ApplicationRecord
     if number.blank?
       return unless borrow_policy
 
-      self.number = if borrow_policy.code == "A"
-        self.class.next_number(999)
-      else
-        self.class.next_number
-      end
+      self.number = self.class.next_number
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -104,11 +104,8 @@ class Item < ApplicationRecord
   before_save :cache_description_as_plain_text
   after_update :clear_holds_if_inactive, :pause_next_hold_if_maintenance
 
-  def self.next_number(limit = nil)
+  def self.next_number
     item_scope = order("number DESC NULLS LAST")
-    if limit
-      item_scope = item_scope.where("number <= ?", limit)
-    end
     last_item = item_scope.limit(1).first
     return 1 unless last_item
     last_item.number.to_i + 1

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -94,7 +94,7 @@
   <% unless item.new_record? %>
     <details>
       <summary>Number: <strong><%= item.number %></strong></summary>
-      <%= form.text_field :number, hint: "Only change this with good reason! Next available A number is #{Item.next_number(999)}." %>
+      <%= form.text_field :number, hint: "Only change this with good reason! Next available A number is #{Item.next_number}." %>
     </details>
   <% end %>
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -11,6 +11,16 @@ class ItemTest < ActiveSupport::TestCase
     assert item.number
   end
 
+  test "assigns a number, with an existing item" do
+    create(:item, number: 999)
+
+    borrow_policy = create(:borrow_policy)
+    item = build(:item, number: nil, borrow_policy: borrow_policy)
+    item.save!
+
+    assert_equal 1000, item.number
+  end
+
   test "it has a due_on date" do
     loan = create(:loan, due_at: Date.tomorrow.end_of_day)
     loan.item.reload

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -11,10 +11,20 @@ class ItemTest < ActiveSupport::TestCase
     assert item.number
   end
 
-  test "assigns a number, with an existing item" do
+  test "assigns the next available for B tools" do
     create(:item, number: 999)
 
-    borrow_policy = create(:borrow_policy)
+    borrow_policy = create(:borrow_policy, code: "B")
+    item = build(:item, number: nil, borrow_policy: borrow_policy)
+    item.save!
+
+    assert_equal 1000, item.number
+  end
+
+  test "assigns the next available number for A tools" do
+    create(:item, number: 999)
+
+    borrow_policy = create(:borrow_policy, code: "A")
     item = build(:item, number: nil, borrow_policy: borrow_policy)
     item.save!
 


### PR DESCRIPTION
# What it does

We originally treated A tools (those that we don't individually number) specially, with the idea being that having their numbers be 3 digits would be another signal that they were A tools. This worked, but... we're gonna run out of numbers since B tools start at 1000.

So the solution is to remove that special case for A tools. Once this is merged, all new items will get the next available number in the system.

# Why it is important

I don't know what will happen if we hit 1000 for A tools, but let's not find out.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
