### PR TITLE
Send welcome SMS to users who opt into text reminders

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -129,6 +129,9 @@ class Member < ApplicationRecord
 
   def send_welcome_text
     MemberTexter.new(self).welcome_info
+  rescue RuntimeError => e
+    Rails.logger.error("Error notifying member #{id}: #{e}")
+    Appsignal.send_error(e)
   end
 
   def update_user_email

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -56,6 +56,9 @@ class Member < ApplicationRecord
   before_validation :set_default_address_fields
   before_validation :downcase_email
 
+  after_save :send_welcome_text, if: -> {
+    reminders_via_text? && (saved_change_to_phone_number? || saved_change_to_reminders_via_text?)
+  }
   after_save :update_user_email
   after_update :update_neon_crm, if: :can_update_neon_crm?
 
@@ -123,6 +126,10 @@ class Member < ApplicationRecord
   end
 
   private
+
+  def send_welcome_text
+    MemberTexter.new(self).welcome_info
+  end
 
   def update_user_email
     user.update_column(:email, email) if user && !user.new_record? # Skip validations

--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -7,10 +7,21 @@ class MemberTexter < BaseTexter
     @member = member
   end
 
+  def welcome_info
+    message = <<~EOM.chomp
+      Hello! You will get Chicago Tool Library reminders from this number
+
+      You can turn off text reminders at #{edit_account_member_url}
+    EOM
+    result = text(to: @member.canonical_phone_number, body: message)
+    store_notification("welcome_info", message, result)
+    result
+  end
+
   def overdue_notice(summaries)
     return unless member.reminders_via_text?
 
-    message = <<~EOM
+    message = <<~EOM.chomp
       Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "overdue item")}! Please schedule a return appointment at #{new_account_appointment_url}
     EOM
     result = text(to: @member.canonical_phone_number, body: message)
@@ -21,7 +32,7 @@ class MemberTexter < BaseTexter
   def hold_available(hold)
     return unless member.reminders_via_text?
 
-    message = <<~EOM
+    message = <<~EOM.chomp
       Chicago Tool Library Reminder: Your hold for #{hold.item.complete_number} is available! Schedule a pick-up at #{new_account_appointment_url}
     EOM
     result = text(to: @member.canonical_phone_number, body: message)
@@ -32,7 +43,7 @@ class MemberTexter < BaseTexter
   def return_reminder(summaries)
     return unless member.reminders_via_text?
 
