### PR TITLE
Get a fresh schema dump post Rails upgrades

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,46 +18,46 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     "fine",
     "membership",
     "donation",
-    "payment"
+    "payment",
   ], force: :cascade
 
   create_enum :adjustment_source, [
     "cash",
     "square",
-    "forgiveness"
+    "forgiveness",
   ], force: :cascade
 
   create_enum :hold_request_status, [
     "new",
     "completed",
-    "denied"
+    "denied",
   ], force: :cascade
 
   create_enum :item_attachment_kind, [
     "manual",
     "parts_list",
-    "other"
+    "other",
   ], force: :cascade
 
   create_enum :item_status, [
     "pending",
     "active",
     "maintenance",
-    "retired"
+    "retired",
   ], force: :cascade
 
   create_enum :notification_status, [
     "pending",
     "sent",
     "bounced",
-    "error"
+    "error",
   ], force: :cascade
 
   create_enum :pickup_status, [
     "building",
     "ready_for_pickup",
     "picked_up",
-    "cancelled"
+    "cancelled",
   ], force: :cascade
 
   create_enum :power_source, [
@@ -65,34 +65,34 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     "gas",
     "air",
     "electric (corded)",
-    "electric (battery)"
+    "electric (battery)",
   ], force: :cascade
 
   create_enum :renewal_request_status, [
     "requested",
     "approved",
-    "rejected"
+    "rejected",
   ], force: :cascade
 
   create_enum :reservation_status, [
     "pending",
     "requested",
     "approved",
-    "rejected"
+    "rejected",
   ], force: :cascade
 
   create_enum :ticket_status, [
     "assess",
     "parts",
     "repairing",
-    "resolved"
+    "resolved",
   ], force: :cascade
 
   create_enum :user_role, [
     "staff",
     "admin",
     "member",
-    "super_admin"
+    "super_admin",
   ], force: :cascade
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -110,7 +110,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -122,7 +122,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -174,13 +174,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
   end
 
   create_table "appointments", force: :cascade do |t|
-    t.datetime "starts_at", null: false
-    t.datetime "ends_at", null: false
+    t.datetime "starts_at", precision: nil, null: false
+    t.datetime "ends_at", precision: nil, null: false
     t.text "comment", default: "", null: false
     t.bigint "member_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "completed_at"
+    t.datetime "completed_at", precision: nil
     t.index ["member_id"], name: "index_appointments_on_member_id"
   end
 
@@ -198,7 +198,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     t.string "comment"
     t.string "remote_address"
     t.string "request_uuid"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"
@@ -270,8 +270,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
   create_table "events", force: :cascade do |t|
     t.string "calendar_id", null: false
     t.string "calendar_event_id", null: false
-    t.datetime "start", null: false
-    t.datetime "finish", null: false
+    t.datetime "start", precision: nil, null: false
+    t.datetime "finish", precision: nil, null: false
     t.string "summary"
     t.string "description"
     t.datetime "created_at", null: false
@@ -302,11 +302,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     t.bigint "creator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "ended_at"
+    t.datetime "ended_at", precision: nil
     t.bigint "loan_id"
     t.integer "library_id"
-    t.datetime "started_at"
-    t.datetime "expires_at"
+    t.datetime "started_at", precision: nil
+    t.datetime "expires_at", precision: nil
     t.integer "position", null: false
     t.index ["creator_id"], name: "index_holds_on_creator_id"
     t.index ["item_id", "position"], name: "index_holds_on_item_id_and_position", unique: true
@@ -389,8 +389,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
   create_table "loans", force: :cascade do |t|
     t.bigint "item_id"
     t.bigint "member_id"
-    t.datetime "due_at"
-    t.datetime "ended_at"
+    t.datetime "due_at", precision: nil
+    t.datetime "ended_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "uniquely_numbered", null: false
@@ -558,16 +558,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at"
+    t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "role", default: "member", null: false, enum_type: "user_role"
@@ -632,8 +632,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
     GROUP BY loans.library_id, loans.item_id, loans.member_id, COALESCE(loans.initial_loan_id, loans.id);
   SQL
   create_view "monthly_adjustments", sql_definition: <<-SQL
