### PR TITLE
Add message when renewal is not available for an item

### DIFF
--- a/app/controllers/admin/bulk_renewals_controller.rb
+++ b/app/controllers/admin/bulk_renewals_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def update
       @member.loans.checked_out.each do |loan|
-        renew_loan(loan) if loan.renewable?
+        renew_loan(loan) if loan.within_renewal_limit?
       end
 
       redirect_to admin_member_url(@member.id), status: :see_other

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -84,19 +84,18 @@ class Loan < ApplicationRecord
   end
 
   # Will another renewal exceed the maximum number of renewals?
-  # TODO rename this within_renewal_limit?
-  def renewable?
+  def within_renewal_limit?
     renewal_count < item.borrow_policy.renewal_limit
   end
 
   # Can a member renew this loan themselves without approval?
   def member_renewable?
-    renewable? && item.borrow_policy.member_renewable? && ended_at.nil?
+    within_renewal_limit? && item.borrow_policy.member_renewable? && ended_at.nil?
   end
 
   # Can a member request this loan be renewed?
   def member_renewal_requestable?
-    renewable? && ended_at.nil? && !any_active_holds? && !renewal_requests.any?
+    within_renewal_limit? && ended_at.nil? && !any_active_holds? && !renewal_requests.any?
   end
 
   # Does the item have any active holds?

--- a/app/policies/loan_policy.rb
+++ b/app/policies/loan_policy.rb
@@ -36,7 +36,7 @@ class LoanPolicy
 
   def renew?
     if user.admin?
-      loan.renewable?
+      loan.within_renewal_limit?
     else
       user.member == loan.member && loan.member_renewable?
     end

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -49,6 +49,8 @@
                   <span class="message">You can renew this loan without librarian approval if you need it for more time.</span> <%= button_to "Renew Loan", account_renewals_path(loan_id: loan), method: :post, class: "btn" %>
                 <% elsif loan.member_renewal_requestable? %>
                   <span class="message">If you need more time, you can request a renewal but we may not be able to grant it due to demand.</span> <%= button_to "Request Loan Renewal", account_renewal_requests_path(loan_id: loan), method: :post, class: "btn" %>
+                <% else %>
+                  <span class="message">Renewal unavailable for this item.</span>
                 <% end %>
               </div>
             </li>

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -41,7 +41,7 @@
               <div class="actions">
                 <% if loan.renewal_requests.any? %>
                   <% if loan.latest_renewal_request.rejected? %>
-                    Renewal denied! There are others waiting to borrow this tool.
+                    Renewal unavailable. Please return this item soon.
                   <% else %>
                     Renewal requested
                   <% end %>
@@ -50,9 +50,9 @@
                 <% elsif loan.member_renewal_requestable? %>
                   <span class="message">If you need more time, you can request a renewal but we may not be able to grant it due to demand.</span> <%= button_to "Request Loan Renewal", account_renewal_requests_path(loan_id: loan), method: :post, class: "btn" %>
                 <% elsif loan.any_active_holds? %>
-                  <span class="message">This loan cannot be renewed because it's on hold by another member.</span>
+                  <span class="message">Renewal unavailable. Another borrower is waiting on this item.</span>
                 <% elsif !loan.within_renewal_limit? %>
-                  <span class="message">This loan cannot be renewed because our policy limits it to <%= loan.item.borrow_policy.renewal_limit %> renewals.</span>
+                  <span class="message">No renewals remaining. This item is limited to <%= loan.item.borrow_policy.renewal_limit %> renewals.</span>
                 <% else %>
                   <span class="message">This loan cannot be renewed.</span>
                 <% end %>

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -51,7 +51,7 @@
                   <span class="message">If you need more time, you can request a renewal but we may not be able to grant it due to demand.</span> <%= button_to "Request Loan Renewal", account_renewal_requests_path(loan_id: loan), method: :post, class: "btn" %>
                 <% elsif loan.any_active_holds? %>
                   <span class="message">This loan cannot be renewed because it's on hold by another member.</span>
