### PR TITLE
Disable turbo on buttons that redirect to Square.

### DIFF
--- a/app/views/renewal/payments/new.html.erb
+++ b/app/views/renewal/payments/new.html.erb
@@ -29,7 +29,7 @@
         <%= form.money_field :amount_dollars, label: "Your membership fee:", class: "input-lg" %>
       </fieldset>
       <%= form.actions do %>
-        <%= form.submit "Pay Online Now" %>
+        <%= form.submit "Pay Online Now", data: {turbo: false} %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/signup/payments/new.html.erb
+++ b/app/views/signup/payments/new.html.erb
@@ -28,7 +28,7 @@
         <%= form.money_field :amount_dollars, label: "Your membership fee:", class: "input-lg" %>
       </fieldset>
       <%= form.actions do %>
-        <%= form.submit "Pay Online Now" %>
+        <%= form.submit "Pay Online Now", data: {turbo: false} %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
# What it does

The buttons in our payments flows that redirect aren't working properly with the newest version of Turbo. This PR disables Turbo for those buttons and also updates the remote system tests we have that verify this behavior so that they are compatible with the current version of the Square checkout page.

# Implementation notes

* The two APIs we are using are deprecated, so I'll follow this PR up with another that replaces those with different APIs based on their recommended migration docs.