-      SELECT (date_part('year'::text, adjustments.created_at))::integer AS year,
-      (date_part('month'::text, adjustments.created_at))::integer AS month,
+      SELECT (EXTRACT(year FROM adjustments.created_at))::integer AS year,
+      (EXTRACT(month FROM adjustments.created_at))::integer AS month,
       count(*) FILTER (WHERE ((adjustments.kind = 'membership'::adjustment_kind) AND (adjustments.adjustable_id = first_memberships.first_membership_id))) AS new_membership_count,
       sum((- adjustments.amount_cents)) FILTER (WHERE ((adjustments.kind = 'membership'::adjustment_kind) AND (adjustments.adjustable_id = first_memberships.first_membership_id))) AS new_membership_total_cents,
       count(*) FILTER (WHERE ((adjustments.kind = 'membership'::adjustment_kind) AND (adjustments.adjustable_id <> first_memberships.first_membership_id))) AS renewal_membership_count,
@@ -647,8 +647,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
              FROM (members
                LEFT JOIN memberships ON ((members.id = memberships.member_id)))
             GROUP BY members.id) first_memberships ON ((first_memberships.member_id = adjustments.member_id)))
-    GROUP BY ((date_part('year'::text, adjustments.created_at))::integer), ((date_part('month'::text, adjustments.created_at))::integer)
-    ORDER BY ((date_part('year'::text, adjustments.created_at))::integer), ((date_part('month'::text, adjustments.created_at))::integer);
+    GROUP BY ((EXTRACT(year FROM adjustments.created_at))::integer), ((EXTRACT(month FROM adjustments.created_at))::integer)
+    ORDER BY ((EXTRACT(year FROM adjustments.created_at))::integer), ((EXTRACT(month FROM adjustments.created_at))::integer);
   SQL
   create_view "monthly_loans", sql_definition: <<-SQL
       WITH dates AS (
@@ -659,8 +659,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
            SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
              FROM dates
           )
-   SELECT (date_part('year'::text, months.month))::integer AS year,
-      (date_part('month'::text, months.month))::integer AS month,
+   SELECT (EXTRACT(year FROM months.month))::integer AS year,
+      (EXTRACT(month FROM months.month))::integer AS month,
       count(DISTINCT l.id) AS loans_count,
       count(DISTINCT l.member_id) AS active_members_count
      FROM (months
@@ -677,8 +677,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
            SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
              FROM dates
           )
-   SELECT (date_part('year'::text, months.month))::integer AS year,
-      (date_part('month'::text, months.month))::integer AS month,
+   SELECT (EXTRACT(year FROM months.month))::integer AS year,
+      (EXTRACT(month FROM months.month))::integer AS month,
       count(DISTINCT m.id) FILTER (WHERE (m.status = 0)) AS pending_members_count,
       count(DISTINCT m.id) FILTER (WHERE (m.status = 1)) AS new_members_count
      FROM (months
@@ -695,8 +695,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
            SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
              FROM dates
           )
-   SELECT (date_part('year'::text, months.month))::integer AS year,
-      (date_part('month'::text, months.month))::integer AS month,
+   SELECT (EXTRACT(year FROM months.month))::integer AS year,
+      (EXTRACT(month FROM months.month))::integer AS month,
       count(DISTINCT a.id) AS appointments_count,
       count(DISTINCT a.id) FILTER (WHERE (a.completed_at IS NOT NULL)) AS completed_appointments_count
      FROM (months
@@ -757,4 +757,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_201843) do
      FROM tree_nodes;
   SQL
   add_index "category_nodes", ["id"], name: "index_category_nodes_on_id", unique: true
+
 end

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ pre-commit:
     standard:
       tags: style
       glob: "*.rb"
