### PR TITLE
Fix error guarding in text message code

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -60,7 +60,7 @@ class ActivityNotifier
         .or(member.loan_summaries.includes(:renewal_requests).checked_out)
         .includes(item: :borrow_policy)
       yield member, summaries
-    rescue RuntimeError => e
+    rescue => e
       Rails.logger.error("Error notifying member #{member.id}: #{e}")
       Appsignal.send_error(e)
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -141,7 +141,7 @@ class Member < ApplicationRecord
 
   def send_welcome_text
     MemberTexter.new(self).welcome_info
-  rescue RuntimeError => e
+  rescue => e
     Rails.logger.error("Error notifying member #{id}: #{e}")
     Appsignal.send_error(e)
   end

--- a/test/lib/activity_notifier_test.rb
+++ b/test/lib/activity_notifier_test.rb
@@ -213,7 +213,7 @@ class ActivityNotifierTest < ActiveSupport::TestCase
       3.times { create(:loan, member: create(:verified_member, reminders_via_text: true), due_at: Time.current.end_of_day, created_at: 1.week.ago) }
 
       # Make MemberTexter.new explode one time then work
-      error = RuntimeError.new("oh no")
+      error = Twilio::REST::TwilioError.new
       orig_method = MemberTexter.method(:new)
       call_count = 0
       explode_once = ->(member) {


### PR DESCRIPTION
# What it does

Turns out rescuing from RuntimeError is _not_ what you want to do, since TwilioErrors all descent from StandardError but not RuntimeError. Whoops!

# Why it is important

This should prevent any future errors from Twilio from stopping the notification train.

# Implementation notes

* Note that standardrb wants us to omit the error class entirely when rescuing from StandardError, as the bare `rescue` is equivalent to that.