### PR TITLE
SMS Return Reminders

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -29,6 +29,10 @@ class ActivityNotifier
 
     each_member(members_with_items_due_tomorrow) do |member, summaries|
       MemberMailer.with(member: member, summaries: summaries, now: @now).return_reminder.deliver
+      if sms_reminders_enabled?
+        due_tomorrow_summaries = summaries.checked_out.due_on(tomorrow)
+        MemberTexter.new(member).return_reminder(due_tomorrow_summaries)
+      end
     end
   end
 

--- a/app/models/loan_summary.rb
+++ b/app/models/loan_summary.rb
@@ -14,6 +14,7 @@ class LoanSummary < ApplicationRecord
   }
 
   scope :checked_out, -> { where(ended_at: nil) }
+  scope :due_on, ->(day) { where("due_at BETWEEN ? AND ?", day.beginning_of_day.utc, day.end_of_day.utc) }
   scope :overdue, -> { overdue_as_of(Time.current) }
   scope :overdue_as_of, ->(date) { checked_out.where "due_at < ?", date }
   scope :returned, -> { where.not(ended_at: nil) }

--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -18,6 +18,17 @@ class MemberTexter < BaseTexter
     result
   end
 
+  def return_reminder(summaries)
+    return unless member.reminders_via_text?
+
+    message = <<~EOM
+      Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "item")} due tomorrow. Review your loans at #{account_loans_url}
+    EOM
+    result = text(to: @member.canonical_phone_number, body: message)
+    store_notification("return_reminder", message, result)
+    result
+  end
+
   def store_notification(action_name, message, result)
     Notification.create!(
       member: member,

--- a/test/test_helpers/twilio_helper.rb
+++ b/test/test_helpers/twilio_helper.rb
@@ -4,6 +4,9 @@ module TwilioHelper
     SUCCESSFUL_FROM = "+15005550006"
   end
 
+  # See https://www.twilio.com/docs/glossary/what-sms-character-limit
+  SEGMENT_LENGTH = 160
+
   # Via https://thoughtbot.com/blog/testing-sms-interactions
   class FakeSMS
     Message = Struct.new(:from, :to, :body, :sid, :status, keyword_init: true)

--- a/test/texters/member_texter_test.rb
+++ b/test/texters/member_texter_test.rb
@@ -20,9 +20,10 @@ class MemberTexterTest < ActionMailer::TestCase
     text = TwilioHelper::FakeSMS.messages.first
     assert_equal text.to, member.canonical_phone_number
     assert_includes text.body, "4 overdue items"
+    assert_operator text.body.length, :<=, TwilioHelper::SEGMENT_LENGTH, "fits in a single SMS segment"
   end
 
-  test "skips the notice if the member has not opted into text reminders" do
+  test "skips overdue notice if the member has not opted into text reminders" do
     member = build(:member, reminders_via_text: false)
     summaries = [:list, :of, :overdue, :summaries]
 
@@ -31,7 +32,7 @@ class MemberTexterTest < ActionMailer::TestCase
     assert_empty TwilioHelper::FakeSMS.messages
   end
 
-  test "stores a notification record of a successful message" do
+  test "stores a notification record of a successful overdue notice" do
     member = create(:member)
     summaries = [:list, :of, :overdue, :summaries]
 
@@ -44,5 +45,43 @@ class MemberTexterTest < ActionMailer::TestCase
     assert_equal text.body, notification.subject
     assert_equal member.id, notification.member_id
     assert_equal "accepted", notification.status
+    assert_equal "overdue_notice", notification.action
+  end
+
+  test "sends a return reminder to the member" do
+    member = build(:member)
+    summaries = [:list, :of, :summaries, :due, :tomorrow]
+
+    MemberTexter.new(member).return_reminder(summaries)
+
+    text = TwilioHelper::FakeSMS.messages.first
+    assert_equal text.to, member.canonical_phone_number
+    assert_includes text.body, "5 items due tomorrow"
+    assert_operator text.body.length, :<=, TwilioHelper::SEGMENT_LENGTH, "fits in a single SMS segment"
+  end
+
+  test "skips return reminder if the member has not opted into text reminders" do
+    member = build(:member, reminders_via_text: false)
+    summaries = [:list, :of, :summaries, :due, :tomorrow]
+
+    MemberTexter.new(member).return_reminder(summaries)
+
+    assert_empty TwilioHelper::FakeSMS.messages
+  end
+
+  test "stores a notification record of a successful return reminder" do
+    member = create(:member)
+    summaries = [:list, :of, :summaries, :due, :tomorrow]
+
+    MemberTexter.new(member).return_reminder(summaries)
+
+    notification = Notification.last
+    text = TwilioHelper::FakeSMS.messages.first
+
+    assert_equal text.to, notification.address
+    assert_equal text.body, notification.subject
+    assert_equal member.id, notification.member_id
+    assert_equal "accepted", notification.status
+    assert_equal "return_reminder", notification.action
   end
 end


### PR DESCRIPTION
# What it does

Adds SMS reminder version of our return reminders, which notify members when they have items due tomorrow.

# Why it is important

Hopefully text reminders will help more members return items on time.

# UI Change Screenshot

Text message:

![IMG_CF5373DC01E6-1](https://github.com/chicago-tool-library/circulate/assets/37534/0d839aa7-36fd-4002-a41f-eaa4c20ef2a2)

Notifications report:

![2024-02-13 at 09 10 24@2x](https://github.com/chicago-tool-library/circulate/assets/37534/218520e8-be23-49ed-b1e6-df664431130d)


