### PR TITLE
Add Pickup checkin/checkout

### DIFF
--- a/app/controllers/admin/pickups/checkins_controller.rb
+++ b/app/controllers/admin/pickups/checkins_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  module Pickups
+    class CheckinsController < BaseController
+      def create
+        @pickup.transaction do
+          @pickup.update(status: Pickup.statuses[:returned])
+          @pickup.reservation_loans.each do |reservation_loan|
+            reservation_loan.update!(checked_in_at: Time.current)
+          end
+        end
+
+        redirect_to admin_pickup_path(@pickup), status: :see_other
+      end
+    end
+  end
+end

--- a/app/controllers/admin/pickups/checkouts_controller.rb
+++ b/app/controllers/admin/pickups/checkouts_controller.rb
@@ -1,0 +1,17 @@
+module Admin
+  module Pickups
+    class CheckoutsController < BaseController
+      def create
+        # TODO verify that the checkout is on the day of the reservation
+        @pickup.transaction do
+          @pickup.update(status: Pickup.statuses[:picked_up])
+          @pickup.reservation_loans.each do |reservation_loan|
+            reservation_loan.update!(checked_out_at: Time.current)
+          end
+        end
+
+        redirect_to admin_pickup_path(@pickup), status: :see_other
+      end
+    end
+  end
+end

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -153,7 +153,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
     tag.div(data: {controller: "dynamic-fields"}) {
       safe_join([
         fields_for(association) { |ff| yield ff },
-        tag.button(label, data: {action: "dynamic-fields#add"}),
+        tag.button(label, type: "button", data: {action: "dynamic-fields#add"}),
         tag.template(data: {dynamic_fields_target: "template"}) {
           fields_for(association, association.to_s.classify.constantize.new,
             child_index: "__CHILD_INDEX__") { |ff| yield ff }

--- a/app/models/pickup.rb
+++ b/app/models/pickup.rb
@@ -3,6 +3,7 @@ class Pickup < ApplicationRecord
     building: "building",
     ready_for_pickup: "ready_for_pickup",
     picked_up: "picked_up",
+    returned: "returned",
     cancelled: "cancelled"
   }
 
@@ -14,5 +15,9 @@ class Pickup < ApplicationRecord
 
   def reservation_satisfied?
     reservation.date_holds.all? { |dh| dh.satisfied? }
+  end
+
+  def editable?
+    status == Pickup.statuses[:building]
   end
 end

--- a/app/models/reservable_item.rb
+++ b/app/models/reservable_item.rb
@@ -1,6 +1,7 @@
 class ReservableItem < ApplicationRecord
   belongs_to :creator, class_name: "User"
   belongs_to :item_pool, counter_cache: true
+  has_many :reservation_loans
 
   validates :name, presence: true
 

--- a/app/models/reservation_loan.rb
+++ b/app/models/reservation_loan.rb
@@ -5,8 +5,17 @@ class ReservationLoan < ApplicationRecord
 
   validate :date_hold_quantity_not_exceeded
   validates :reservable_item_id, uniqueness: {scope: :date_hold_id, message: "has already been added"}
+  validate :item_is_available
 
   acts_as_tenant :library
+
+  scope :pending, -> { where(checked_out_at: nil) }
+  scope :checked_out, -> { where.not(checked_out_at: nil).and(where(checked_in_at: nil)) }
+  scope :pending_or_checked_out, -> { pending.or(checked_out) }
+
+  def editable?
+    checked_out_at.nil?
+  end
 
   private
 
@@ -14,8 +23,18 @@ class ReservationLoan < ApplicationRecord
     return unless date_hold
     return unless date_hold.item_pool.uniquely_numbered?
 
-    if date_hold.reservation_loans.count >= date_hold.quantity
+    if date_hold.reservation_loans.where.not(id:).count >= date_hold.quantity
       errors.add(:reservable_item_id, "only #{date_hold.quantity} #{date_hold.item_pool.name} are required")
+    end
+  end
+
+  def item_is_available
+    return unless reservable_item
+    return true unless date_hold.item_pool.uniquely_numbered?
+
+    # Prevent an item from being attached to more than one pickup at a time
+    if reservable_item.reservation_loans.pending_or_checked_out.where.not(id:).any?
+      errors.add(:reservable_item_id, "is already assigned to another pickup")
     end
   end
 end

--- a/app/views/admin/pickups/_date_hold.erb
+++ b/app/views/admin/pickups/_date_hold.erb
@@ -3,7 +3,7 @@
         <%= date_hold.item_pool.name %>
         (<%= date_hold.loaned_quantity %>/<%= date_hold.quantity %>)
 
-        <% unless date_hold.item_pool.uniquely_numbered? || date_hold.satisfied? %>
+        <% if pickup.editable? && !date_hold.item_pool.uniquely_numbered? && !date_hold.satisfied? %>
         <%= button_to "Add all",
             admin_pickup_reservation_loans_path(pickup),
             method: :post,
@@ -21,7 +21,9 @@
             <%= reservation_loan.reservable_item.id %> -
             <%= reservation_loan.reservable_item.name %>
             <% end %>
-            <%= button_to "Remove", admin_pickup_reservation_loan_path(pickup, reservation_loan), method: :delete, class: "btn btn-sm" %>
+            <% if reservation_loan.editable? %>
+                <%= button_to "Remove", admin_pickup_reservation_loan_path(pickup, reservation_loan), method: :delete, class: "btn btn-sm" %>
+            <% end %>
         </li>
         <% end %>
     </ul>

--- a/app/views/admin/pickups/_status.html.erb
+++ b/app/views/admin/pickups/_status.html.erb
@@ -2,7 +2,7 @@
     <% if pickup.reservation_satisfied? && pickup.status == Pickup.statuses[:building] %>
     <div class="toast toast-success">
         All requirements satisfied.
-        <%= button_to "Mark Ready for Pickup", admin_pickup_path(@pickup), method: :put, params: {pickup: { status: "ready_for_pickup"} }%>
+        <%= button_to "Mark Ready for Pickup", admin_pickup_path(@pickup), method: :put, params: {pickup: {status: "ready_for_pickup"}} %>
     </div>
     <% end %>
 </div>

--- a/app/views/admin/pickups/_status.html.erb
+++ b/app/views/admin/pickups/_status.html.erb
@@ -1,7 +1,8 @@
 <div id="pickup-status">
-    <% if pickup.reservation_satisfied? %>
+    <% if pickup.reservation_satisfied? && pickup.status == Pickup.statuses[:building] %>
     <div class="toast toast-success">
         All requirements satisfied.
+        <%= button_to "Mark Ready for Pickup", admin_pickup_path(@pickup), method: :put, params: {pickup: { status: "ready_for_pickup"} }%>
     </div>
     <% end %>
 </div>

--- a/app/views/admin/pickups/show.html.erb
+++ b/app/views/admin/pickups/show.html.erb
@@ -5,6 +5,11 @@
       ) %>
   <%= index_header "Pickup ##{@pickup.id}" do %>
     <%= link_to "Edit", edit_admin_pickup_path(@pickup), class: "btn" %>
+    <% if @pickup.status == Pickup.statuses[:ready_for_pickup] %>
+      <%= button_to "Check out", admin_pickup_checkout_path(@pickup), class: "btn", method: :create %>
+    <% elsif @pickup.status == Pickup.statuses[:picked_up] %>
+      <%= button_to "Check in", admin_pickup_checkin_path(@pickup), class: "btn", method: :create %>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -14,7 +19,9 @@
 
 <div class="divider"></div>
 
-<%= render partial: "admin/pickups/reservation_loans/form", locals: {pickup: @pickup, reservation_loan: ReservationLoan.new} %>
+<% if @pickup.editable? %>
+  <%= render partial: "admin/pickups/reservation_loans/form", locals: {pickup: @pickup, reservation_loan: ReservationLoan.new} %>
+<% end %>
 <br>
 
 <div id="date-holds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,8 @@ Rails.application.routes.draw do
       resources :pickups do
         scope module: "pickups" do
           resources :reservation_loans, only: [:create, :destroy]
+          resource :checkout, only: :create
+          resource :checkin, only: :create
         end
       end
     end

--- a/db/migrate/20240319044204_add_check_out_times_to_reservation_loans.rb
+++ b/db/migrate/20240319044204_add_check_out_times_to_reservation_loans.rb
@@ -1,0 +1,6 @@
+class AddCheckOutTimesToReservationLoans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reservation_loans, :checked_out_at, :timestamp
+    add_column :reservation_loans, :checked_in_at, :timestamp
+  end
+end

--- a/db/migrate/20240319050749_add_returned_to_pickup_statuses.rb
+++ b/db/migrate/20240319050749_add_returned_to_pickup_statuses.rb
@@ -1,0 +1,5 @@
+class AddReturnedToPickupStatuses < ActiveRecord::Migration[7.1]
+  def change
+    add_enum_value :pickup_status, "returned"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_151214) do
     "ready_for_pickup",
     "picked_up",
     "cancelled",
+    "returned",
   ], force: :cascade
 
   create_enum :power_source, [
@@ -577,6 +578,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_151214) do
     t.bigint "library_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "checked_out_at", precision: nil
+    t.datetime "checked_in_at", precision: nil
     t.index ["date_hold_id"], name: "index_reservation_loans_on_date_hold_id"
     t.index ["library_id"], name: "index_reservation_loans_on_library_id"
     t.index ["pickup_id"], name: "index_reservation_loans_on_pickup_id"


### PR DESCRIPTION
# What it does

Extends our group lending prototype to allow for pickups to be checked out and back in to represent a reservation being picked from the library and then brought back sometime later on.

# UI Change Screenshot

<img width="989" alt="Screenshot 2024-04-17 at 9 00 50 AM" src="https://github.com/chicago-tool-library/circulate/assets/3331/f7a31cce-c89b-40fd-a88e-9b3932912a36">
<img width="986" alt="Screenshot 2024-04-17 at 9 01 21 AM" src="https://github.com/chicago-tool-library/circulate/assets/3331/34afe75f-6fe2-4548-9dce-ad764de90440">
