### PR TITLE
Tell Dependabot to do updates in weekly batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,36 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "rails"
+          - "standard"
+          - "standard-rails"
+          - "erb_lint"
+      rails:
+        patterns:
+          - "rails"
+      linters:
+        patterns:
+          - "standard"
+          - "standard-rails"
+          - "erb_lint"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@rails*"
+      rails:
+        patterns:
+          - "@rails*"
+


### PR DESCRIPTION
# What it does

Reconfigure dependabot to run weekly instead of daily, and have it batch updates into a few groups.

# Why it is important

Dependabot has proven to be moderately noisy when running daily, so I think it's worth trying to see if batching feels easier to manage.

# Implementation notes

* There are a lot of tools for deciding what gets batched together. As I start I tried splitting out rails and linter updates from others, but it'll be easy to tweak these as we learn more.
* Notably [dependabot cannot batch updates across package ecosystems yet](https://github.com/dependabot/dependabot-core/issues/8126), so rails upgrades will still likely need to be done manually so we sync the npm and ruby packages.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
