### PR TITLE
Update production data scrubbing tasks to be more thorough.

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -2,7 +2,7 @@ class Loan < ApplicationRecord
   belongs_to :item, optional: true
   belongs_to :member
   has_one :adjustment, as: :adjustable
-  has_many :renewals, class_name: "Loan", foreign_key: "initial_loan_id"
+  has_many :renewals, class_name: "Loan", foreign_key: "initial_loan_id", dependent: :destroy
   has_many :renewal_requests, dependent: :destroy
   belongs_to :initial_loan, class_name: "Loan", optional: true
   has_one :hold, dependent: :nullify

--- a/lib/tasks/production.rake
+++ b/lib/tasks/production.rake
@@ -90,7 +90,7 @@ def scrub_data
   SQL
 
   # There are some members in the database without associated users that the above query doesn't update.
-  Member.left_joins(:user).where(user: { id: nil }).each { |m| m.destroy }
+  Member.left_joins(:user).where(user: {id: nil}).each { |m| m.destroy }
 
   User.connection.execute(<<~SQL)
     UPDATE users
@@ -106,7 +106,6 @@ def scrub_data
   SQL
 
   Adjustment.where.not(square_transaction_id: nil).update_all(square_transaction_id: "sqtrxnid")
-
 end
 
 namespace :staging do

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class MemberTest < ActiveSupport::TestCase
+  include Lending
+
   test "strips no digits from phone number" do
     member = Member.new(phone_number: "(123) 456-7890")
     member.valid?
@@ -253,5 +255,11 @@ class MemberTest < ActiveSupport::TestCase
     )
 
     assert appsignal_spy.has_been_called_with?(error)
+  end
+
+  test "can destroy member with renewals" do
+    loan = create(:overdue_loan)
+    renew_loan(loan)
+    loan.member.destroy
   end
 end


### PR DESCRIPTION
# What it does

Fixes some issues with the production data scrubbing:

* There were some changes needed to accommodate changes to how ActiveStorage handles variants.
* More instances of personal information are cleared out or deleted.
* Some rough edges in the import process have been addressed so that importing production data is less likely to leak PG extensions, etc. into your local environment.

- [x] I have the time and interest to make additional changes to this PR based on feedback.