### PR TITLE
Add an improved test tagging system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Configuring your database](#configuring-your-database)
   - [Resetting the application](#resetting-the-application)
   - [Running tests](#running-tests)
+    - [Remote tests and test tagging](#remote-tests-and-test-tagging)
   - [Code formatting and linting](#code-formatting-and-linting)
   - [Setup pre-commit checks](#setup-pre-commit-checks)
   - [Documentation](#documentation)
@@ -176,6 +177,42 @@ $ rails test:system # to run system tests
 ```
 
 Note, in order to get system tests to run, you will need `chromedriver` installed. See [Requirements section](#requirements) above.
+
+#### Remote tests and test tagging
+
+Tests tagged as `remote` are not run by default. They are defined by passing additional arguments to `test` when defining the test methods:
+
+```ruby
+test "do something with a remote server", :remote do
+  # interact with a remote machine
+end
+```
+
+This kind of test are useful to ensure that some code in the repository actually works with an external server properly, but since that test has a dependency on that server (and often on having access to credentials), we don't want to automatically run those tests all the time.
+
+If you'd like to run all the tests (regardless of whether they are remote or not), you can do that:
+
+```console
+$ bin/rails test -t :remote
+```
+
+This works for running the tests in a file as well:
+
+```console
+$ bin/rails test path/to/file -t :remote
+```
+
+The `:` prefix clears the default setting that negates tests with the `remote` flag. You can also run only tests tagged with `remote` (or any other tag):
+
+```console
+$ bin/rails test path/to/file -t remote
+```
+
+It's also possible to filter out tests with other tags (should we add them) using the `~` prefix. The following would cause the test runner to ignore any tests tagged with `slow`:
+
+```console
+$ bin/rails test -t ~slow
+```
 
 ### Code formatting and linting
 

--- a/test/minitest/tags_plugin.rb
+++ b/test/minitest/tags_plugin.rb
@@ -1,0 +1,118 @@
+module Minitest
+  # This is based roughly on the way tag filtering is done by Rspec.
+  #
+  # Tags can be either required or negated.
+  #
+  # If any tags are required, tests much match at least one of the provided
+  # tags. Required tags have no prefix.
+  #
+  # If any tags are negated, tests matching any negated tag will not run. Tags
+  # can be negated with ` tilde (`~`) prefix.
+  #
+  # Tests tagged with `remote` are negated by default.
+  #
+  # To clear a tag (make it neither required or negated), a colon (`:`) can
+  # be used as a tag prefix.
+  class TagFilter
+    def initialize
+      @required_tags = []
+      @negated_tags = []
+    end
+
+    def require_tag(name)
+      name_symbol = name.to_sym
+      @negated_tags.delete_if { |k| k == name_symbol }
+      @required_tags << name_symbol
+    end
+
+    def negate_tag(name)
+      name_symbol = name.to_sym
+      @required_tags.delete_if { |k| k == name_symbol }
+      @negated_tags << name_symbol
+    end
+
+    def clear_tag(name)
+      name_symbol = name.to_sym
+      @negated_tags.delete_if { |k| k == name_symbol }
+      @required_tags.delete_if { |k| k == name_symbol }
+    end
+
+    def apply_tag_string(tag_string)
+      tag_string.split.each do |tag|
+        match, prefix, name = *tag.match(/([~:]?)(\w+)/)
+
+        unless match
+          raise "unrecognized tag #{tag}, tags must use only letters, numbers, and underscores"
+        end
+
+        if prefix == ""
+          require_tag(name)
+        elsif prefix == "~"
+          negate_tag(name)
+        elsif prefix == ":"
+          clear_tag(name)
+        else
+          raise "unrecognized tag #{tag}, only ~ or : are supported as prefixes"
+        end
+      end
+    end
+
+    # Determine if a test with the specified tags run should run
+    def allow_tags?(tags)
+      tags = tags.map(&:to_sym)
+
+      # If there are additive tags, at least one must match
+      unless @required_tags.empty?
+        return false if @required_tags.intersection(tags).size == 0
+      end
+
+      # If there are negated tags, none can match
+      return false if @negated_tags.intersection(tags).size > 0
+
+      true
+    end
+  end
+
+  def self.allow_tags?(tags)
+    @tag_filter.allow_tags?(tags)
+  end
+
+  def self.plugin_tags_options(opts, options)
+    opts.on "--tag TAG", "Filter tests by tag (use ~ to negate)" do |tags|
+      options[:tags] ||= []
+      options[:tags] << tags
+    end
+  end
+
+  def self.plugin_tags_init(options)
+    @tag_filter = TagFilter.new.tap do |tag_filter|
+      tag_filter.negate_tag :remote # don't run remote test by default
+      if options.key?(:tags)
+        options[:tags].each do |tags|
+          tag_filter.apply_tag_string(tags)
+        end
+      end
+    end
+  end
+end
+
+module TestCasePatch
+  # This method returns the names of method that will be run by the test runner.
+  def runnable_methods
+    super.select { |name| Minitest.allow_tags?(method_tags[name]) }
+  end
+
+  # Store a map of method name -> tag array
+  def method_tags
+    @method_tags ||= {}
+  end
+
+  # Override test definition to allow for extra arguments. These become the tags.
+  def test(subject, *tags, &block)
+    super(subject, &block).tap do |method|
+      method_tags[method.name] = tags
+    end
+  end
+end
+
+ActiveSupport::TestCase.send :extend, TestCasePatch

--- a/test/minitest/tags_plugin.rb
+++ b/test/minitest/tags_plugin.rb
@@ -115,4 +115,4 @@ module TestCasePatch
   end
 end
 
-ActiveSupport::TestCase.send :extend, TestCasePatch
+ActiveSupport::TestCase.extend TestCasePatch

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,10 @@ require "minitest/mock"
 require "helpers/return_values"
 require "helpers/ensure_request_tenant"
 
+# Explicit require means the plugin is available when tests are evaluated;
+# otherwise, the plugin isn't loaded until later.
+require "minitest/tags_plugin"
+
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
@@ -19,22 +23,6 @@ class ActiveSupport::TestCase
 
   def assert_size(expected, subject)
     assert_equal expected, subject.size, "wrong size; got #{subject.size} instead of #{expected}"
-  end
-
-  class << self
-    def env_tags
-      @env_tags ||= ENV.fetch("TAGS", "").split
-    end
-
-    def test(subject, *tags, &block)
-      if tags.include?(:remote) && !env_tags.include?("remote")
-        super(subject) do
-          skip "Skipping remote test"
-        end
-      else
-        super(subject, &block)
-      end
-    end
   end
 
   setup do


### PR DESCRIPTION
# What it does

In the process of upgrading the Square library, I found myself working with our test tagging a bunch and found it rather lacking. I looked for something off-the-shelf, but [the closest thing I could find](https://github.com/ordinaryzelig/minispec-metadata) only works with minitest-spec (which we aren't using).

The [README changes](https://github.com/chicago-tool-library/circulate/pull/1309/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R181) describe how this works fairly well, but here's a high level summary:

* Tests are tagged by passing a list of symbols after the test name, like `test "the app works", :remote do .... end`.
* We don't run tests tagged with `remote` by default.
* I based the syntax for tags off [how Rspec does it](https://rspec.info/features/3-12/rspec-core/command-line/tag/), albeit in a very simplified form.
    * You can use `-t` or `--tag` to scope the tests that are run to a specific tag, like `bin/rails test -t remote` will only run remote tests.
    * You can also negate tags to not run them using `~`. If we didn't negate remote tests by default, you could do the same thing with `bin/rails test -t ~remote`.
    * You can clear the settings for a tag using `:`. So to run all tests (and ignore the default negation of remote-tagged tests), you'd run `bin/rails test -t :remote`.
    * To run, tests have to match at least one required tag but none of the negated tags.

# Why it is important

As we're adding more remote tests and different types of tests, being able to run a specific subset will be very useful.

I started to mess with putting remote tests in a different directory, but then I had some lib tests and some system tests, and then I needed a way to share code between the remote and normal tests for the same class now that they were split apart. By leveraging tags, we can co-locate the test code when needed but still have control over what runs when.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
