### PR TITLE
Wait for logs to write to appsignal before exiting rake tasks.

### DIFF
--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -10,25 +10,25 @@ namespace :email do
   desc "Send daily loan summary emails"
   task :send_daily_loan_summaries, [:date] => :environment do |task, args|
     send_emails :send_daily_loan_summaries, args[:date]
-    appsignal_flush
+    flush_logs_to_appsignal
   end
 
   desc "Send overdue notice emails"
   task :send_overdue_notices, [:date] => :environment do |task, args|
     send_emails :send_overdue_notices, args[:date]
-    appsignal_flush
+    flush_logs_to_appsignal
   end
 
   desc "Send return reminder emails"
   task :send_return_reminders, [:date] => :environment do |task, args|
     send_emails :send_return_reminders, args[:date]
-    appsignal_flush
+    flush_logs_to_appsignal
   end
 
   desc "Send reminders to pending members older than 1 month"
   task :send_pending_member_reminders, [:date] => :environment do |task, args|
     send_emails :remind_pending_members, args[:date]
-    appsignal_flush
+    flush_logs_to_appsignal
   end
 
   desc "Send membership renewal reminder emails"
@@ -38,20 +38,12 @@ namespace :email do
       amount = member.last_membership&.amount || Money.new(0)
       MemberMailer.with(member: member, amount: amount).membership_renewal_reminder.deliver_now
     end
-    appsignal_flush
+    flush_logs_to_appsignal
   end
 
   desc "Send staff renewal request summary emails"
   task :send_staff_daily_renewal_requests, [:date] => :environment do |task, args|
     send_emails :send_staff_daily_renewal_requests, args[:date]
-    appsignal_flush
+    flush_logs_to_appsignal
   end
-end
-
-# Close process allowing Appsignal to flush any exceptions that were rescued
-# and manually sent along, per recommendations here:
-# https://docs.appsignal.com/ruby/integrations/rake.html#rake-tasks-and-containers
-def appsignal_flush
-  Appsignal.stop "rake"
-  sleep 5
 end

--- a/lib/tasks/shared.rake
+++ b/lib/tasks/shared.rake
@@ -1,0 +1,6 @@
+# Allow time for AppSignal to ship logs before the process exits
+# https://docs.appsignal.com/ruby/integrations/rake.html#rake-tasks-and-containers
+def wait_for_logs_to_flush
+  Appsignal.stop "rails"
+  sleep 5
+end

--- a/lib/tasks/shared.rake
+++ b/lib/tasks/shared.rake
@@ -1,6 +1,7 @@
-# Allow time for AppSignal to ship logs before the process exits
+# Close process allowing Appsignal to flush any exceptions that were rescued
+# and manually sent along, per recommendations here:
 # https://docs.appsignal.com/ruby/integrations/rake.html#rake-tasks-and-containers
-def wait_for_logs_to_flush
-  Appsignal.stop "rails"
+def flush_logs_to_appsignal
+  Appsignal.stop "rake"
   sleep 5
 end

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -6,7 +6,7 @@ namespace :sync do
       sync_calendar Event.volunteer_shift_calendar_id
     end
 
-    wait_for_logs_to_flush
+    flush_logs_to_appsignal
   end
 
   def sync_calendar(calendar_id)

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -5,6 +5,8 @@ namespace :sync do
       sync_calendar Event.appointment_slot_calendar_id
       sync_calendar Event.volunteer_shift_calendar_id
     end
+
+    wait_for_logs_to_flush
   end
 
   def sync_calendar(calendar_id)


### PR DESCRIPTION
# What it does

I noticed that logs for tasks run through the Heroku scheduler aren't showing up in AppSignal. [Their docs mention needing to add some code to ensure that logs are send before the process exits](https://docs.appsignal.com/ruby/integrations/rake.html#rake-tasks-and-containers), so I added that to the calendar tasks. If it works, we can add it to the other ones that send emails and the like.

# Why it is important

It's nice to keep an eye on if these tasks are running and how many events they are updating.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.