### PR TITLE
Updating renewal requests to default to requested

### DIFF
--- a/app/controllers/admin/renewal_requests_controller.rb
+++ b/app/controllers/admin/renewal_requests_controller.rb
@@ -36,7 +36,7 @@ module Admin
     def index_filter
       allowed = %w[all requested rejected]
       return params[:filter] if allowed.include? params[:filter]
-      "all"
+      "requested"
     end
 
     def renewal_request_params

--- a/app/controllers/admin/renewal_requests_controller.rb
+++ b/app/controllers/admin/renewal_requests_controller.rb
@@ -34,7 +34,7 @@ module Admin
     private
 
     def index_filter
-      allowed = %w[all requested rejected]
+      allowed = %w[requested rejected all]
       return params[:filter] if allowed.include? params[:filter]
       "requested"
     end

--- a/app/views/admin/renewal_requests/index.html.erb
+++ b/app/views/admin/renewal_requests/index.html.erb
@@ -7,14 +7,14 @@
     <div class="items-summary">
       Viewing
       <div class="btn-group">
-        <%= link_to_unless params[:filter] == "all" || params[:filter].blank?, "all", {}, class: "btn btn-sm" do %>
-          <button class="btn btn-sm active">all</button>
-        <% end %>
-        <%= link_to_unless_current "requested", {filter: "requested"}, class: "btn btn-sm" do %>
+        <%= link_to_unless params[:filter] == "requested" || params[:filter].blank?, "requested", {}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">requested</button>
         <% end %>
         <%= link_to_unless_current "rejected", {filter: "rejected"}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">rejected</button>
+        <% end %>
+        <%= link_to_unless_current "all", {filter: "all"}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">all</button>
         <% end %>
       </div>
     </div>

--- a/test/system/admin/renewal_requests_test.rb
+++ b/test/system/admin/renewal_requests_test.rb
@@ -23,9 +23,8 @@ class AdminRenewalRequestsTest < ApplicationSystemTestCase
     perform_enqueued_jobs do
       click_on "Renew"
 
-      within ".table" do
-        assert_text "approved, due"
-        refute_text "Renew"
+      within ".empty" do
+        assert_text "No matching renewal requests"
       end
     end
 
@@ -41,9 +40,8 @@ class AdminRenewalRequestsTest < ApplicationSystemTestCase
     perform_enqueued_jobs do
       click_on "Reject"
 
-      within ".table" do
-        assert_text "rejected"
-        refute_text "Reject"
+      within ".empty" do
+        assert_text "No matching renewal requests"
       end
     end
 


### PR DESCRIPTION
# What it does

Updates the admin renewal request page to default to "requested" renewals instead of "all" renewals

# Why it is important

The user experience for approving loan renewals was tedious requiring extra clicks and scrolling.

# UI Change Screenshot

Before:
![image](https://github.com/chicago-tool-library/circulate/assets/2738059/1f073e76-00e4-43e1-bb1e-bff9749e038f)

After (default view):
![image](https://github.com/chicago-tool-library/circulate/assets/2738059/7ea6ac7d-9087-4802-8857-892030a3b189)

# Implementation notes

None

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
