### PR TITLE
Specify node/yarn version where heroku buildpack will find them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-engines
 
       - run: bin/rails assets:precompile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: "package.json"
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install --frozen-lockfile --ignore-engines
+      - run: yarn install --frozen-lockfile
 
       - run: bin/rails assets:precompile
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,12 @@
           mkShell {
             buildInputs = [
               ruby
-              nodejs
-              yarn
+              nodejs_20
               foreman
+
+              # Remove built-in node from yarn package so it picks up pinned
+              # node v20 above
+              (yarn.override { nodejs = nodejs_20; })
 
               # needed to build pg gem, even though we'll run the db from Docker
               postgresql_15

--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
           mkShell {
             buildInputs = [
               ruby
-              nodejs_20
               foreman
+              nodejs_20
 
-              # Remove built-in node from yarn package so it picks up pinned
-              # node v20 above
+              # Make sure yarn uses the version-specific node package specified
+              # above
               (yarn.override { nodejs = nodejs_20; })
 
               # needed to build pg gem, even though we'll run the db from Docker

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "circulate",
   "private": true,
   "engines": {
-    "node": "20.6.1",
-    "yarn": "1.22.4"
+    "node": "20.x",
+    "yarn": "1.22.x"
   },
   "dependencies": {
     "@appsignal/javascript": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "circulate",
   "private": true,
+  "engines": {
+    "node": "20.6.1",
+    "yarn": "1.22.4"
+  },
   "dependencies": {
     "@appsignal/javascript": "^1.3.28",
     "@appsignal/stimulus": "^1.0.18",

--- a/test/lib/version_consistency_test.rb
+++ b/test/lib/version_consistency_test.rb
@@ -14,8 +14,8 @@ class VersionConsistencyTest < ActiveSupport::TestCase
     tool_versions = parse_tool_versions
     package_json = JSON.parse(File.read(Rails.root.join("package.json")))
 
-    assert_equal tool_versions["yarn"], package_json["engines"]["yarn"]
-    assert_equal tool_versions["nodejs"], package_json["engines"]["node"]
+    assert_equal tool_versions["yarn"].split(".").take(2), package_json["engines"]["yarn"].split(".").take(2), "major and minor yarn version match"
+    assert_equal tool_versions["nodejs"].split(".").take(1), package_json["engines"]["node"].split(".").take(1), "major node version matches"
   end
 
   # Heroku buildpack reads from Gemfile

--- a/test/lib/version_consistency_test.rb
+++ b/test/lib/version_consistency_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class VersionConsistencyTest < ActiveSupport::TestCase
+  def parse_tool_versions
+    File.readlines(Rails.root.join(".tool-versions")).each_with_object({}) do |line, h|
+      tool, version = line.split(" ")
+      h[tool] = version
+      h
+    end
+  end
+  # Heroku buildpack reads from package.json
+  # asdf reads from .tool-versions
+  test "node and yarn versions match between package.json and .tool-versions" do
+    tool_versions = parse_tool_versions
+    package_json = JSON.parse(File.read(Rails.root.join("package.json")))
+
+    assert_equal tool_versions["yarn"], package_json["engines"]["yarn"]
+    assert_equal tool_versions["nodejs"], package_json["engines"]["node"]
+  end
+
+  # Heroku buildpack reads from Gemfile
+  # asdf reads from .tool-versions
+  # nix reads from .ruby-version
+  test "ruby version matches between Gemfile, .ruby-version, and .tool-versions" do
+    tool_versions = parse_tool_versions
+    gemfile_version = Bundler::Definition.build("Gemfile", nil, {}).ruby_version.versions.first
+    ruby_version_file_version = File.read(Rails.root.join(".ruby-version")).split("-").last.chomp
+
+    assert_equal tool_versions["ruby"], ruby_version_file_version
+    assert_equal tool_versions["ruby"], gemfile_version
+  end
+end


### PR DESCRIPTION
# What it does

As a part of #1185 we need to tell the nodejs buildpack which version of node to deploy. To do this we follow [the heroku docs](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version) and add to package.json.

Added a few unit tests to help us remember to keep versions consistent in the various config files.

# Why it is important

Per #1185 this gets us in line with Heroku's recommendations and quells a big warning in the logs every time we deploy.