### PR TITLE
Update dotenv and use it directly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "mini_magick"
 
 gem "barnes"
 gem "sucker_punch"
-gem "dotenv-rails"
+gem "dotenv"
 gem "appsignal"
 
 gem "chronic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,10 +168,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     domain_name (0.6.20240107)
-    dotenv (2.7.6)
-    dotenv-rails (2.7.6)
-      dotenv (= 2.7.6)
-      railties (>= 3.2)
+    dotenv (3.1.0)
     drb (2.2.1)
     e2mmap (0.1.0)
     erb_lint (0.5.0)
@@ -573,7 +570,7 @@ DEPENDENCIES
   chronic
   cssbundling-rails (~> 1.4)
   devise
-  dotenv-rails
+  dotenv
   erb_lint (~> 0.5.0)
   factory_bot_rails
   http


### PR DESCRIPTION
# What it does

Updates us to dotenv 3, and moves to using that gem directly instead of `dotenv-rails` which is [no longer necessary](https://github.com/bkeepers/dotenv/pull/468).

This effectively the same as #1378, but moves to using `dotenv` as a direct dependency.