### PR TITLE
Improve devdata somewhat

### DIFF
--- a/db/devdata/action_text/rich_texts.yml
+++ b/db/devdata/action_text/rich_texts.yml
@@ -1,0 +1,21 @@
+- id: 3
+  name: body
+  body: <div>This is the waiver of indemnification. It is editable, and usually says that folks will only check out items they are confident they can use safely.</div>
+  record_type: Document
+  record_id: 3
+  created_at: 2019-07-19 14:25:59 UTC
+  updated_at: 2019-07-26 04:06:08 UTC
+- id: 5
+  name: body
+  body: <div>This is the code of conduct. It is editable and says to be cool.</div>
+  record_type: Document
+  record_id: 5
+  created_at: 2019-07-19 14:25:59 UTC
+  updated_at: 2019-07-26 04:06:08 UTC
+- id: 4
+  name: body
+  body: <div>This is the borrowing policy. It is editable and described the lending rules to members.</div>
+  record_type: Document
+  record_id: 4
+  created_at: 2019-07-19 14:25:59 UTC
+  updated_at: 2019-07-26 04:06:08 UTC

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,12 +48,13 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
     Time.use_zone "America/Chicago" do
       monday_morning_at_midnight = Time.current.at_beginning_of_week
 
-      52.times do |week| # for each day in the next year
+      52.times do |week| # for each week in the next year
         3.upto(5).each do |day| # on Thursday, Friday, and Saturday
           ten_am = monday_morning_at_midnight + week.weeks + day.days + 10.hours
           noon = ten_am + 2.hours
           two_pm = ten_am + 4.hours
 
+          # Create morning and afternoon appointment slots
           Event.create!(calendar_id: "appointmentSlots@calendar.google.com", calendar_event_id: "morning#{week}#{day}#{email_suffix}", start: ten_am, finish: noon)
           Event.create!(calendar_id: "appointmentSlots@calendar.google.com", calendar_event_id: "afternoon#{week}#{day}#{email_suffix}", start: noon, finish: two_pm)
         end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,8 +41,19 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
     User.create!(email: expires_in_one_week_member.email, password: "password", member: expires_in_one_week_member)
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 
-    3.upto(7).each do |number|
-      Event.create!(calendar_id: "appointmentSlots@calendar.google.com", calendar_event_id: "event#{number}#{email_suffix}", start: number.days.since, finish: number.days.since + 2.hours)
+    Time.use_zone "America/Chicago" do
+      monday_morning_at_midnight = Time.current.at_beginning_of_week
+
+      52.times do |week| # for each day in the next year
+        3.upto(5).each do |day| # on Thursday, Friday, and Saturday
+          ten_am = monday_morning_at_midnight + week.weeks + day.days + 10.hours
+          noon = ten_am + 2.hours
+          two_pm = ten_am + 4.hours
+
+          Event.create!(calendar_id: "appointmentSlots@calendar.google.com", calendar_event_id: "morning#{week}#{day}#{email_suffix}", start: ten_am, finish: noon)
+          Event.create!(calendar_id: "appointmentSlots@calendar.google.com", calendar_event_id: "afternoon#{week}#{day}#{email_suffix}", start: noon, finish: two_pm)
+        end
+      end
     end
 
     LibraryUpdate.create(title: "December updates", body: "<h1>Library Closures!</h1><div>The tool library will be closed for a bit.</div>", published: true)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,6 +41,10 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
     User.create!(email: expires_in_one_week_member.email, password: "password", member: expires_in_one_week_member)
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 
+    # Hardcoding this value (the value of which is "password") means that user sessions aren't invalidated when running
+    # bin/reset and you won't have to log in again.
+    User.update_all(encrypted_password: "$2a$11$7iZBpCm6HGkC0B4fSbJCCen2IalyVwtDraM249IArh36CSQyqXuOa")
+
     Time.use_zone "America/Chicago" do
       monday_morning_at_midnight = Time.current.at_beginning_of_week
 

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -45,6 +45,7 @@ namespace :devdata do
   end
 
   task load: :environment do
+    Document.delete_all # There are some documents created in old migrations that we can safely blow away.
     Library.all.each_with_index do |library, index|
       offset = (index + 1) * 10000
       admin = library.users.where(role: "admin").first
@@ -54,6 +55,7 @@ namespace :devdata do
           load_models BorrowPolicy, id_offset: offset
           load_models Category, id_offset: offset
           load_models Item, id_offset: offset
+          load_models ActionText::RichText, id_offset: offset
         end
       end
     end


### PR DESCRIPTION
# What it does

This improves a few things about how we do devdata based on a discussion at tonight's meetup:

# Why it is important

It's important that we reduce the number of sharp edges in the development environment so that we're as welcoming to new volunteers as we can be.

# UI Change Screenshot

![Screenshot 2024-01-08 at 9 23 56 PM](https://github.com/chicago-tool-library/circulate/assets/3331/6f794f38-74c2-4606-a482-9334d52c4547)

# Implementation notes

* We now generate a lot of events, (two a day, three days a week, each week for the next year). This means that folks won't have to run `bin/reset` if it's been more than a week since they last ran it. I still think it's a good idea to run it fairly often, but what we have now is a pretty bad experience considering that contributors are likely to go more than a week while working on a feature.
* Hardcoding an encrypted password should mean that you don't get logged out when you run `bin/reset` anymore!
* I updated the Documents to contain human-friendly default values so that it's more obvious when they appear in the app. Before, for example, when signing up as a new user you'd just see an empty page because there wasn't any content set in the Documents.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