-                <% elsif !loan.renewable? %>
+                <% elsif !loan.within_renewal_limit? %>
                   <span class="message">This loan cannot be renewed because our policy limits it to <%= loan.item.borrow_policy.renewal_limit %> renewals.</span>
                 <% else %>
                   <span class="message">This loan cannot be renewed.</span>

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -49,8 +49,12 @@
                   <span class="message">You can renew this loan without librarian approval if you need it for more time.</span> <%= button_to "Renew Loan", account_renewals_path(loan_id: loan), method: :post, class: "btn" %>
                 <% elsif loan.member_renewal_requestable? %>
                   <span class="message">If you need more time, you can request a renewal but we may not be able to grant it due to demand.</span> <%= button_to "Request Loan Renewal", account_renewal_requests_path(loan_id: loan), method: :post, class: "btn" %>
+                <% elsif loan.any_active_holds? %>
+                  <span class="message">This loan cannot be renewed because it's on hold by another member.</span>
+                <% elsif !loan.renewable? %>
+                  <span class="message">This loan cannot be renewed because our policy limits it to <%= loan.item.borrow_policy.renewal_limit %> renewals.</span>
                 <% else %>
-                  <span class="message">Renewal unavailable for this item.</span>
+                  <span class="message">This loan cannot be renewed.</span>
                 <% end %>
               </div>
             </li>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -90,13 +90,13 @@
               <%= button_to [:admin, summary.latest_loan], params: {loan: {ended: 1}}, method: :patch, class: "btn btn-primary mb-2", remote: true do %>
                 <%= feather_icon "download" %>Return
               <% end %>
-              <%= renewal_tooltop summary.latest_loan.renewable?, summary.item.borrow_policy.renewal_limit do %>
+              <%= renewal_tooltop summary.latest_loan.within_renewal_limit?, summary.item.borrow_policy.renewal_limit do %>
                 <% renew_button_data = if summary.latest_loan.any_active_holds?
                       {turbo_confirm: "This item is on hold by other members and should only be renewed under special circumstances. Click OK to renew the item, or Cancel to go back."}
                    else
                       {}
                    end %>
-                <%= button_to admin_renewals_path(loan_id: summary.latest_loan), method: :post, class: "btn ml-2 mb-2", disabled: !summary.latest_loan.renewable?, remote: true, data: renew_button_data do %>
+                <%= button_to admin_renewals_path(loan_id: summary.latest_loan), method: :post, class: "btn ml-2 mb-2", disabled: !summary.latest_loan.within_renewal_limit?, remote: true, data: renew_button_data do %>
                   <%= feather_icon "repeat" %>Renew
                 <% end %>
               <% end %>

--- a/test/controllers/concerns/lending_test.rb
+++ b/test/controllers/concerns/lending_test.rb
@@ -74,12 +74,12 @@ class LendingTest < ActiveSupport::TestCase
 
     loan = create(:loan, item: item, created_at: (sunday - 7.days), due_at: sunday, uniquely_numbered: true)
 
-    assert loan.renewable?
+    assert loan.within_renewal_limit?
     renewal = Loan.stub(:open_days, [0, 4]) {
       renew_loan(loan, now: sunday)
     }
 
-    assert renewal.renewable?
+    assert renewal.within_renewal_limit?
     second_renewal = Loan.stub(:open_days, [0, 4]) {
       renew_loan(renewal, now: monday)
     }
@@ -99,7 +99,7 @@ class LendingTest < ActiveSupport::TestCase
       renew_loan(loan, now: sunday)
     }
 
-    refute renewal.renewable?
+    refute renewal.within_renewal_limit?
   end
 
   test "updates appointment loans to point to the renewal" do


### PR DESCRIPTION
# What it does

Adds language on the member loans page to indicate explicitly when an item is not renewable.

# Why it is important

Resolves #1440 

# UI Change Screenshot

![2024-04-04 at 12 08 26@2x](https://github.com/chicago-tool-library/circulate/assets/37534/2c016e92-e9c0-4630-bea8-5345b9dc80d7)
