### PR TITLE
Fix hold member links on iPhones

### DIFF
--- a/app/javascript/controllers/hold_order_controller.js
+++ b/app/javascript/controllers/hold_order_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
     },
       chosenClass: "sorting",
       ghostClass: "ghost",
+      preventOnFilter: false, // we still want links and inputs to work on non-reorderable rows
     })
 
     setupFeatherIcons();


### PR DESCRIPTION
# What it does

Fixes #1435

# Why it is important

People using iPhones to browse holds can't click the notified user.

# Implementation notes

* I can't imagine how we'd set up an automated test for this since it only happens on iPhones, but I manually tested it in an iPhone simulator and it seems to fix the issue.