### PR TITLE
Update spectre to point to fork

### DIFF
--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -1,6 +1,6 @@
 @import 'globals';
 
-@import 'spectre.css/src/mixins/_shadow';
+@import '@spectre-org/spectre-css/src/mixins/_shadow';
 
 .selectize-input {
   box-shadow: none;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,11 +1,11 @@
 @import 'globals';
 
-@import 'spectre.css/src/spectre';
-@import 'spectre.css/src/spectre-icons';
-@import 'spectre.css/src/spectre-exp';
+@import '@spectre-org/spectre-css/src/spectre';
+@import '@spectre-org/spectre-css/src/spectre-icons';
+@import '@spectre-org/spectre-css/src/spectre-exp';
 @import 'trix/dist/trix';
 
-@import 'spectre.css/src/mixins/_shadow';
+@import '@spectre-org/spectre-css/src/mixins/_shadow';
 @import './partials/index';
 
 @import './helpers/layouts_helper';

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@rails/activestorage": "^7.1.3",
     "@rails/ujs": "^7.1.3",
     "@selectize/selectize": "^0.15.2",
+    "@spectre-org/spectre-css": "^1.0.0",
     "awesomplete": "^1.1.4",
     "esbuild": "^0.20.0",
     "feather-icons": "^4.29.1",
@@ -18,18 +19,15 @@
     "mjml": "^4.15.3",
     "sass": "^1.71.0",
     "sortablejs": "^1.15.2",
-    "spectre.css": "^0.5.8",
     "trix": "^2.0.10"
   },
   "version": "0.1.0",
   "devDependencies": {
-    "markdown-toc": "^1.2.0",
-    "sass-migrator": "^2.0.2"
+    "markdown-toc": "^1.2.0"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --minify --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --target=chrome58,firefox57,safari11 --define:process.env.APPSIGNAL_FRONTEND_KEY=\\\"$APPSIGNAL_FRONTEND_KEY\\\"",
     "build-dev": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --target=chrome58,firefox57,safari11  --define:process.env.APPSIGNAL_FRONTEND_KEY=\\\"$APPSIGNAL_FRONTEND_KEY\\\"",
-    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
-    "postinstall": "sass-migrator -d division node_modules/spectre.css/**/*.scss"
+    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,11 @@
   optionalDependencies:
     jquery-ui "^1.13.2"
 
+"@spectre-org/spectre-css@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@spectre-org/spectre-css/-/spectre-css-1.0.0.tgz#914282725936638ff3e081f6ca90137598a92398"
+  integrity sha512-DPPnQzj3qQgmGJFrAlj85fb2kVeC1pWGujTVKNQc2FiAqYfW7D8cPtX3ITgyIbnOGomCRr49jH2sq80kvRdfSw==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1651,11 +1656,6 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-sass-migrator@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/sass-migrator/-/sass-migrator-2.0.2.tgz#e40adb308e7086fd1ef48ee0f6b7e143f2138c86"
-  integrity sha512-+uQjxYL+wuU9nw2IKnZk1hz8MlONp6yQPYb+fJLkekPjMUvNip1Sd2arZdPdhXwVzGFyrGq7AkskQohC2wc1kQ==
-
 sass@^1.71.0:
   version "1.71.0"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.71.0.tgz#b3085759b9b2ab503a977aecb7e91153bf941117"
@@ -1723,11 +1723,6 @@ spark-md5@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
-
-spectre.css@^0.5.8:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/spectre.css/-/spectre.css-0.5.9.tgz#86c732d093036d9fdc0a2ba570f005e4023ae6ca"
-  integrity sha512-9jUqwZmCnvflrxFGcK+ize43TvjwDjqMwZPVubEtSIHzvinH0TBUESm1LcOJx3Ur7bdPaeOHQIjOqBl1Y5kLFw==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
# What it does

The Spectre CSS Framework had stagnated under its original maintainer and some community members forked it to an org, which looks better maintained. https://github.com/spectre-org

# Why it is important

They fixed the sass incompatibilities, so we can drop the sass-migrator workaround.