### PR TITLE
Fix flaky RemoveHoldsTest cases

### DIFF
--- a/test/system/remove_holds_test.rb
+++ b/test/system/remove_holds_test.rb
@@ -28,7 +28,14 @@ class RemoveHoldsTest < ApplicationSystemTestCase
 
     visit account_holds_path
     accept_confirm { click_on "Remove Hold" }
-    click_on "Appointments"
+
+    # This sleep seems to quell a flaky failure with Capybara clicking on the
+    # Appointments link after the accept_confirm above
+    sleep 1
+    within("header.navbar") do
+      click_on "Appointments"
+    end
+    assert_current_path account_appointments_path
 
     appointment_card = find("li.appointment")
     within(appointment_card) do
@@ -44,7 +51,14 @@ class RemoveHoldsTest < ApplicationSystemTestCase
 
     visit account_holds_path
     accept_confirm { click_on "Remove Hold" }
-    click_on "Appointments"
+
+    # This sleep seems to quell a flaky failure with Capybara clicking on the
+    # Appointments link after the accept_confirm above
+    sleep 1
+    within("header.navbar") do
+      click_on "Appointments"
+    end
+    assert_current_path account_appointments_path
 
     assert_text "You have no scheduled appointments"
   end


### PR DESCRIPTION
Closes #1275

# What it does

The tests seem to be failing because the `click_on "Appointments"` action is not working after the `accept_confirm`. This changes the `click_on` to be more conservative and adds an assertion to make the error message clear when that's the step that's failing. It also adds a short sleep between the `accept_confirm` and the `click_on` which in my testing seemed to address the flakiness of these two tests.

# Why it is important

Flaky tests bad. Tests should reliably pass!

# Implementation notes

I know that adding sleeps to address flaky Capybara tests is generally discouraged, but I feel like I exhausted all our other options in this investigation (barring something more drastic like moving away from javascript popups - I did find [one article suggesting they should be avoided](https://medium.com/@bsemaj/6-tips-to-get-your-flaky-capybara-tests-passing-a97817af1aec) because they're a source of flaky capybara behavior).
