### PR TITLE
Handle Twilio message status callbacks

### DIFF
--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -1,0 +1,11 @@
+class TwilioController < ApplicationController
+  # Handle callbacks from Twilio with message status
+  # Per docs at https://www.twilio.com/docs/messaging/guides/track-outbound-message-status
+  def callback
+    notification = Notification.find_by_uuid!(params[:MessageSid])
+    notification.status = params[:MessageStatus]
+    notification.save!
+
+    head :ok
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -149,4 +149,8 @@ Rails.application.configure do
     config.action_mailer.preview_path = Rails.root.join("test/mailers/previews")
     config.action_mailer.show_previews = true
   end
+
+  # Verify Twilio callbacks
+  # Per recommendations at https://www.twilio.com/docs/usage/webhooks/webhooks-security#validating-signatures-from-twilio
+  config.middleware.use Rack::TwilioWebhookAuthentication, ENV["TWILIO_AUTH_TOKEN"], "/twilio/callback"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,8 @@ Rails.application.routes.draw do
   resources :documents, only: :show
   resources :homepage, only: [:index, :create]
 
+  post "/twilio/callback", to: "twilio#callback"
+
   root to: "home#index"
 
   if Rails.env.test?

--- a/test/controllers/twilio_controller_test.rb
+++ b/test/controllers/twilio_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class TwilioControllerTest < ActionDispatch::IntegrationTest
+  test "updates notification status" do
+    notification = create(:notification)
+    post twilio_callback_url, params: {MessageSid: notification.uuid, MessageStatus: "delivered"}
+    assert_equal notification.reload.status, "delivered"
+  end
+end


### PR DESCRIPTION
# What it does

Implement a Delivery Status Callback for Twilio per their docs at https://www.twilio.com/docs/messaging/guides/track-outbound-message-status

# Why it is important

This makes our Notifications records have more up-to-date statuses so we can tell if a text message was actually delivered or not without having to dig through the Twilio console.

# Implementation notes

* There's a middleware that performs [webhook signature validation](https://www.twilio.com/docs/usage/webhooks/webhooks-security#validating-signatures-from-twilio) so that random traffic can't hit the webhook.
* This is a basic implementation that doesn't account for messages arriving out of order or being missed. Twilio [recommends for production grade applications](https://www.twilio.com/docs/messaging/guides/outbound-message-logging#recommendations-for-maintaining-messaging-records) you also implement a daily reconciliation job to account for missed messages. Text messages are not mission critical for us, so I think this is fine as an incremental next step.
* I wish there were a better way to test the webhook for real, but since we only have one number there's only one place to specify the callback. The good news is that it's pretty harmless if it doesn't work.