### PR TITLE
Add link to filtered notifications report

### DIFF
--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -2,6 +2,7 @@
   <%= index_header preferred_or_default_name(@member) do %>
     <%= link_to "Edit Member", edit_admin_member_path(@member), class: "btn" %>
     <%= link_to "Add Note to Member", new_admin_member_note_path(@member), class: "btn", data: {turbo_frame: "new-note"} %>
+    <%= link_to "View Notifications", admin_reports_notifications_path(member_id: @member), class: "btn" %>
     <%# <%= link_to 'Record Payment', new_admin_member_payment_path(@member), class: "btn" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
# What it does

Adds a link to the members page that goes to the notifications report, filtered by that member. It turns out this functionality has been there for a while, but there was just not a convenient link that exposed it.

This obviates the need for #1250.

# Why it is important

It's really useful to see what communications we've sent to a given member.

# UI Change Screenshot

<img width="996" alt="image" src="https://github.com/chicago-tool-library/circulate/assets/3331/bb7d995c-12ba-41e4-9d62-891892dd200a">

# Implementation notes

* There's already an index in the database on `notifications.member_id`.