### PR TITLE
Remove categories from appointments list

### DIFF
--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -18,24 +18,16 @@
               <div class="column col-12">
                 <h5>Pickup Items</h5>
                 <div class="columns table-header">
-                  <div class="column col-4">Item Name</div>
-                  <div class="column col-4">Item ID</div>
-                  <div class="column col-4">Category</div>
+                  <div class="column col-6">Item Name</div>
+                  <div class="column col-6">Item ID</div>
                 </div>
                 <% appointment.holds.each do |hold| %>
                   <div class="columns">
-                    <div class="column col-4">
+                    <div class="column col-6">
                       <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %>
                     </div>
-                    <div class="column col-4">
+                    <div class="column col-6">
                       <%= hold.item.complete_number %>
-                    </div>
-                    <div class="column col-4">
-                      <% if hold.item.categories.size > 0 %>
-                          <% hold.item.categories.sort_by(&:name).each do |category| %>
-                              <span><%= category.name %></span>
-                          <% end %>
-                      <% end %>
                     </div>
                   </div>
                 <% end %>
@@ -49,24 +41,16 @@
               <div class="column col-12">
                 <h5>Dropoff Items</h5>
                 <div class="columns table-header">
-                  <div class="column col-4">Item Name</div>
-                  <div class="column col-4">Item ID</div>
-                  <div class="column col-4">Category</div>
+                  <div class="column col-6">Item Name</div>
+                  <div class="column col-6">Item ID</div>
                 </div>
                 <% appointment.loans.each do |loan| %>
                   <div class="columns">
-                    <div class="column col-4">
+                    <div class="column col-6">
                       <%= link_to loan.item.name, admin_item_path(loan.item), title: loan.item.complete_number %>
                     </div>
-                    <div class="column col-4">
+                    <div class="column col-6">
                       <%= loan.item.complete_number %>
-                    </div>
-                    <div class="column col-4">
-                      <% if loan.item.categories.size > 0 %>
-                          <% loan.item.categories.sort_by(&:name).each do |category| %>
-                              <span><%= category.name %></span>
-                          <% end %>
-                      <% end %>
                     </div>
                   </div>
                 <% end %>


### PR DESCRIPTION
# What it does

As discussed with librarians in Slack, categories aren't all that useful to have in the appointments list. The categories aren't currently indicative of location and because some of them are long they add a lot of vertical space to the list.

# Why it is important

We're working on making the appointments page more useful to librarians when they prepare orders, and their feedback is important!

# UI Change Screenshot

Before:

![2024-03-15 at 13 26 48@2x](https://github.com/chicago-tool-library/circulate/assets/37534/bacf89a7-cb2a-475f-8e79-59bd7d27307a)

After:

![2024-03-15 at 13 27 02@2x](https://github.com/chicago-tool-library/circulate/assets/37534/af9f0f50-4b4b-4805-9949-47173f6a5b3d)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
