### PR TITLE
Add missing feature flag guard on welcome text

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -17,9 +17,7 @@ class ActivityNotifier
     each_member(members_with_overdue_items) do |member, summaries|
       summaries = summaries.overdue_as_of(@now.tomorrow.beginning_of_day)
       MemberMailer.with(member: member, summaries: summaries, now: @now).overdue_notice.deliver
-      if FeatureFlags.sms_reminders_enabled?
-        MemberTexter.new(member).overdue_notice(summaries)
-      end
+      MemberTexter.new(member).overdue_notice(summaries)
     end
   end
 
@@ -29,10 +27,8 @@ class ActivityNotifier
 
     each_member(members_with_items_due_tomorrow) do |member, summaries|
       MemberMailer.with(member: member, summaries: summaries, now: @now).return_reminder.deliver
-      if FeatureFlags.sms_reminders_enabled?
-        due_tomorrow_summaries = summaries.checked_out.due_on(tomorrow)
-        MemberTexter.new(member).return_reminder(due_tomorrow_summaries)
-      end
+      due_tomorrow_summaries = summaries.checked_out.due_on(tomorrow)
+      MemberTexter.new(member).return_reminder(due_tomorrow_summaries)
     end
   end
 

--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -8,6 +8,8 @@ class MemberTexter < BaseTexter
   end
 
   def welcome_info
+    return unless member.reminders_via_text?
+
     message = <<~EOM.chomp
       Hello! You will get Chicago Tool Library reminders from this number
 

--- a/app/texters/member_texter.rb
+++ b/app/texters/member_texter.rb
@@ -8,7 +8,7 @@ class MemberTexter < BaseTexter
   end
 
   def welcome_info
-    return unless member.reminders_via_text?
+    return unless should_text?
 
     message = <<~EOM.chomp
       Hello! You will get Chicago Tool Library reminders from this number
@@ -21,7 +21,7 @@ class MemberTexter < BaseTexter
   end
 
   def overdue_notice(summaries)
-    return unless member.reminders_via_text?
+    return unless should_text?
 
     message = <<~EOM.chomp
       Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "overdue item")}! Please schedule a return appointment at #{new_account_appointment_url}
@@ -32,7 +32,7 @@ class MemberTexter < BaseTexter
   end
 
   def hold_available(hold)
-    return unless member.reminders_via_text?
+    return unless should_text?
 
     message = <<~EOM.chomp
       Chicago Tool Library Reminder: Your hold for #{hold.item.complete_number} is available! Schedule a pick-up at #{new_account_appointment_url}
@@ -43,7 +43,7 @@ class MemberTexter < BaseTexter
   end
 
   def return_reminder(summaries)
-    return unless member.reminders_via_text?
+    return unless should_text?
 
     message = <<~EOM.chomp
       Chicago Tool Library Reminder: You have #{pluralize(summaries.length, "item")} due tomorrow. Review your loans at #{account_loans_url}
@@ -52,6 +52,8 @@ class MemberTexter < BaseTexter
     store_notification("return_reminder", message, result)
     result
   end
+
+  private
 
   def store_notification(action_name, message, result)
     Notification.create!(
@@ -63,5 +65,9 @@ class MemberTexter < BaseTexter
       status: result.status,
       library: member.library
     )
+  end
+
+  def should_text?
+    FeatureFlags.sms_reminders_enabled? && member.reminders_via_text?
   end
 end

--- a/lib/tasks/holds.rake
+++ b/lib/tasks/holds.rake
@@ -4,10 +4,7 @@ namespace :holds do
     Time.use_zone("America/Chicago") do
       Hold.start_waiting_holds do |hold|
         MemberMailer.with(member: hold.member, hold: hold).hold_available.deliver_now
-
-        if FeatureFlags.sms_reminders_enabled?
-          MemberTexter.new(hold.member).hold_available(hold)
-        end
+        MemberTexter.new(hold.member).hold_available(hold)
       end
     end
   end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -235,6 +235,13 @@ class MemberTest < ActiveSupport::TestCase
     assert_includes text.body, "Hello!"
   end
 
+  test "welcome text is skipped if feature flag is off" do
+    FeatureFlags.stub :sms_reminders_enabled?, false do
+      create(:member, reminders_via_text: true)
+      assert_equal 0, TwilioHelper::FakeSMS.messages.length
+    end
+  end
+
   test "welcome text does not explode if it fails" do
     error = RuntimeError.new("oh no")
     Spy.on(MemberTexter, :new).and_raise(error)

--- a/test/texters/member_texter_test.rb
+++ b/test/texters/member_texter_test.rb
@@ -131,6 +131,14 @@ class MemberTexterTest < ActionMailer::TestCase
     assert_operator text.body.length, :<=, TwilioHelper::SEGMENT_LENGTH, "fits in a single SMS segment"
   end
 
+  test "skips welcome message if member has not opted in" do
+    member = build(:verified_member, reminders_via_text: false)
+
+    MemberTexter.new(member).welcome_info
+
+    assert_equal 0, TwilioHelper::FakeSMS.messages.length, "no text was sent"
+  end
+
   test "stores a notification record of the welcome message" do
     member = create(:verified_member, reminders_via_text: true)
 


### PR DESCRIPTION
# What it does

Fixes member creation when text reminder feature flag is off.

# Why it is important

It's broken now!