### PR TITLE
Remove unused smooth-scroll-into-view package

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,16 +12,3 @@ import { setupFeatherIcons } from "./lib/feather"
 
 document.documentElement.addEventListener("turbo:load", setupFeatherIcons);
 document.documentElement.addEventListener("turbo:frame-render", setupFeatherIcons);
-
-// import scrollIntoView from 'smooth-scroll-into-view-if-needed';
-// 
-// Turbo.ScrollManager.prototype.scrollToElement = function(element) {
-//   let classes = element.classList;
-//   if (classes.contains("highlightable")) {
-//     classes.add("highlight");
-//   }
-//   scrollIntoView(element, {
-//     behavior: 'smooth',
-//     scrollMode: 'if-needed',
-//   });
-// }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "mjml": "^4.15.2",
     "sass": "^1.67.0",
     "selectize": "^0.12.6",
-    "smooth-scroll-into-view-if-needed": "^1.1.33",
     "sortablejs": "^1.15.0",
     "spectre.css": "^0.5.8",
     "trix": "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,11 +442,6 @@ commander@^6.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-compute-scroll-into-view@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
-  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1714,13 +1709,6 @@ sass@^1.67.0:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-scroll-into-view-if-needed@^2.2.28:
-  version "2.2.28"
-  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz#5a15b2f58a52642c88c8eca584644e01703d645a"
-  integrity sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==
-  dependencies:
-    compute-scroll-into-view "^1.0.17"
-
 selectize@^0.12.6:
   version "0.12.6"
   resolved "https://registry.yarnpkg.com/selectize/-/selectize-0.12.6.tgz#c2cf08cbaa4cb06c5e99bb452919d71b080690d6"
@@ -1778,13 +1766,6 @@ slick@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/slick/-/slick-1.12.2.tgz#bd048ddb74de7d1ca6915faa4a57570b3550c2d7"
   integrity sha1-vQSN23TefRymkV+qSldXCzVQwtc=
-
-smooth-scroll-into-view-if-needed@^1.1.33:
-  version "1.1.33"
-  resolved "https://registry.yarnpkg.com/smooth-scroll-into-view-if-needed/-/smooth-scroll-into-view-if-needed-1.1.33.tgz#2c7b88c82784c69030cb0489b9df584e94e01533"
-  integrity sha512-crS8NfAaoPrtVYOCMSAnO2vHRgUp22NiiDgEQ7YiaAy5xe2jmR19Jm+QdL8+97gO8ENd7PUyQIAQojJyIiyRHw==
-  dependencies:
-    scroll-into-view-if-needed "^2.2.28"
 
 sortablejs@^1.15.0:
   version "1.15.0"


### PR DESCRIPTION
# What it does

Removes an unused dependency, as discussed in https://github.com/chicago-tool-library/circulate/pull/1272

# Why it is important

Less code makes maintenance easier!