### PR TITLE
Clean up member listing status column

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -160,7 +160,7 @@ header.navbar {
   display: grid;
   grid-row-gap: .5rem;
   grid-column-gap: .3rem;
-  grid-template-columns: .3fr 1fr 1fr 1fr 1fr .5fr .5fr;
+  grid-template-columns: .5fr 2fr 4fr 2fr 2.5fr .5fr .5fr;
 
   .members-table-header {
     font-weight: bold;

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -122,6 +122,18 @@ class Member < ApplicationRecord
     "+1#{phone_number}"
   end
 
+  def membership_status
+    if active_membership
+      "active"
+    elsif pending_membership
+      "pending"
+    elsif last_membership
+      "ended"
+    else
+      "no membership"
+    end
+  end
+
   private
 
   def update_user_email

--- a/app/views/admin/members/_members.html.erb
+++ b/app/views/admin/members/_members.html.erb
@@ -3,7 +3,7 @@
   <%= tag.div "Name", class: "members-table-name members-table-header" %>
   <%= tag.div "Email", class: "members-table-email members-table-header" %>
   <%= tag.div "Phone", class: "members-table-phone members-table-header" %>
-  <%= tag.div "Status", class: "members-table-status members-table-header" %>
+  <%= tag.div "Membership Status", class: "members-table-status members-table-header" %>
   <%= tag.div "Loans", class: "members-table-number members-table-header" %>
   <%= tag.div "Holds", class: "members-table-number members-table-header" %>
 
@@ -15,11 +15,7 @@
     <%= tag.div member.email, class: "members-table-email" %>
     <%= tag.div format_phone_number(member.phone_number), class: "members-table-phone" %>
     <%= tag.div class: "members-table-status" do %>
-      <% if member.active_membership %>
-        <span class="chip">membership</span>
-      <% elsif member.last_membership %>
-        <span class="chip">ended</span>
-      <% end %>
+      <span class="chip"><%= member.membership_status %></span>
       <% if member.status_verified? %>
         <span class="chip">verified</span>
       <% end %>

--- a/db/migrate/20240314004211_scope_member_number_uniqueness_to_library.rb
+++ b/db/migrate/20240314004211_scope_member_number_uniqueness_to_library.rb
@@ -1,0 +1,7 @@
+class ScopeMemberNumberUniquenessToLibrary < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :members, :number, unique: true
+    remove_index :members, [:number, :library_id]
+    add_index :members, [:library_id, :number], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_03_164619) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_14_004211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -452,9 +452,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_03_164619) do
     t.text "pronouns", default: [], array: true
     t.integer "library_id"
     t.string "pronunciation"
+    t.index ["library_id", "number"], name: "index_members_on_library_id_and_number", unique: true
     t.index ["library_id"], name: "index_members_on_library_id"
-    t.index ["number", "library_id"], name: "index_members_on_number_and_library_id"
-    t.index ["number"], name: "index_members_on_number", unique: true
   end
 
   create_table "memberships", force: :cascade do |t|


### PR DESCRIPTION
# What it does

Two things, somewhat related:

* Revises how the membership status is displayed in the member list. As of right now it shows some nonsensical things for new members in certain states (see #1345).
* Fixes the member number uniqueness constraint to be scoped to libraries. It's not currently, which means that some of the members created by dev data are broken and can't be verified or have memberships started. This isn't an issue in production, but we may as well fix it.

# UI Change Screenshot

This is the right three columns for the same set of members on the admin member listing.

Before:
<img width="335" alt="Screenshot 2024-03-18 at 11 25 21 PM" src="https://github.com/chicago-tool-library/circulate/assets/3331/730b74dd-7c13-48dd-b95e-974f486dc9bf">

After:
<img width="312" alt="Screenshot 2024-03-18 at 11 25 14 PM" src="https://github.com/chicago-tool-library/circulate/assets/3331/790ce749-eace-4b76-8388-dacd50cedb22">

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.