### PR TITLE
Add Ahoy for tracking and begin recording events for tool search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,3 +102,5 @@ gem "jsbundling-rails", "~> 1.3"
 gem "cssbundling-rails", "~> 1.4"
 
 gem "twilio-ruby", "~> 7.0"
+
+gem "ahoy_matey", "~> 5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,10 @@ GEM
       rails (>= 6.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    ahoy_matey (5.1.0)
+      activesupport (>= 6.1)
+      device_detector (>= 1)
+      safely_block (>= 0.4)
     apimatic_core (0.3.5)
       apimatic_core_interfaces (~> 0.2.0)
       certifi (~> 2018.1, >= 2018.01.18)
@@ -160,6 +164,7 @@ GEM
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
     date (3.3.4)
+    device_detector (1.1.2)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -455,6 +460,7 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
+    safely_block (0.4.0)
     scenic (1.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -575,6 +581,7 @@ DEPENDENCIES
   activerecord-postgres_enum
   acts_as_list
   acts_as_tenant
+  ahoy_matey (~> 5.1)
   appsignal
   audited
   aws-sdk-s3

--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -10,6 +10,7 @@ module Account
 
       @new_hold.transaction do
         if @new_hold.save
+          Ahoy.track "Placed hold", hold_id: @new_hold.id
           @new_hold.start! if @new_hold.ready_for_pickup?
           redirect_to item_path(@item), success: "Hold placed.", status: :see_other
         else

--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -10,7 +10,7 @@ module Account
 
       @new_hold.transaction do
         if @new_hold.save
-          Ahoy.track "Placed hold", hold_id: @new_hold.id
+          ahoy.track "Placed hold", hold_id: @new_hold.id
           @new_hold.start! if @new_hold.ready_for_pickup?
           redirect_to item_path(@item), success: "Hold placed.", status: :see_other
         else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
     # Track that a search was performed if we are on the first page
     if @query && @pagy.page == 1
-      Ahoy.track "Searched", query: @query
+      ahoy.track "Searched", query: @query
     end
   end
 
@@ -34,7 +34,7 @@ class ItemsController < ApplicationController
       @current_hold_count = current_member.active_holds.active_hold_count_for_item(@item).to_i
     end
 
-    Ahoy.track "Item viewed", item_id: @item.id
+    ahoy.track "Item viewed", item_id: @item.id
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,11 @@ class ItemsController < ApplicationController
 
     @categories = CategoryNode.with_items
     @pagy, @items = pagy(item_scope)
+
+    # Track that a search was performed if we are on the first page
+    if @query && @pagy.page == 1
+      Ahoy.track "Searched", query: @query
+    end
   end
 
   def show
@@ -28,6 +33,8 @@ class ItemsController < ApplicationController
       @current_hold = current_member.active_holds.active.where(item_id: @item.id).first
       @current_hold_count = current_member.active_holds.active_hold_count_for_item(@item).to_i
     end
+
+    Ahoy.track "Item viewed", item_id: @item.id
   end
 
   private

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,0 +1,8 @@
+class Ahoy::Event < ApplicationRecord
+  include Ahoy::QueryMethods
+
+  self.table_name = "ahoy_events"
+
+  belongs_to :visit
+  belongs_to :user, optional: true
+end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,0 +1,6 @@
+class Ahoy::Visit < ApplicationRecord
+  self.table_name = "ahoy_visits"
+
+  has_many :events, class_name: "Ahoy::Event"
+  belongs_to :user, optional: true
+end

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,10 @@
+class Ahoy::Store < Ahoy::DatabaseStore
+end
+
+# set to true for JavaScript tracking
+Ahoy.api = false
+
+# set to true for geocoding (and add the geocoder gem to your Gemfile)
+# we recommend configuring local geocoding as well
+# see https://github.com/ankane/ahoy#geocoding
+Ahoy.geocode = false

--- a/db/migrate/20240411151214_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20240411151214_create_ahoy_visits_and_events.rb
@@ -1,0 +1,62 @@
+class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ahoy_visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+
+      # the rest are recommended but optional
+      # simply remove any you don't want
+
+      # user
+      t.references :user
+
+      # standard
+      t.string :ip
+      t.text :user_agent
+      t.text :referrer
+      t.string :referring_domain
+      t.text :landing_page
+
+      # technology
+      t.string :browser
+      t.string :os
+      t.string :device_type
+
+      # location
+      t.string :country
+      t.string :region
+      t.string :city
+      t.float :latitude
+      t.float :longitude
+
+      # utm parameters
+      t.string :utm_source
+      t.string :utm_medium
+      t.string :utm_term
+      t.string :utm_content
+      t.string :utm_campaign
+
+      # native apps
+      t.string :app_version
+      t.string :os_version
+      t.string :platform
+
+      t.datetime :started_at
+    end
+
+    add_index :ahoy_visits, :visit_token, unique: true
+    add_index :ahoy_visits, [:visitor_token, :started_at]
+
+    create_table :ahoy_events do |t|
+      t.references :visit
+      t.references :user
+
+      t.string :name
+      t.jsonb :properties
+      t.datetime :time
+    end
+
+    add_index :ahoy_events, [:name, :time]
+    add_index :ahoy_events, :properties, using: :gin, opclass: :jsonb_path_ops
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_14_004211) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_151214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -151,6 +151,49 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_004211) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["member_id"], name: "index_agreement_acceptances_on_member_id"
+  end
+
+  create_table "ahoy_events", force: :cascade do |t|
+    t.bigint "visit_id"
+    t.bigint "user_id"
+    t.string "name"
+    t.jsonb "properties"
+    t.datetime "time"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
+    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", force: :cascade do |t|
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.bigint "user_id"
+    t.string "ip"
+    t.text "user_agent"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.text "landing_page"
+    t.string "browser"
+    t.string "os"
+    t.string "device_type"
+    t.string "country"
+    t.string "region"
+    t.string "city"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
+    t.string "utm_content"
+    t.string "utm_campaign"
+    t.string "app_version"
+    t.string "os_version"
+    t.string "platform"
+    t.datetime "started_at"
+    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
+    t.index ["visitor_token", "started_at"], name: "index_ahoy_visits_on_visitor_token_and_started_at"
   end
 
   create_table "appointment_holds", force: :cascade do |t|


### PR DESCRIPTION
# What it does

This installs the [`ahoy_matey`](https://github.com/ankane/ahoy) gem for first-party analytics and begins using it to track when members do a search, view an item, and place a hold.

# Why it is important

As we aim to improve search in the system (#1240), it will be helpful to see what users are actually searching for and whether they are finding it.

# Implementation notes

* 🤫 By using a first-party analytics system (i.e. one that stores data in the same database we already use and control) we're not storing or exposing any more user information than we already have via our member information and logs.
* 🏋🏻 It's worth noting that this will put more storage pressure on the database, because it's recording rows for stuff we expect users to do a lot. So we'll want to keep an eye on database growth.
* ♻️ Along those lines, will want to add [a job that prunes old data](https://github.com/ankane/ahoy?tab=readme-ov-file#data-retention) but I figure that can come in a follow-on PR.
* 📈 We can add as many more events as we like over time, but I figure starting relatively simple is the way to go.
