### PR TITLE
Remove barnes require so that Heroku can track Puma metrics

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,3 @@
-require "barnes"
-
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match


### PR DESCRIPTION
# What it does

I noticed that we weren't seeing any Ruby metrics in Heroku, despite having followed the directions a while back to set them up:
![Screenshot 2024-04-08 at 8 34 44 PM](https://github.com/chicago-tool-library/circulate/assets/3331/193bb076-e03e-45a0-b973-3ad70f069bdb)

I am interested in these metrics to help figure out how to tune the app's concurrency and ideally address the memory errors we've been seeing.

The app was setup according the [the Heroku instructions](https://devcenter.heroku.com/articles/language-runtime-metrics-ruby), but evidently [they are out of date](https://github.com/heroku/barnes/issues/36#issuecomment-765733448) and having an explicit require of `barnes` in `config/puma.rb` loads the library before Rails, causing the Barnes server to not start properly and therefore not report metrics.