### PR TITLE
Turn appsignal error collection on in staging environment.

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -19,6 +19,10 @@ development:
   <<: *defaults
   active: false
 
+staging:
+  <<: *defaults
+  active: true
+
 production:
   <<: *defaults
   active: true


### PR DESCRIPTION
# What it does

We were getting this warning on staging:

```
[2024-01-21T01:30:15 (process) #2][ERROR] appsignal: Not loading from config file: config for 'staging' not found
```

I added a config for `staging` to the appsignal config file so that it goes away and we start sending errors to appsignal. 

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
