### PR TITLE
894 add complete button to appointment page

### DIFF
--- a/app/controllers/admin/appointment_detail_completions_controller.rb
+++ b/app/controllers/admin/appointment_detail_completions_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class AppointmentDetailController < BaseController
+  class AppointmentDetailCompletionsController < BaseController
     include ActionView::RecordIdentifier
 
     before_action :are_appointments_enabled?

--- a/app/views/admin/appointments/_complete.html.erb
+++ b/app/views/admin/appointments/_complete.html.erb
@@ -9,4 +9,3 @@
 
   <%= button_to "Cancel", admin_appointment_path(appointment), class: "btn mt-2", method: :delete, data: {turbo_submits_with: "Cancelling appointment...", turbo_confirm: "Are you sure to cancel this appointment?"} %>
 </div>
-

--- a/app/views/admin/appointments/_complete.html.erb
+++ b/app/views/admin/appointments/_complete.html.erb
@@ -1,10 +1,10 @@
 <div id="<%= dom_id(appointment) %>-complete">
   <% if appointment.completed? %>
-    <%= button_to "Restore", admin_appointment_detail_path(appointment),
+    <%= button_to "Restore", admin_appointment_detail_completion_path(appointment),
           method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
   <% else %>
-    <%= button_to "Complete", admin_appointment_path(appointment),
-          method: :put, class: "btn btn-primary", data: {disable_with: "saving"} %>
+    <%= button_to "Complete", admin_appointment_detail_completion_path(appointment),
+          method: :post, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
   <% end %>
 
   <%= button_to "Cancel", admin_appointment_path(appointment), class: "btn mt-2", method: :delete, data: {turbo_submits_with: "Cancelling appointment...", turbo_confirm: "Are you sure to cancel this appointment?"} %>

--- a/app/views/admin/appointments/_complete.html.erb
+++ b/app/views/admin/appointments/_complete.html.erb
@@ -7,6 +7,6 @@
           method: :put, class: "btn btn-primary", data: {disable_with: "saving"} %>
   <% end %>
 
-  <%= button_to "Cancel", admin_appointment_path(appointment), class: "btn mt-2 btn-danger", method: :delete, data: {turbo_submits_with: "Cancelling appointment...", turbo_confirm: "Are you sure to cancel this appointment?"} %>
+  <%= button_to "Cancel", admin_appointment_path(appointment), class: "btn mt-2", method: :delete, data: {turbo_submits_with: "Cancelling appointment...", turbo_confirm: "Are you sure to cancel this appointment?"} %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       resources :checkouts, only: [:create], controller: :appointment_checkouts
       resources :checkins, only: [:create], controller: :appointment_checkins
       resource :completion, only: [:create, :destroy], controller: :appointment_completions
-      resource :detail, only: [:create, :destroy], controller: :appointment_detail
+      resource :detail_completion, only: [:create, :destroy], controller: :appointment_detail_completions
     end
     resources :manage_features, only: [:index, :update]
     resources :items do

--- a/test/controllers/admin/appointment_detail_completions_controller_test.rb
+++ b/test/controllers/admin/appointment_detail_completions_controller_test.rb
@@ -1,7 +1,7 @@
 require "application_system_test_case"
 
 module Admin
-  class AppointmentDetailsControllerTest < ActionDispatch::IntegrationTest
+  class AppointmentDetailCompletionsControllerTest < ActionDispatch::IntegrationTest
     include Devise::Test::IntegrationHelpers
 
     setup do
@@ -16,16 +16,16 @@ module Admin
     end
 
     test "completes an appointment" do
-      post admin_appointment_detail_path(@appointment), as: :turbo_stream
+      post admin_appointment_detail_completion_path(@appointment), as: :turbo_stream
 
-      assert @appointment.reload.completed_at
       assert_redirected_to admin_appointments_path
+      assert @appointment.reload.completed_at
     end
 
     test "un-completes an appointment" do
       @appointment.update!(completed_at: Time.current)
 
-      delete admin_appointment_detail_path(@appointment), as: :turbo_stream
+      delete admin_appointment_detail_completion_path(@appointment), as: :turbo_stream
       assert_response :success
 
       assert_nil @appointment.reload.completed_at


### PR DESCRIPTION
# What it does

Adding a complete button to the appointment details page. Clicking this button completes the appointment and returns to the appointment list page. If viewing a completed appointment, the button will restore the appointment and leave the user on the appointment details page.

# Why it is important

Users have requested a button here to avoid having to go back to the appointment list page before completing the appointment.

# UI Change Screenshot

Before:
![Screenshot 2024-02-11 115409](https://github.com/chicago-tool-library/circulate/assets/2738059/18863681-a610-4c85-868c-e54987f2882a)

After:
![Screenshot 2024-02-11 115110](https://github.com/chicago-tool-library/circulate/assets/2738059/9809be4e-e874-4105-9380-62e3e6d9bd32)

# Implementation notes

Not 100% sure about the creation of the new controller and partial view approach. If the reviewer could make sure that it is following Ruby on Rails best practices, that would be great!

# Your bandwidth for additional changes to this PR

I have the time and interest to make additional changes to this PR based on feedback.
