### PR TITLE
Improve readability of member appointment page

### DIFF
--- a/app/assets/stylesheets/account.scss
+++ b/app/assets/stylesheets/account.scss
@@ -6,6 +6,9 @@
     @media all and (min-width: 841px) {      
       margin-left: 2rem;
     }
+    @media all and (max-width: 840px) {
+      margin-top: 2rem;
+    }
     ul {
       list-style: outside;
     }
@@ -20,15 +23,11 @@
     margin: 0;
     list-style: none outside;
     li {
-      margin-bottom: 1.5rem;
-      border-bottom: solid 2px $gray-color-light;
+      margin-bottom: 1rem;
       padding-bottom: 1rem;
-      &:last-of-type {
-        border: none;
-      }
     }
     .image {
-      float: right;
+      float: left;
       width: 8rem;
       height: 100%;
       padding-right: .8rem;
@@ -67,6 +66,9 @@
 
 
 .account-appointments-index {
+  .section-header {
+    align-items: center;
+  }
   .appointment-list {
     margin: 0;
   }

--- a/app/assets/stylesheets/account.scss
+++ b/app/assets/stylesheets/account.scss
@@ -75,14 +75,14 @@
   .appointment {
     margin-top: 1rem;
     list-style: none outside;
-    h2 {
+    h3 {
       line-height: 1.2rem;
     }
     .schedule {
       display: flex;
       justify-content: space-between;
       .time {
-        font-size: 1rem;
+        font-size: 0.9rem;
         color: $gray-color;
       }
       .actions {

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -19,7 +19,7 @@
                   <% unless appointment.completed? %>
                     <%= button_to "Modify Appointment", edit_account_appointment_path(appointment), class: "btn btn-primary", method: :get, data: {turbo_submits_with: "Editing appointment..."} %>
                   <% end %>
-                <div>
+                </div>
               </div>
 
               <div class="card-body">

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -11,10 +11,10 @@
           <% @appointments.each do |appointment| %>
             <li class="appointment card">
               <div class="card-header schedule">
-                <h2>
+                <h3>
                   <%= appointment.starts_at.strftime("%A, %b %-d, %Y") %><br>
                   <span class="time">between <%= appointment_time(appointment) %></span>
-                </h2>
+                </h3>
                 <div class="actions">
                   <% unless appointment.completed? %>
                     <%= button_to "Modify Appointment", edit_account_appointment_path(appointment), class: "btn btn-primary", method: :get, data: {turbo_submits_with: "Editing appointment..."} %>

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -49,12 +49,20 @@ namespace :devdata do
     Library.all.each_with_index do |library, index|
       offset = (index + 1) * 10000
       admin = library.users.where(role: "admin").first
+
+      image = File.open(Rails.root.join("test", "fixtures", "files", "tool-image.jpg"))
+
       ActsAsTenant.with_tenant(library) do
         Audited.audit_class.as_user(admin) do
           load_models Document, id_offset: offset
           load_models BorrowPolicy, id_offset: offset
           load_models Category, id_offset: offset
           load_models Item, id_offset: offset
+          Item.find_each do |item|
+            # create attachment
+            item.image.attach(io: image, filename: "tool-image.jpg")
+            image.rewind
+          end
           load_models ActionText::RichText, id_offset: offset
         end
       end


### PR DESCRIPTION
# What it does

Fixes #1236. Readability improvements to the member appointment page. It fixes the points called out in the issue, plus a few other small changes.

* Decrease the font size of the date and time
* Move images to the left of descriptions
* Remove horizontal lines between items
* Add vertical margin between the "Appointments" section and the "How do appointments work" section when viewed on small screens (e.g., phones). There was already a horizontal margin when viewed on a wide screen.

This PR also adds images to all items in the development version of the app. The same image is used for all items.

# Why it is important

#1236 

# UI Change Screenshot

Before:

![image](https://github.com/chicago-tool-library/circulate/assets/38900370/ab3436f5-3972-4129-ba5b-7f8e6fd632b8)

After:

![image](https://github.com/chicago-tool-library/circulate/assets/38900370/8de36b1a-c5bc-41fa-a0a4-3b59f033fe56)

# Implementation notes

The main issue was a div tag that wasn't closed properly. That caused the date/time header to flow directly into the card body rather than starting a new line.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
