### PR TITLE
Install dependencies when starting bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -5,6 +5,18 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+# Install missing yarn dependencies
+if ! yarn install -s; then
+  echo "Yarn dependencies could not be installed!"
+  exit
+fi
+
+# Install missing Ruby dependencies
+if ! bundle install --quiet; then
+  echo "Ruby dependencies could not be installed!"
+  exit
+fi
+
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 


### PR DESCRIPTION
# What it does

I noticed that it's easy to forget to install updated dependencies when you've pulled down new code. This adds extra steps to `bin/dev` to do this for you when you start up the dev server.

From my testing this doesn't add a significant delay to everything starting up, and I think it will save folks time from not having done this for both sets of dependencies. Now that we're keeping them fairly up to date, they will change more often.

# Implementation notes

* Both `yarn` and `bundle ` are invoked with arguments to not output any text, but there is a "Nothing to migrate!" message that is printed when `yarn installs`. I don't think it's a huge deal; we can fix that in the future.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
