### PR TITLE
Attempt fix for InvalidAuthenticityToken errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,17 @@ class ApplicationController < ActionController::Base
   include ActiveSupport::Testing::TimeHelpers
   include PageAttributes
 
+  # Move CSRF token storage from its default location in the session (which is
+  # destroyed after every browser close) to a long lived cookie in order to
+  # prevent InvalidAuthenticityToken errors raised from cached
+  # pages being reloaded. For a detailed analysis see:
+  #
+  #  - The ancient Rails bug tracking this: https://github.com/rails/rails/issues/21948
+  #  - The Rails PR with the new feature we're using: https://github.com/rails/rails/pull/44283
+  #  - A PR that includes an *excellent* write up and a similar implementation
+  #    made before the above feature landed: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/6332
+  protect_from_forgery store: NonSessionCookieStore.new(:csrf_token), with: :exception
+
   set_current_tenant_through_filter
   before_action :set_tenant
 

--- a/app/lib/non_session_cookie_store.rb
+++ b/app/lib/non_session_cookie_store.rb
@@ -1,0 +1,44 @@
+# This is a copy of CookieStore from ActionDispatch that does not store or
+# check the session ID in order to make the csrf_token truly long lived. Two
+# lines have been commented with CHANGE to highlight the differences from the
+# original.
+#
+# For a copy of the original code in context, see:
+# https://github.com/rails/rails/blob/v7.1.3/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L312
+#
+# See the comment above protect_from_forgery in our ApplicationController for
+# more background.
+class NonSessionCookieStore
+  def initialize(cookie = :csrf_token)
+    @cookie_name = cookie
+  end
+
+  def fetch(request)
+    contents = request.cookie_jar.encrypted[@cookie_name]
+    return nil if contents.nil?
+
+    value = JSON.parse(contents)
+    # CHANGE: This is the check we're skipping:
+    # return nil unless value.dig("session_id", "public_id") == request.session.id_was&.public_id
+
+    value["token"]
+  rescue JSON::ParserError
+    nil
+  end
+
+  def store(request, csrf_token)
+    request.cookie_jar.encrypted.permanent[@cookie_name] = {
+      value: {
+        token: csrf_token
+        # CHANGE: And we're not storing session ID in the cookie.
+        # session_id: request.session.id,
+      }.to_json,
+      httponly: true,
+      same_site: :lax
+    }
+  end
+
+  def reset(request)
+    request.cookie_jar.delete(@cookie_name)
+  end
+end


### PR DESCRIPTION
# What it does

Implements a change suggested [here](https://blog.alex-miller.co/rails/2017/01/07/rails-authenticity-token-and-mobile-safari.html) and [here](https://github.com/rails/rails/issues/21948#issuecomment-147738473) which should hopefully reduce the number of InvalidAuthenticityToken errors we see.

# Why it is important

ActionController::InvalidAuthenticityToken is one of the more common errors we see, and though some of them probably come from random web traffic, there are enough to suggest we have an actual issue.