### PR TITLE
Use newer default value for config.action_dispatch.cookies_same_site_protection

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module Circulate
     # get it installed in our Heroku environment before we can switch.
     config.active_storage.variant_processor = :mini_magick
     config.active_job.queue_adapter = :sucker_punch
-    config.action_dispatch.cookies_same_site_protection = nil
+    config.action_dispatch.cookies_same_site_protection = :lax
     config.action_view.form_with_generates_remote_forms = false
     ActiveSupport.utc_to_local_returns_utc_offset_times = false
 


### PR DESCRIPTION
# What it does

Starting in Rails 6.1, the default value of this setting was changed to `:lax`. Our app predates that default, and the current behavior is less secure than the default.

[The Rails guides have more info](https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-cookies-same-site-protection).

You can see [the security warning from GitHub](https://github.com/chicago-tool-library/circulate/security/code-scanning/3) as well.