### PR TITLE
Fix "remove item" button in appointment

### DIFF
--- a/app/controllers/admin/appointment_holds_controller.rb
+++ b/app/controllers/admin/appointment_holds_controller.rb
@@ -17,7 +17,7 @@ module Admin
     def remove_appointment_hold
       @remove_appointment_hold ||= appointment.appointment_holds.find_by(hold_id: params[:id]).destroy
 
-      if params[:cancel_hold]
+      if params[:cancel_hold].to_s.downcase == 'true'
         Hold.find(params[:id]).destroy
       end
     end

--- a/app/controllers/admin/appointment_holds_controller.rb
+++ b/app/controllers/admin/appointment_holds_controller.rb
@@ -17,7 +17,7 @@ module Admin
     def remove_appointment_hold
       @remove_appointment_hold ||= appointment.appointment_holds.find_by(hold_id: params[:id]).destroy
 
-      if params[:cancel_hold].to_s.downcase == 'true'
+      if params[:cancel_hold].to_s.downcase == "true"
         Hold.find(params[:id]).destroy
       end
     end

--- a/test/controllers/admin/appointment_holds_controller_test.rb
+++ b/test/controllers/admin/appointment_holds_controller_test.rb
@@ -1,0 +1,44 @@
+require "application_system_test_case"
+
+module Admin
+  class AppointmentHoldsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @appointment = FactoryBot.build(:appointment)
+      @user = FactoryBot.create(:user)
+      @member = FactoryBot.create(:member, user: @user)
+      @hold = FactoryBot.create(:hold, member: @member)
+      @appointment.holds << @hold
+      @appointment.member = @member
+      @appointment.starts_at = "2020-10-05 7:00AM"
+      @appointment.ends_at = "2020-10-05 8:00AM"
+      @appointment.save
+
+      @user = create(:admin_user)
+      sign_in @user
+    end
+
+    test "remove item with cancel_hold true" do
+      # Test that when `cancel_hold` is true, the hold is deleted from the appointment
+      # *and* the member's holds. This test emulates the behavior of the "Cancel Hold"
+      # button on the librarian view of an appointment.
+      assert_difference("@appointment.holds.count", -1) do
+        assert_difference("@member.holds.count", -1) do
+          delete admin_appointment_hold_path(@appointment, @hold), params: {cancel_hold: true}
+        end
+      end
+    end
+
+    test "remove item with cancel_hold false" do
+      # Test that when `cancel_hold` is false, the hold is deleted from the appointment
+      # but the member still has the hold. This test emulates the behavior of the 
+      # "Remove Item" button on the librarian view of an appointment.
+      assert_difference("@appointment.holds.count", -1) do
+        assert_no_difference("@member.holds.count") do
+          delete admin_appointment_hold_path(@appointment, @hold), params: {cancel_hold: false}
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/admin/appointment_holds_controller_test.rb
+++ b/test/controllers/admin/appointment_holds_controller_test.rb
@@ -32,7 +32,7 @@ module Admin
 
     test "remove item with cancel_hold false" do
       # Test that when `cancel_hold` is false, the hold is deleted from the appointment
-      # but the member still has the hold. This test emulates the behavior of the 
+      # but the member still has the hold. This test emulates the behavior of the
       # "Remove Item" button on the librarian view of an appointment.
       assert_difference("@appointment.holds.count", -1) do
         assert_no_difference("@member.holds.count") do


### PR DESCRIPTION
# What it does

Fixes #989. Previously, the "Remove Item" button removed the item from the appointment *and* canceled the member's hold on the item. Now the "Remove Item" button works as expected: it removes the item from the current appointment but does not remove the member's hold on the item.

# Why it is important

Fixes #989

# UI Change Screenshot

No UI changes.

# Implementation notes

* The `cancel_hold` parameter was being passed to the `remove_appointment_hold` method as a string rather than a boolean value, which caused the conditional statement to always evaluate as true. I fixed the issue by coercing to a boolean value, which I think should work whether the parameter is passed in as a string or a boolean. Let me know if it would be better to fix it upstream, i.e., by making sure we're passing a boolean into the function rather than a string.
* I did not create or update any unit tests. Let me know if we should add a unit test for removing an item (I would likely need some help with this).

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
