### PR TITLE
Checkout notices/librarian view

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -699,7 +699,7 @@ form.membership-amount {
 }
 
 .admin {
-  .member-lookup-items, .member-appointment-form {
+  .member-lookup-items, .member-appointment-form, .member-panel {
     background: white;
     padding: .7rem .5rem;
     .info-box {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -699,7 +699,7 @@ form.membership-amount {
 }
 
 .admin {
-  .member-lookup-items, .member-appointment-form, .member-panel {
+  .member-lookup-items, .member-appointment-form, .member-panel, .app-body {
     background: white;
     padding: .7rem .5rem;
     .info-box {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -699,7 +699,7 @@ form.membership-amount {
 }
 
 .admin {
-  .member-lookup-items, .member-appointment-form, .member-panel, .app-body {
+  .member-lookup-items, .member-appointment-form, .member-panel, .checkout-notice {
     background: white;
     padding: .7rem .5rem;
     .info-box {
@@ -768,6 +768,10 @@ form.membership-amount {
     p:last-of-type {
       margin-bottom: 0;
     }
+  }
+
+  .checkout-notice {
+    padding: 0;
   }
 }
 

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -16,6 +16,22 @@
           <% end %>
         <% end %>
 
+        
+        <% if return_item.checked_out? %>
+        <%= link_to "remove item", admin_appointment_loan_path(@appointment, return_item), method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
+        <% end %>
+        </div>
+        <div class="column col-sm-6 col-4">
+        <p><%= return_item.item.name %></p>
+        <p><%= link_to full_item_number(return_item.item), admin_item_path(return_item.item) %></p>
+        </div>
+        <div class="column col-sm-12 col-4 text-right">
+        <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]), class: "btn btn-primary", data: {disable_with: "Checking-in..."}, disabled: !return_item.checked_out? %>
+        <% if !return_item.checked_out? %>
+        <em>Item checked-in</em>
+        <% end %>
+        </div>
+        </div>
         <% if return_item.item.checkout_notice? %>
         <div class="info-box">
           <p>
@@ -24,22 +40,6 @@
           </p>
         </div>
       <% end %>
-
-        <% if return_item.checked_out? %>
-          <%= link_to "remove item", admin_appointment_loan_path(@appointment, return_item), method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
-        <% end %>
-      </div>
-      <div class="column col-sm-6 col-4">
-        <p><%= return_item.item.name %></p>
-        <p><%= link_to full_item_number(return_item.item), admin_item_path(return_item.item) %></p>
-      </div>
-      <div class="column col-sm-12 col-4 text-right">
-        <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]), class: "btn btn-primary", data: {disable_with: "Checking-in..."}, disabled: !return_item.checked_out? %>
-        <% if !return_item.checked_out? %>
-          <em>Item checked-in</em>
-        <% end %>
-      </div>
-    </div>
   <% end %>
 
   <% unless items_available_to_add_to_dropoff.empty? %>

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -16,7 +16,6 @@
           <% end %>
         <% end %>
 
-        
         <% if return_item.checked_out? %>
         <%= link_to "remove item", admin_appointment_loan_path(@appointment, return_item), method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
         <% end %>

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -15,6 +15,16 @@
             <div class="image-placeholder"></div>
           <% end %>
         <% end %>
+
+        <% if return_item.item.checkout_notice? %>
+        <div class="info-box">
+          <p>
+            <strong>Checkout Notice:</strong><br>
+            <%= return_item.item.checkout_notice %>
+          </p>
+        </div>
+      <% end %>
+
         <% if return_item.checked_out? %>
           <%= link_to "remove item", admin_appointment_loan_path(@appointment, return_item), method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
         <% end %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -11,16 +11,27 @@
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
           <% if pickup_item.item.image.attached? %>
-            <%= image_tag item_image_url(pickup_item.item.image, resize_to_limit: [160, 112]) %>
+          <%= image_tag item_image_url(pickup_item.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
-            <div class="image-placeholder"></div>
+          <div class="image-placeholder"></div>
           <% end %>
-        <% end %>
+          <% end %>
         <div class="divider"></div>
       </div>
       <div class="column col-sm-6 col-4">
         <p><%= pickup_item.item.name %></p>
         <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
+        
+        <!-- here are your changes -->
+        <% if pickup_item.item.checkout_notice? %>
+          <div class="info-box">
+            <p>
+              <strong>Checkout Notice:</strong><br>
+              <%= pickup_item.item.checkout_notice %>
+            </p>
+          </div>
+        <% end %>
+
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column">
         <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -17,12 +17,7 @@
           <% end %>
           <% end %>
         <div class="divider"></div>
-      </div>
-      <div class="column col-sm-6 col-4">
-        <p><%= pickup_item.item.name %></p>
-        <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
-        
-        <!-- here are your changes -->
+
         <% if pickup_item.item.checkout_notice? %>
           <div class="info-box">
             <p>
@@ -32,6 +27,11 @@
           </div>
         <% end %>
 
+      </div>
+      
+      <div class="column col-sm-6 col-4">
+        <p><%= pickup_item.item.name %></p>
+        <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column">
         <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -18,9 +18,8 @@
           <% end %>
         <div class="divider"></div>
 
-        
         </div>
-        
+
         <div class="column col-sm-6 col-4">
         <p><%= pickup_item.item.name %></p>
         <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
@@ -38,7 +37,7 @@
         </div>
         </div>
         </div>
-        
+
         <% if pickup_item.item.checkout_notice? %>
         <div>
           <div class="info-box">

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -18,34 +18,37 @@
           <% end %>
         <div class="divider"></div>
 
+        
+        </div>
+        
+        <div class="column col-sm-6 col-4">
+        <p><%= pickup_item.item.name %></p>
+        <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
+        </div>
+        <div class="column col-sm-12 col-4 text-right checkout-button-column">
+        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? %>
+        <div class="checkout-button-group">
+        <% if pickup_item.active? %>
+        <%= button_to "Cancel Hold", admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: true), class: "btn btn-sm mt-2 float-right", method: :delete, data: {disable_with: "Canceling...", confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?"} %>
+        <%= button_to "Remove Item", admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: false), class: "btn btn-sm mt-2 float-right", method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
+        <% end %>
+        <% if !pickup_item.active? %>
+        <em>Item checked-out</em>
+        <% end %>
+        </div>
+        </div>
+        </div>
+        
         <% if pickup_item.item.checkout_notice? %>
+        <div>
           <div class="info-box">
             <p>
               <strong>Checkout Notice:</strong><br>
               <%= pickup_item.item.checkout_notice %>
             </p>
           </div>
-        <% end %>
-
-      </div>
-      
-      <div class="column col-sm-6 col-4">
-        <p><%= pickup_item.item.name %></p>
-        <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
-      </div>
-      <div class="column col-sm-12 col-4 text-right checkout-button-column">
-        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? %>
-        <div class="checkout-button-group">
-          <% if pickup_item.active? %>
-            <%= button_to "Cancel Hold", admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: true), class: "btn btn-sm mt-2 float-right", method: :delete, data: {disable_with: "Canceling...", confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?"} %>
-            <%= button_to "Remove Item", admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: false), class: "btn btn-sm mt-2 float-right", method: :delete, data: {disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?"} %>
-          <% end %>
-          <% if !pickup_item.active? %>
-            <em>Item checked-out</em>
-          <% end %>
         </div>
-      </div>
-    </div>
+        <% end %>
   <% end %>
 
   <div class="divider"></div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -4,11 +4,13 @@
   </div>
 
   <% if @item.checkout_notice.present? %>
-    <div class="info-box">
-      <p>
-        <strong>Checkout Notice:</strong><br>
-        <%= @item.checkout_notice %>
-      </p>
+    <div class="checkout-notice">
+      <div class="info-box">
+        <p>
+          <strong>Checkout Notice:</strong><br>
+          <%= @item.checkout_notice %>
+        </p>
+      </div>
     </div>
   <% end %>
 

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     status { Item.statuses[:active] }
     before :create, &:assign_number
     borrow_policy
-    checkout_notice { "Make sure all five removable pieces are returned." }
+    checkout_notice { "Example Notice: Make sure all five removable pieces are returned." }
 
     factory :complete_item do
       brand { "Dewalt" }

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     status { Item.statuses[:active] }
     before :create, &:assign_number
     borrow_policy
+    checkout_notice { "Make sure all five removable pieces are returned." }
 
     factory :complete_item do
       brand { "Dewalt" }


### PR DESCRIPTION
# What it does

This PR includes checkout notices in the librarian view of the member appointment when an item is checked in or out. I also tried to keep styling consistent across the application and took notice length into account. A `checkout notice` field was added to the item factory for inclusion in testing.

# Why it is important

A request from the librarians to be able to see the checkout notices easily when interacting with a customer. Closes issue #678 
From the issue: "These notices contain really important information about items (safety, necessary components etc.) and while they aren't on all items, they need to be seen by librarians before the member takes the item."

# UI Change Screenshot
A view of before changes were made, this item has a checkout notice, but it is not appearing in the librarian view
<img width="1128" alt="Before - Box Cutter - Short" src="https://github.com/chicago-tool-library/circulate/assets/31836822/36b09683-c7a5-42ff-83cd-46e7cd6f6eaa">

Same item, with a checkout notice:
<img width="1111" alt="After - Box Cutter - Short" src="https://github.com/chicago-tool-library/circulate/assets/31836822/4cd750f8-c066-49cf-b97a-f3a77c949442">

Example of a longer form checkout notice:
<img width="758" alt="After - Long Message" src="https://github.com/chicago-tool-library/circulate/assets/31836822/105bcb63-d459-448e-990e-610ac033f1d3">

Added styling to match checkout notices that appear in other places:
✨ Before ✨ 

<img width="1098" alt="Before - No Styling" src="https://github.com/chicago-tool-library/circulate/assets/31836822/440d8bfe-61ea-485d-b09f-7f61d5a6cd85">
 ✨ After ✨ 

<img width="1242" alt="After - With Styling" src="https://github.com/chicago-tool-library/circulate/assets/31836822/73fa1711-516f-4f04-90c9-dd36e4e60c0e">




# Implementation notes

* I'd love if anyone reviewing could click through and see if the notices are showing up everywhere you'd expect! 

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [X] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
