### PR TITLE
Add text part to password reset emails

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,8 @@
+Hello <%= @resource.email %>!
+
+Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<%= edit_password_url(@resource, reset_password_token: @token) %>
+
+If you didn't request this, please ignore this email.
+Your password won't change until you access the link above and create a new one.

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  setup do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "includes HTML and text parts for password reset instructions" do
+    user = create(:user)
+
+    user.send_reset_password_instructions
+
+    mail = ActionMailer::Base.deliveries.last
+
+    expected_link = Rails.application.routes.url_helpers.edit_user_password_url(
+      host: Rails.configuration.action_mailer.default_url_options[:host]
+    )
+
+    assert mail.multipart?, "mail should be multipart"
+    assert_includes mail.html_part.body.to_s, expected_link, "mail should include reset link in html part"
+    assert_includes mail.text_part.body.to_s, expected_link, "mail should include reset link in text part"
+  end
+end


### PR DESCRIPTION
# What it does

Hopefully this addresses the problem in #1245 - we'll need to test deliverability in production to know if it fixes it or not.

# Why it is important

We don't want any emails to be marked as spam - especially password reset emails!

# Implementation notes

* See https://github.com/heartcombo/devise/issues/5034 for some good background on this approach.