### PR TITLE
Fix broken teamup redirect

### DIFF
--- a/app/controllers/volunteer/base_controller.rb
+++ b/app/controllers/volunteer/base_controller.rb
@@ -10,7 +10,7 @@ module Volunteer
     end
 
     def redirect_to_teamup
-      redirect_to "https://teamup.com/ksnp8rrsst1ow8nvwn", status: :see_other
+      redirect_to "https://teamup.com/ksnp8rrsst1ow8nvwn", status: :see_other, allow_other_host: true
       false
     end
   end


### PR DESCRIPTION
# What it does

Fixes the `UnsafeRedirectError` we [saw yesterday](https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/3113/samples/timestamp/2024-04-05T02:38:32Z).

# Why it is important

Errors bad!