### PR TITLE
Fix CSRF error when reordering holds

### DIFF
--- a/app/javascript/lib/request.js
+++ b/app/javascript/lib/request.js
@@ -8,7 +8,7 @@ export function turboFetch(url, method, body) {
     );
 
     if (token) {
-        headers['X-CSRF-Token'] = token.textContent;
+        headers['X-CSRF-Token'] = token.getAttribute("content");
     }
 
     return fetch(url, {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,9 +32,6 @@ Rails.application.configure do
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
-
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -89,6 +89,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   setup do
     ActsAsTenant.test_tenant = libraries(:chicago_tool_library)
+    # System tests submit real forms so we can exercise CSRF protection
+    ActionController::Base.allow_forgery_protection = true
   end
 
   include Warden::Test::Helpers
@@ -102,6 +104,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   teardown do
     ActsAsTenant.test_tenant = nil
+    ActionController::Base.allow_forgery_protection = false
 
     errors = page.driver.browser.logs.get(:browser)
     fail = false


### PR DESCRIPTION
# What it does

Fixes #1427

# Implementation notes

There was a small bug in getting the right token content from the meta tag that tests didn't catch because they have CSRF protection off. Turning on CSRF protection in system tests catches this bug and should hopefully prevent future ones too.