### PR TITLE
Item loan history page uses item layout

### DIFF
--- a/app/controllers/admin/items/loan_histories_controller.rb
+++ b/app/controllers/admin/items/loan_histories_controller.rb
@@ -1,0 +1,10 @@
+module Admin
+  module Items
+    class LoanHistoriesController < BaseController
+      def show
+        @item = Item.find(params[:item_id])
+        @loans = @item.loans.includes(:member).order(created_at: :desc)
+      end
+    end
+  end
+end

--- a/app/views/admin/items/loan_histories/show.html.erb
+++ b/app/views/admin/items/loan_histories/show.html.erb
@@ -7,6 +7,7 @@
         <th>Member</th>
         <th>Checked out</th>
         <th>Due / Returned</th>
+        <th>Date</th>
       </tr>
     </thead>
 
@@ -16,13 +17,15 @@
           <td><%= full_item_number(loan.item) %></td>
           <td><%= link_to loan.item.name, [:admin, loan.item] %></td>
           <td><%= link_to preferred_or_default_name(loan.member), [:admin, loan.member] %></td>
-          <td><%= loan.created_at %></td>
+          <td><%= date_with_time_title(loan.created_at) %></td>
           <td>
-            <% if loan.ended? %>
-              returned <%= loan.ended_at %>
-            <% else %>
-              due <%= loan.due_at %></td>
-            <% end %>
+            <span class="chip <%= loan.ended? ? "bg-success" : "bg-primary" %>">
+              <%= loan.ended? ? "Returned" : "Due" %>
+            </span>
+          </td>
+          <td>
+            <%= date_with_time_title(loan.ended? ? loan.ended_at : loan.due_at) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/items/loan_histories/show.html.erb
+++ b/app/views/admin/items/loan_histories/show.html.erb
@@ -1,0 +1,30 @@
+<%= render "admin/items/profile" do %>
+  <table class="table table-scroll">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Item</th>
+        <th>Member</th>
+        <th>Checked out</th>
+        <th>Due / Returned</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @loans.each do |loan| %>
+        <tr>
+          <td><%= full_item_number(loan.item) %></td>
+          <td><%= link_to loan.item.name, [:admin, loan.item] %></td>
+          <td><%= link_to preferred_or_default_name(loan.member), [:admin, loan.member] %></td>
+          <td><%= loan.created_at %></td>
+          <td>
+            <% if loan.ended? %>
+              returned <%= loan.ended_at %>
+            <% else %>
+              due <%= loan.due_at %></td>
+            <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
       scope module: "items" do
         resources :attachments
         resource :history, only: :show
+        resource :loan_history, only: :show
         resources :holds, only: :index do
           scope module: "holds" do
             resource :position, only: :update


### PR DESCRIPTION
# What it does

Adds an admin `LoanHistoriesController` and corresponding route to use same layout as the rest of the tabs in the admin/item view. 

# Why it is important

More seamless navigation on Item Loan History Page

# UI Change Screenshot
<img width="1211" alt="Screenshot 2024-05-02 at 10 04 35 PM" src="https://github.com/chicago-tool-library/circulate/assets/33136052/d936f94c-eb39-45f9-8c92-b70561a43fb7">


# Implementation notes

Modeled `LoanHistoriesController` based on `HistoriesController` in `app/controllers/admin/items/histories_controller.rb`

Also made the due/returned status a chip and added an extra "Date" column to the table to work nicely with the chip.

Is `app/views/admin/loan_histories/show.html.erb` used anywhere else? I haven't been able to find where the existing loan history page is used elsewhere but I want to confirm before removing.


Resolves [#1147](https://github.com/chicago-tool-library/circulate/issues/1147)