### PR TITLE
Rework logging config to try to get rake logs in appsignal

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,27 +100,6 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
-
-  config.lograge.enabled = true
-  config.lograge.keep_original_rails_log = true
-
-  config.lograge.logger = Appsignal::Logger.new(
-    "rails",
-    format: Appsignal::Logger::LOGFMT
-  )
-
-  config.lograge.custom_payload do |controller|
-    {
-      user_id: controller.current_user.try(:id),
-      request_id: controller.request.request_id
-    }
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,16 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+
+  # Set a few custom parameters on log lines
+  config.lograge.custom_payload do |controller|
+    {
+      user_id: controller.current_user.try(:id),
+      request_id: controller.request.request_id
+    }
+  end
+
+  # Heroku environments will set this env var and expect logs on stdout
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.lograge.logger = ActiveSupport::Logger.new($stdout)
+  end
+end


### PR DESCRIPTION
# What it does

Reconfigure logging to attempt to get non-web tasks to show up in AppSignal

# Why it is important

We want logs for background work!

# Implementation notes

* I went down the rabbit hole reading about this, and I think the best thing for us to try next is to remove the [Ruby level Appsignal logging integration](https://docs.appsignal.com/logging/platforms/integrations/ruby.html) and instead use a [Heroku Log Drain](https://docs.appsignal.com/logging/platforms/heroku.html).
* I've already configured the Heroku Log Drain in production, so this change is meant to simplify the config to just let lograge give us logs on stdout.