### PR TITLE
Issue 1247 create_loan bug

### DIFF
--- a/app/controllers/concerns/lending.rb
+++ b/app/controllers/concerns/lending.rb
@@ -4,14 +4,10 @@ module Lending
   def create_loan(item, member, now: Time.current)
     loan = Loan.lend(item, to: member, now: now)
     loan.transaction do
-      if loan.save
-        if item.borrow_policy.consumable? && return_loan(loan, now: now)
-          item.decrement_quantity
-        end
-        loan
-      else
-        false
+      if loan.save && item.borrow_policy.consumable? && return_loan(loan, now: now)
+        item.decrement_quantity
       end
+      loan
     end
   end
 

--- a/test/controllers/concerns/lending_test.rb
+++ b/test/controllers/concerns/lending_test.rb
@@ -246,6 +246,15 @@ class LendingTest < ActiveSupport::TestCase
     assert member.checked_out_loans.empty?
   end
 
+  test "can't loan item in maintenance" do
+    item = create(:item, status: Item.statuses[:maintenance])
+    member = create(:member)
+
+    loan = create_loan(item, member)
+    assert !loan.persisted?
+    assert member.checked_out_loans.empty?
+  end
+
   test "marks the item as retired when the quantity hits 0" do
     borrow_policy = create(:consumable_borrow_policy)
     item = create(:item, quantity: 1, borrow_policy: borrow_policy)


### PR DESCRIPTION
# What it does

- Change return of create_loan method to always return loan so loans_controller persisted? logic handles items appropriately
- Create test for creating loans for items in maintenance scenario

# Why it is important

[Issue 1247](https://github.com/chicago-tool-library/circulate/issues/1247) addresses issue where undefined values were being passed and causing internal server errors.

# UI Change Screenshot

Close your eyes and imagine a HTTP 500 slowly fading away~

# Implementation notes

* _Anything notable about the technical approach you took._
No

* _Any open questions you have about the PR or areas where you'd like specific feedback._
I have not yet reproduced the error logged in as an admin or verified_member!! I'm new to the app, so I'm not sure how to create a loan on an item in maintenance because I don't see the button to do it for example on item B-1341 Airbrush kit. Need some help testing this change will work.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe): 
