### PR TITLE
Update minitest and fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem "minitest", "5.15.0"
+  gem "minitest", "5.22.0"
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
   gem "minitest-ci"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.5)
-    minitest (5.15.0)
+    minitest (5.22.0)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mjml-rails (4.7.2)
@@ -578,7 +578,7 @@ DEPENDENCIES
   listen
   lograge
   mini_magick
-  minitest (= 5.15.0)
+  minitest (= 5.22.0)
   minitest-ci
   mjml-rails
   money-rails

--- a/test/controllers/renewal/payments_controller_test.rb
+++ b/test/controllers/renewal/payments_controller_test.rb
@@ -26,13 +26,12 @@ module Renewal
 
       mock_checkout = Minitest::Mock.new
       Time.use_zone "America/Chicago" do
-        mock_checkout.expect :checkout_url, mock_result, [{
+        mock_checkout.expect(:checkout_url, mock_result,
           amount: Money.new(1200),
           email: @member.email,
           return_to: "http://example.com/renewal/payments/callback",
           member_id: @member.id,
-          date: Date.current
-        }]
+          date: Date.current)
 
         SquareCheckout.stub :new, mock_checkout do
           post renewal_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
@@ -51,7 +50,12 @@ module Renewal
       mock_result.expect :error, [{code: "SOMETHING_WENT_WRONG"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :checkout_url, mock_result, [Hash]
+      mock_checkout.expect(:checkout_url, mock_result,
+        amount: Money,
+        email: String,
+        return_to: String,
+        member_id: Integer,
+        date: Date)
 
       SquareCheckout.stub :new, mock_checkout do
         post renewal_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
@@ -72,10 +76,9 @@ module Renewal
       mock_result.expect :value, Money.new(1234)
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [{
+      mock_checkout.expect(:fetch_transaction, mock_result,
         member: @member,
-        transaction_id: "abcd1234"
-      }]
+        transaction_id: "abcd1234")
 
       SquareCheckout.stub :new, mock_checkout do
         assert_difference "Membership.count" => 1, "Adjustment.count" => 2 do
@@ -97,7 +100,7 @@ module Renewal
       mock_result.expect :error, [{code: "ERROR_CODE"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+      mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
       SquareCheckout.stub :new, mock_checkout do
         assert_no_difference ["Membership.count", "Adjustment.count"] do
@@ -120,7 +123,7 @@ module Renewal
       mock_result.expect :error, [{code: "NOT_FOUND"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+      mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
       SquareCheckout.stub :new, mock_checkout do
         assert_no_difference ["Membership.count", "Adjustment.count"] do
@@ -143,7 +146,7 @@ module Renewal
         mock_result.expect :error, [{code: "NOT_FOUND"}]
 
         mock_checkout = Minitest::Mock.new
-        mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+        mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
         SquareCheckout.stub :new, mock_checkout do
           get callback_renewal_payments_url, params: {transactionId: "abcd1234"}

--- a/test/controllers/signup/payments_controller_test.rb
+++ b/test/controllers/signup/payments_controller_test.rb
@@ -20,13 +20,12 @@ module Signup
 
       mock_checkout = Minitest::Mock.new
       Time.use_zone "America/Chicago" do
-        mock_checkout.expect :checkout_url, mock_result, [{
+        mock_checkout.expect(:checkout_url, mock_result,
           amount: Money.new(1200),
           email: @member.email,
           return_to: "http://example.com/signup/payments/callback",
           member_id: @member.id,
-          date: Date.current
-        }]
+          date: Date.current)
 
         SquareCheckout.stub :new, mock_checkout do
           post signup_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
@@ -45,7 +44,12 @@ module Signup
       mock_result.expect :error, [{code: "SOMETHING_WENT_WRONG"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :checkout_url, mock_result, [Hash]
+      mock_checkout.expect(:checkout_url, mock_result,
+        amount: Money,
+        email: String,
+        return_to: String,
+        member_id: Integer,
+        date: Date)
 
       SquareCheckout.stub :new, mock_checkout do
         post signup_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
@@ -66,10 +70,9 @@ module Signup
       mock_result.expect :value, Money.new(1234)
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [{
+      mock_checkout.expect(:fetch_transaction, mock_result,
         member: @member,
-        transaction_id: "abcd1234"
-      }]
+        transaction_id: "abcd1234")
 
       SquareCheckout.stub :new, mock_checkout do
         assert_difference "Membership.count" => 1, "Adjustment.count" => 2 do
@@ -91,7 +94,7 @@ module Signup
       mock_result.expect :error, [{code: "ERROR_CODE"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+      mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
       SquareCheckout.stub :new, mock_checkout do
         assert_no_difference ["Membership.count", "Adjustment.count"] do
@@ -114,7 +117,7 @@ module Signup
       mock_result.expect :error, [{code: "NOT_FOUND"}]
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+      mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
       SquareCheckout.stub :new, mock_checkout do
         assert_no_difference ["Membership.count", "Adjustment.count"] do
@@ -138,7 +141,7 @@ module Signup
         mock_result.expect :error, [{code: "NOT_FOUND"}]
 
         mock_checkout = Minitest::Mock.new
-        mock_checkout.expect :fetch_transaction, mock_result, [Hash]
+        mock_checkout.expect :fetch_transaction, mock_result, member: Member, transaction_id: String
 
         SquareCheckout.stub :new, mock_checkout do
           get callback_signup_payments_url, params: {transactionId: "abcd1234"}

--- a/test/lib/square_checkout_test.rb
+++ b/test/lib/square_checkout_test.rb
@@ -16,31 +16,28 @@ class SquareCheckoutTest < ActiveSupport::TestCase
     mock_response.expect :body, mock_body
 
     mock_checkout = Minitest::Mock.new
-    mock_checkout.expect :create_checkout, mock_response, [
-      {
-        location_id: "SQ_LOCATION_ID",
-        body: {
-          idempotency_key: "test",
-          redirect_url: "http://example.com/callback",
-          pre_populate_buyer_email: member.email,
+    mock_checkout.expect(:create_checkout, mock_response,
+      location_id: "SQ_LOCATION_ID",
+      body: {
+        idempotency_key: "test",
+        redirect_url: "http://example.com/callback",
+        pre_populate_buyer_email: member.email,
+        order: {
           order: {
-            order: {
-              location_id: "SQ_LOCATION_ID",
-              reference_id: "20210101-#{member.id}",
-              line_items: [{
-                name: "Annual Membership",
-                quantity: "1",
-                base_price_money: {
-                  amount: form.amount.cents,
-                  currency: "USD"
-                }
-              }]
-            }
-          },
-          note: "Circulate signup payment"
-        }
-      }
-    ]
+            location_id: "SQ_LOCATION_ID",
+            reference_id: "20210101-#{member.id}",
+            line_items: [{
+              name: "Annual Membership",
+              quantity: "1",
+              base_price_money: {
+                amount: form.amount.cents,
+                currency: "USD"
+              }
+            }]
+          }
+        },
+        note: "Circulate signup payment"
+      })
 
     mock_client = Minitest::Mock.new
     mock_client.expect :checkout, mock_checkout
@@ -76,31 +73,28 @@ class SquareCheckoutTest < ActiveSupport::TestCase
     mock_response.expect :errors, "ERRORS"
 
     mock_checkout = Minitest::Mock.new
-    mock_checkout.expect :create_checkout, mock_response, [
-      {
-        location_id: "SQ_LOCATION_ID",
-        body: {
-          idempotency_key: "test",
-          redirect_url: "http://example.com/callback",
-          pre_populate_buyer_email: member.email,
+    mock_checkout.expect(:create_checkout, mock_response,
+      location_id: "SQ_LOCATION_ID",
+      body: {
+        idempotency_key: "test",
+        redirect_url: "http://example.com/callback",
+        pre_populate_buyer_email: member.email,
+        order: {
           order: {
-            order: {
-              location_id: "SQ_LOCATION_ID",
-              reference_id: "20210101-#{member.id}",
-              line_items: [{
-                name: "Annual Membership",
-                quantity: "1",
-                base_price_money: {
-                  amount: form.amount.cents,
-                  currency: "USD"
-                }
-              }]
-            }
-          },
-          note: "Circulate signup payment"
-        }
-      }
-    ]
+            location_id: "SQ_LOCATION_ID",
+            reference_id: "20210101-#{member.id}",
+            line_items: [{
+              name: "Annual Membership",
+              quantity: "1",
+              base_price_money: {
+                amount: form.amount.cents,
+                currency: "USD"
+              }
+            }]
+          }
+        },
+        note: "Circulate signup payment"
+      })
 
     mock_client = Minitest::Mock.new
     mock_client.expect :checkout, mock_checkout
@@ -139,7 +133,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
     mock_response.expect :body, mock_body
 
     mock_transactions = Minitest::Mock.new
-    mock_transactions.expect :retrieve_transaction, mock_response, [{location_id: "SQ_LOCATION_ID", transaction_id: "transaction_1"}]
+    mock_transactions.expect(:retrieve_transaction, mock_response, location_id: "SQ_LOCATION_ID", transaction_id: "transaction_1")
 
     mock_client = Minitest::Mock.new
     mock_client.expect :transactions, mock_transactions
@@ -167,7 +161,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
     mock_response.expect :errors, "ERRORS"
 
     mock_transactions = Minitest::Mock.new
-    mock_transactions.expect :retrieve_transaction, mock_response, [{location_id: "SQ_LOCATION_ID", transaction_id: "transaction_1"}]
+    mock_transactions.expect(:retrieve_transaction, mock_response, location_id: "SQ_LOCATION_ID", transaction_id: "transaction_1")
 
     mock_client = Minitest::Mock.new
     mock_client.expect :transactions, mock_transactions


### PR DESCRIPTION
# What it does

Updates minitest and changes tests to pass in the newer version

# Why it is important

Staying on the latest version of our dependencies is good

# Implementation notes

Minitest's interface changed slightly when they added first class support for kwargs, see https://github.com/minitest/minitest/issues/912

Closes #1269