-    message = <<~EOM
+    message = <<~EOM.chomp
       Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "item")} due tomorrow. Review your loans at #{account_loans_url}
     EOM
     result = text(to: @member.canonical_phone_number, body: message)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
     member_attrs = {
       phone_number: "5005550006", pronouns: ["she/her"], id_kind: 0, address_verified: false, desires: "saws, hammers",
       address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Chicago", region: "IL", postal_code: postal_code,
-      reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
+      reminders_via_email: true, reminders_via_text: false, receive_newsletter: true, volunteer_interest: true
     }
 
     admin_member = Member.create!(member_attrs.merge(

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -113,7 +113,7 @@ namespace :devdata do
       address_verified: true,
       number: number,
       reminders_via_email: true,
-      reminders_via_text: true
+      reminders_via_text: false
     )
 
     membership = member.memberships.create!

--- a/test/factories/members.rb
+++ b/test/factories/members.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     address1 { "1 N. Michigan Ave" }
     user
     reminders_via_email { true }
-    reminders_via_text { true }
+    reminders_via_text { false }
 
     trait :with_bio do
       bio { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." }

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -1,6 +1,16 @@
 require "test_helper"
+require "test_helpers/twilio_helper"
 
 class MemberTest < ActiveSupport::TestCase
+  setup do
+    BaseTexter.client = TwilioHelper::FakeSMS.new
+    TwilioHelper::FakeSMS.messages.clear
+  end
+
+  teardown do
+    BaseTexter.client = nil
+  end
+
   test "strips no digits from phone number" do
     member = Member.new(phone_number: "(123) 456-7890")
     member.valid?
@@ -190,5 +200,48 @@ class MemberTest < ActiveSupport::TestCase
     end
 
     assert_mock mock
+  end
+
+  test "sends welcome text when phone number is set or updated" do
+    original_number = "5551234567"
+    member = create(
+      :member,
+      phone_number: original_number,
+      reminders_via_text: true
+    )
+
+    # Create of member sends welcome
+    assert_equal 1, TwilioHelper::FakeSMS.messages.length
+    text = TwilioHelper::FakeSMS.messages.last
+    assert_includes text.to, member.phone_number
+    assert_includes text.body, "Hello!"
+
+    # Update to phone-number re-sends welcome
+    updated_number = "5557654321"
+    member.phone_number = updated_number
+    member.save!
+
+    assert_equal 2, TwilioHelper::FakeSMS.messages.length
+    text = TwilioHelper::FakeSMS.messages.last
+    assert_includes text.to, updated_number
+    assert_includes text.body, "Hello!"
+
+    # Update to non-phone-number does not send another text
+    member.preferred_name = "Ishmael"
+    member.save!
+    assert_equal 2, TwilioHelper::FakeSMS.messages.length
+
+    # Uncheck of reminders_via_text does not send another text
+    member.reminders_via_text = false
+    member.save!
+    assert_equal 2, TwilioHelper::FakeSMS.messages.length
+
+    # Recheck of reminders_via_text does send another text
+    member.reminders_via_text = true
+    member.save!
+    assert_equal 3, TwilioHelper::FakeSMS.messages.length
+    text = TwilioHelper::FakeSMS.messages.last
+    assert_includes text.to, member.phone_number
+    assert_includes text.body, "Hello!"
   end
 end

--- a/test/tasks/holds_test.rb
+++ b/test/tasks/holds_test.rb
@@ -1,17 +1,10 @@
 require "test_helper"
-require "test_helpers/twilio_helper"
 require "rake"
 
 class HoldsTest < ActiveSupport::TestCase
   setup do
     Circulate::Application.load_tasks if Rake::Task.tasks.empty?
     ActionMailer::Base.deliveries.clear
-    BaseTexter.client = TwilioHelper::FakeSMS.new
-    TwilioHelper::FakeSMS.messages.clear
-  end
-
-  teardown do
-    BaseTexter.client = nil
   end
 
   test "notifies members of holds available via email and text" do
@@ -28,10 +21,7 @@ class HoldsTest < ActiveSupport::TestCase
     assert_includes mail.subject, "One of your holds is available"
     assert_includes mail.encoded, hold.item.complete_number
 
-    texts = TwilioHelper::FakeSMS.messages
-    assert_equal 1, texts.count
-
-    text = texts.first
+    text = TwilioHelper::FakeSMS.messages.last
     assert_includes text.to, hold.member.phone_number
     assert_includes text.body, "Your hold for #{hold.item.complete_number} is available"
   end

--- a/test/tasks/holds_test.rb
+++ b/test/tasks/holds_test.rb
@@ -8,7 +8,7 @@ class HoldsTest < ActiveSupport::TestCase
   end
 
   test "notifies members of holds available via email and text" do
-    hold = create(:hold)
+    hold = create(:hold, member: create(:verified_member, reminders_via_text: true))
 
     Rake::Task["holds:start_waiting_holds"].invoke
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "minitest/mock"
 
 require "helpers/return_values"
 require "helpers/ensure_request_tenant"
+require "test_helpers/twilio_helper"
 
 # Explicit require means the plugin is available when tests are evaluated;
 # otherwise, the plugin isn't loaded until later.
@@ -27,10 +28,15 @@ class ActiveSupport::TestCase
 
   setup do
     ActsAsTenant.test_tenant = libraries(:chicago_tool_library)
+
+    BaseTexter.client = TwilioHelper::FakeSMS.new
+    TwilioHelper::FakeSMS.messages.clear
   end
 
   teardown do
     ActsAsTenant.test_tenant = nil
+
+    BaseTexter.client = nil
   end
 end
 

--- a/test/texters/member_texter_test.rb
+++ b/test/texters/member_texter_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class MemberTexterTest < ActionMailer::TestCase
   test "sends an overdue notice to the member" do
-    member = create(:member)
+    member = create(:verified_member, reminders_via_text: true)
     summaries = [:list, :of, :overdue, :summaries]
 
     MemberTexter.new(member).overdue_notice(summaries)
@@ -15,7 +15,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "skips overdue notice if the member has not opted into text reminders" do
-    member = build(:member, reminders_via_text: false)
+    member = build(:verified_member, reminders_via_text: false)
     summaries = [:list, :of, :overdue, :summaries]
 
     MemberTexter.new(member).overdue_notice(summaries)
@@ -24,7 +24,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "stores a notification record of a successful overdue notice" do
-    member = create(:member)
+    member = create(:verified_member, reminders_via_text: true)
     summaries = [:list, :of, :overdue, :summaries]
 
     MemberTexter.new(member).overdue_notice(summaries)
@@ -40,7 +40,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "sends a return reminder to the member" do
-    member = create(:member)
+    member = create(:verified_member, reminders_via_text: true)
     summaries = [:list, :of, :summaries, :due, :tomorrow]
 
     MemberTexter.new(member).return_reminder(summaries)
@@ -53,7 +53,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "skips return reminder if the member has not opted into text reminders" do
-    member = build(:member, reminders_via_text: false)
+    member = build(:verified_member, reminders_via_text: false)
     summaries = [:list, :of, :summaries, :due, :tomorrow]
 
     TwilioHelper::FakeSMS.messages.clear
@@ -64,7 +64,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "stores a notification record of a successful return reminder" do
-    member = create(:member)
+    member = create(:verified_member, reminders_via_text: true)
     summaries = [:list, :of, :summaries, :due, :tomorrow]
 
     MemberTexter.new(member).return_reminder(summaries)
@@ -80,8 +80,8 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "sends a hold available message to the member" do
-    member = create(:member)
-    hold = create(:hold)
+    member = create(:verified_member, reminders_via_text: true)
+    hold = create(:hold, member: member)
 
     MemberTexter.new(member).hold_available(hold)
 
@@ -93,7 +93,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "skips hold available message if the member has not opted into text reminders" do
-    member = create(:member, reminders_via_text: false)
+    member = create(:verified_member, reminders_via_text: false)
     hold = create(:hold)
 
     TwilioHelper::FakeSMS.messages.clear
@@ -104,8 +104,8 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "stores a notification record of the hold available message" do
-    member = create(:member)
-    hold = create(:hold)
+    member = create(:verified_member, reminders_via_text: true)
+    hold = create(:hold, member: member)
 
     MemberTexter.new(member).hold_available(hold)
 
@@ -120,7 +120,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "sends a welcome message to the member" do
-    member = build(:member)
+    member = build(:verified_member, reminders_via_text: true)
 
     MemberTexter.new(member).welcome_info
 
@@ -132,7 +132,7 @@ class MemberTexterTest < ActionMailer::TestCase
   end
 
   test "stores a notification record of the welcome message" do
-    member = create(:member)
+    member = create(:verified_member, reminders_via_text: true)
 
     MemberTexter.new(member).welcome_info
 


### PR DESCRIPTION
# What it does

Members get an initial welcome message from the system when they have opted into text reminders for the first time and when they update their phone number.

# Why it is important

This should help inform users about what number future reminders will come from and also how to opt-out if they didn't mean to get them.

# UI Change Screenshot

![2024-03-15 at 14 45 44@2x](https://github.com/chicago-tool-library/circulate/assets/37534/6ba84e31-7ca9-4fe6-b417-9601f6680fc4)

# Implementation notes

* I noticed all our SMS body strings were ending in a newline, so I fixed that and added tests to verify we don't do it in the future. I believe Twilio was stripping these out but I figure it's safer for us to do so ourselves.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
