### PR TITLE
Add full name to memberships report

### DIFF
--- a/app/controllers/admin/reports/memberships_controller.rb
+++ b/app/controllers/admin/reports/memberships_controller.rb
@@ -29,10 +29,10 @@ module Admin
 
           format.csv do
             text = CSV.generate(headers: true) { |csv|
-              csv << %w[name email status loans expires_on count amount1 amount2 amount3]
+              csv << %w[preferred_name full_name email status loans expires_on count amount1 amount2 amount3]
 
               @members.find_each do |member|
-                values = [helpers.preferred_or_default_name(member)]
+                values = [member.preferred_name, member.full_name]
                 values.concat member.attributes.values_at("email", "status", "loans_count")
                 values << member.expires_on&.to_date
                 values << member.memberships_count

--- a/app/views/admin/reports/memberships/index.html.erb
+++ b/app/views/admin/reports/memberships/index.html.erb
@@ -9,7 +9,8 @@
 
     <table class="table">
       <tr>
-        <th>Name & Email</th>
+        <th>Name</th>
+        <th>Email</th>
         <th>Status</th>
         <th>Loans</th>
         <th>Expires</th>
@@ -19,9 +20,9 @@
       <% @members.each do |member| %>
         <tr>
           <td>
-            <%= link_to preferred_or_default_name(member), [:admin, member] %> -
-            <%= link_to member.email, [:admin, member] %>
+            <%= link_to member.full_name, [:admin, member] %>
           </td>
+          <td><%= member.email %></td>
           <td><%= member.status %></td>
           <td><%= member.loans_count %></td>
           <td><%= member.expires_on&.to_date&.to_fs(:long) %></td>


### PR DESCRIPTION
# What it does

Adds full names to membership report

# Why it is important

@tessavierk needs a membership report with full member names, and the membership report only shows preferred / first names