-      exclude: "application.rb|routes.rb"
+      exclude: "application.rb|routes.rb|schema.rb"
       run: bundle exec standardrb --parallel --fix {staged_files} && git add {staged_files}
     readme:
       tags: lint

--- a/test/controllers/concerns/lending_test.rb
+++ b/test/controllers/concerns/lending_test.rb
@@ -17,7 +17,7 @@ class LendingTest < ActiveSupport::TestCase
     assert_equal item.id, renewal.item_id
     assert_equal loan.member_id, renewal.member_id
     assert_equal loan.id, renewal.initial_loan_id
-    assert_timestamp_equal sunday + 7.days, renewal.due_at
+    assert_equal sunday + 7.days, renewal.due_at
     assert_equal 1, renewal.renewal_count
     assert renewal.uniquely_numbered
   end
@@ -32,7 +32,7 @@ class LendingTest < ActiveSupport::TestCase
       renew_loan(loan, now: sunday)
     }
 
-    assert_timestamp_equal sunday + 7.days, renewal.due_at
+    assert_equal sunday + 7.days, renewal.due_at
   end
 
   test "renews a loan for a full period starting at due date" do
@@ -46,7 +46,7 @@ class LendingTest < ActiveSupport::TestCase
       renew_loan(loan, now: sunday)
     }
 
-    assert_timestamp_equal thursday + 7.days, renewal.due_at
+    assert_equal thursday + 7.days, renewal.due_at
   end
 
   test "renews a loan due tomorrow" do
@@ -63,7 +63,7 @@ class LendingTest < ActiveSupport::TestCase
     next_day = Loan.stub(:open_days, [0, 4]) {
       Loan.next_open_day(thursday + 7.days)
     }
-    assert_timestamp_equal next_day, renewal.due_at
+    assert_equal next_day, renewal.due_at
   end
 
   test "renews a renewal" do
@@ -85,7 +85,7 @@ class LendingTest < ActiveSupport::TestCase
     }
 
     assert_equal loan.id, second_renewal.initial_loan_id
-    assert_timestamp_equal sunday + 14.days, second_renewal.due_at
+    assert_equal sunday + 14.days, second_renewal.due_at
     assert_equal 2, second_renewal.renewal_count
   end
 

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -90,7 +90,7 @@ class LoanTest < ActiveSupport::TestCase
 
     sunday = Time.utc(2020, 1, 26).end_of_day
 
-    assert_timestamp_equal sunday, loan.due_at
+    assert_equal sunday, loan.due_at
   end
 
   test "returns the same day as the next open day" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,20 +21,6 @@ class ActiveSupport::TestCase
     assert_equal expected, subject.size, "wrong size; got #{subject.size} instead of #{expected}"
   end
 
-  # Postgres stores time at microsecond precision, while Ruby's Time classes
-  # operate at nanosecond precision. To simplify comparison, this helper
-  # truncates the nanosecond portion of the expected argument.
-  #
-  # While it is not required for the equality check to pass, this also converts
-  # the expected argument to a TimeWithZone, which is what ActiveRecord
-  # timestamps will be. This makes the output on failure a little cleaner as
-  # the to_s representations will line up.
-  #
-  # See: https://stackoverflow.com/questions/57703148/rails-timewithzone-doesnt-match
-  def assert_timestamp_equal(expected, subject)
-    assert_equal expected.in_time_zone.floor(6), subject, "expected timestamps to match to within microsecond precision"
-  end
-
   class << self
     def env_tags
       @env_tags ||= ENV.fetch("TAGS", "").split


### PR DESCRIPTION
# What it does

This gets us a fresh dump of the schema by running `db:drop`, `db:create`, and `db:migrate`.

The most important diff here is the `precision: nil` additions, which you can read about at length here:
https://github.com/rails/rails/issues/44571

Because of this change, we can drop the special timestamp handling we had added in the interim upgrades.

# Why it is important

Keeping the `schema.rb` consistent helps us reduce odd diffs in future work that modifies the database.