### PR TITLE
Update some actions to use newer versions of node.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 20
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,11 @@ jobs:
           sudo apt-get install gsfonts
           sudo fc-cache -f -v
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
# What it does

We're getting some warnings because [the use of older versions of Node in actions is deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). This updates a few of the steps to newer versions.