### PR TITLE
Change overdue notice SMS link to appointment page

### DIFF
--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -11,7 +11,7 @@ class MemberTexter < BaseTexter
     return unless member.reminders_via_text?
 
     message = <<~EOM
-      Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "overdue item")}! Please schedule a return appointment at #{account_member_url}
+      Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "overdue item")}! Please schedule a return appointment at #{new_account_appointment_url}
     EOM
     result = text(to: @member.canonical_phone_number, body: message)
     store_notification("overdue_notice", message, result)


### PR DESCRIPTION
# What it does

Change overdue notice SMS url to new appointment page. The member page does not allow you schedule a return appointment directly.

# Why it is important

We're asking users to schedule an appointment to return their tools, so we should route them to a page where that happens.

# UI Change Screenshot

New target page of link:

![2024-02-09 at 14 54 30@2x](https://github.com/chicago-tool-library/circulate/assets/37534/e85e21a4-ead6-447d-81cc-2fd63187942c)
