### PR TITLE
Create appointment updated email

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -80,7 +80,7 @@ module Account
       if simultaneous_appointment
         simultaneous_appointment.merge!(@appointment)
         message = "Your existing appointment scheduled for #{helpers.appointment_date_and_time(simultaneous_appointment)} has been updated."
-        MemberMailer.with(member: @member, appointment: simultaneous_appointment).appointment_confirmation.deliver_later
+        MemberMailer.with(member: @member, appointment: simultaneous_appointment).appointment_updated.deliver_later
       else
         message = "Your appointment was scheduled for #{helpers.appointment_date_and_time(@appointment)}."
         MemberMailer.with(member: @member, appointment: @appointment).appointment_confirmation.deliver_later

--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -83,7 +83,7 @@ module Account
         MemberMailer.with(member: @member, appointment: simultaneous_appointment).appointment_updated.deliver_later
       elsif update_only
         message = "Your existing appointment scheduled for #{helpers.appointment_date_and_time(@appointment)} has been updated."
-        MemberMailer.with(member: @member, appointment: simultaneous_appointment).appointment_updated.deliver_later
+        MemberMailer.with(member: @member, appointment: @appointment).appointment_updated.deliver_later
       else
         message = "Your appointment was scheduled for #{helpers.appointment_date_and_time(@appointment)}."
         MemberMailer.with(member: @member, appointment: @appointment).appointment_confirmation.deliver_later

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -94,6 +94,14 @@ class MemberMailer < ApplicationMailer
     mail(to: @member.email, subject: @subject)
   end
 
+  def appointment_updated
+    @member = params[:member]
+    @library = @member.library
+    @appointment = params[:appointment]
+    @subject = "An appointment was updated for #{appointment_date_and_time(@appointment, include_time: false)}"
+    mail(to: @member.email, subject: @subject)
+  end
+  
   private
 
   def summary_mail(template_name: "summary")

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -101,7 +101,7 @@ class MemberMailer < ApplicationMailer
     @subject = "An appointment was updated for #{appointment_date_and_time(@appointment, include_time: false)}"
     mail(to: @member.email, subject: @subject)
   end
-  
+
   private
 
   def summary_mail(template_name: "summary")

--- a/app/views/member_mailer/appointment_updated.html.erb
+++ b/app/views/member_mailer/appointment_updated.html.erb
@@ -1,0 +1,46 @@
+
+
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center">An appointment was updated!</mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text>
+
+<p>Your appointment is scheduled for <%= appointment_date_and_time(@appointment) %></p>
+
+<% if @appointment.holds.present? %>
+  <p>The following items will be ready to pickup:</p>
+  <ul>
+    <% @appointment.holds.each do |hold| %>
+      <li>
+        <%= hold.item.complete_number %> <%= hold.item.name %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @appointment.loans.any? %>
+  <p>These are the items to be returned at your appointment:</p>
+  <ul>
+    <% @appointment.loans.each do |loan| %>
+      <li>
+        <%= loan.item.complete_number %> <%= loan.item.name %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<p>You can make changes to this appointment <%= link_to "on your account page", account_appointments_url(@appointment) %>.</p>
+
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/test/controllers/account/appointments_controller_test.rb
+++ b/test/controllers/account/appointments_controller_test.rb
@@ -57,7 +57,7 @@ module Account
       }}
 
       @appointment = @member.appointments.last
-      assert_enqueued_email(MemberMailer, :appointment_confirmation, params: {member: @member, appointment: @appointment})
+      assert_enqueued_email(MemberMailer, :appointment_updated, params: {member: @member, appointment: @appointment})
 
       assert_redirected_to account_appointments_path
       assert_equal 1, @member.appointments.count

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -108,4 +108,14 @@ class MemberMailerPreview < ActionMailer::Preview
     appointment.save!
     MemberMailer.with(member: member, appointment: appointment).appointment_confirmation
   end
+
+  def appointment_updated
+    member = Member.verified.first
+    tomorrow = Time.current + 1.day
+    loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: member, due_at: tomorrow, uniquely_numbered: false, library: member.library)
+    appointment = Appointment.new(starts_at: tomorrow, ends_at: tomorrow + 1.hour, member: member)
+    appointment.loans << loan
+    appointment.save!
+    MemberMailer.with(member: member, appointment: appointment).appointment_updated
+  end
 end


### PR DESCRIPTION
# What it does

- Added appointment_updated email template
- Changed single instance of appointment_confirmation to appointment_updated for existing appointment updates in appointment controller
- Updated integration test to expect appointment_updated for existing appointments

# Why it is important

[Issue 1220 :)](https://github.com/chicago-tool-library/circulate/issues/1220)
_"When someone edits an appointment, the email that we send makes it sound like a new appointment was scheduled. We should update the email we send to say "an appointment was updated" instead of "new appointment scheduled"."_

# UI Change Screenshot

_If this PR makes a change to the UI put a screenshot here. If you have before and after screenshots please add these._

# Implementation notes

* _Anything notable about the technical approach you took.

* _Any open questions you have about the PR or areas where you'd like specific feedback.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
