### PR TITLE
Remove unused dependency minitest-ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ group :test do
   gem "minitest", "5.22.1"
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
-  gem "minitest-ci"
   gem "rails-controller-testing"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,8 +281,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.5)
     minitest (5.22.1)
-    minitest-ci (3.4.0)
-      minitest (>= 5.0.6)
     mjml-rails (4.7.2)
     monetize (1.11.0)
       money (~> 6.12)
@@ -577,7 +575,6 @@ DEPENDENCIES
   lograge
   mini_magick
   minitest (= 5.22.1)
-  minitest-ci
   mjml-rails
   money-rails
   omniauth-google-oauth2


### PR DESCRIPTION
# What it does

This was added back when we were using CircleCI (4 years ago in #10). I think it allowed the test results to be parsed by the service in some way. Since we are on Github Actions now, I think this can go.

# Why it is important

More dependencies, more problems.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
