### PR TITLE
Change name display on appointments

### DIFF
--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -5,7 +5,7 @@
     ) do %>
   <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
   <td class="member">
-    <%= link_to appointment.member.full_name, admin_member_path(appointment.member) %><br>
+    <%= link_to preferred_or_default_name(appointment.member), admin_member_path(appointment.member), class: "tooltip", data: {tooltip: appointment.member.full_name} %><br>
     <%= appointment.member.display_pronouns %>
   </td>
   <td class="items">

--- a/app/views/admin/appointments/_appointment_mobile.html.erb
+++ b/app/views/admin/appointments/_appointment_mobile.html.erb
@@ -1,7 +1,8 @@
 <div id="<%= dom_id(appointment) %>-mobile" class="card <%= "completed" if appointment.completed? %>">
   <div class="card-header">
     <div class="card-title h5">
-      <%= link_to appointment.member.full_name, admin_member_path(appointment.member) %><br>
+      <%= link_to preferred_or_default_name(appointment.member), admin_member_path(appointment.member) %>
+      <small>(<%= appointment.member.full_name %>)</small>
     </div>
     <div class="card-subtitle text-gray">
       <%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %>


### PR DESCRIPTION
# What it does

Updates member name display on admin appointments page

* Desktop: Preferred name w/ full name in tooltip
* Mobile: Preferred name w/ full name in parens (since tooltips on links don't work on mobile as there's no hover)

# Why it is important

Staff wants to address people by preferred name, but they sometimes need to differentiate between multiple people with the same name.

# UI Change Screenshot

Desktop:

![2024-04-27 at 10 12 27@2x](https://github.com/chicago-tool-library/circulate/assets/37534/0ac3150d-4f4d-40e0-8542-427e0b7d67cd)

Mobile:

![2024-04-27 at 11 50 06@2x](https://github.com/chicago-tool-library/circulate/assets/37534/40372ae6-bc0d-4d0b-9432-9676dc92b010)

