### PR TITLE
Issue 1312 Change loan renewal request routing

### DIFF
--- a/app/controllers/account/renewals_controller.rb
+++ b/app/controllers/account/renewals_controller.rb
@@ -7,7 +7,7 @@ module Account
       authorize @loan, :renew?
 
       renew_loan(@loan)
-      redirect_to account_home_path, success: "#{@loan.item.name} was renewed.", status: :see_other
+      redirect_to account_loans_path, success: "#{@loan.item.name} was renewed.", status: :see_other
     end
   end
 end

--- a/test/controllers/account/renewals_controller_test.rb
+++ b/test/controllers/account/renewals_controller_test.rb
@@ -19,7 +19,7 @@ module Account
       loan = create(:loan, member: @member, item: item)
 
       post account_renewals_url(loan_id: loan)
-      assert_redirected_to account_home_url
+      assert_redirected_to account_loans_url
     end
 
     test "member cannot renew a non-renewable loan" do


### PR DESCRIPTION
# What it does

Addresses [issue 1312!](https://github.com/chicago-tool-library/circulate/issues/1312)

# Why it is important

Makes renewing multiple items more seamless!
Users were being routed back to their account home page instead of back to the renewal page for items that could be renewed without librarian consent (as opposed to renewal requested items that were routing users back to the loans page).
It gives the two types of renewals the same behavior. 

Whether or not they should be ideologically separate is a whole other discussion... :P

# UI Change Screenshot

_If this PR makes a change to the UI put a screenshot here. If you have before and after screenshots please add these._

# Implementation notes

* _Anything notable about the technical approach you took.

* _Any open questions you have about the PR or areas where you'd like specific feedback.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [ ] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [x] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
