### PR TITLE
SMS Hold Available Notifications

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -17,7 +17,7 @@ class ActivityNotifier
     each_member(members_with_overdue_items) do |member, summaries|
       summaries = summaries.overdue_as_of(@now.tomorrow.beginning_of_day)
       MemberMailer.with(member: member, summaries: summaries, now: @now).overdue_notice.deliver
-      if sms_reminders_enabled?
+      if FeatureFlags.sms_reminders_enabled?
         MemberTexter.new(member).overdue_notice(summaries)
       end
     end
@@ -64,9 +64,5 @@ class ActivityNotifier
       Rails.logger.error("Error notifying member #{member.id}: #{e}")
       Appsignal.send_error(e)
     end
-  end
-
-  def sms_reminders_enabled?
-    ENV["FEATURE_SMS_REMINDERS"] == "on"
   end
 end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,0 +1,5 @@
+class FeatureFlags
+  def self.sms_reminders_enabled?
+    ENV["FEATURE_SMS_REMINDERS"] == "on"
+  end
+end

--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -18,6 +18,17 @@ class MemberTexter < BaseTexter
     result
   end
 
+  def hold_available(hold)
+    return unless member.reminders_via_text?
+
+    message = <<~EOM
+      Chicago Tool Library Reminder: Your hold for #{hold.item.complete_number} is available! Schedule a pick-up at #{new_account_appointment_url}
+    EOM
+    result = text(to: @member.canonical_phone_number, body: message)
+    store_notification("hold_available", message, result)
+    result
+  end
+
   def store_notification(action_name, message, result)
     Notification.create!(
       member: member,

--- a/lib/tasks/holds.rake
+++ b/lib/tasks/holds.rake
@@ -4,6 +4,10 @@ namespace :holds do
     Time.use_zone("America/Chicago") do
       Hold.start_waiting_holds do |hold|
         MemberMailer.with(member: hold.member, hold: hold).hold_available.deliver_now
+
+        if FeatureFlags.sms_reminders_enabled?
+          MemberTexter.new(hold.member).hold_available(hold)
+        end
       end
     end
   end

--- a/test/tasks/holds_test.rb
+++ b/test/tasks/holds_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "test_helpers/twilio_helper"
+require "rake"
+
+class HoldsTest < ActiveSupport::TestCase
+  setup do
+    Circulate::Application.load_tasks if Rake::Task.tasks.empty?
+    ActionMailer::Base.deliveries.clear
+    BaseTexter.client = TwilioHelper::FakeSMS.new
+    TwilioHelper::FakeSMS.messages.clear
+  end
+
+  teardown do
+    BaseTexter.client = nil
+  end
+
+  test "notifies members of holds available via email and text" do
+    hold = create(:hold)
+
+    Rake::Task["holds:start_waiting_holds"].invoke
+
+    mails = ActionMailer::Base.deliveries
+    assert_equal 1, mails.count
+
+    mail = mails.first
+    assert_includes mail.to, hold.member.email
+
+    assert_includes mail.subject, "One of your holds is available"
+    assert_includes mail.encoded, hold.item.complete_number
+
+    texts = TwilioHelper::FakeSMS.messages
+    assert_equal 1, texts.count
+
+    text = texts.first
+    assert_includes text.to, hold.member.phone_number
+    assert_includes text.body, "Your hold for #{hold.item.complete_number} is available"
+  end
+end


### PR DESCRIPTION
# What it does

Adds text message notifications when a hold becomes available.

# Why it is important

Hopefully this will help users who might not check email often remember to pick up their holds.

# UI Change Screenshot

(coming soon)

# Implementation notes

* I couldn't find any rake task testing patterns in the app so I wrapped a simple test around the `holds:start_waiting_holds` test using tips from this article: https://josh-works.medium.com/testing-rake-tasks-in-rails-6573f7185a0a 
* This starts to consolidate feature flag lookups into a centralized class. I'll follow up with a pass to update the other places we have feature flags.
* In #1336 I have SMS segment length as a constant, I'll update the magic number in the test to refer to that once that lands
