### PR TITLE
Add standardjs check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,24 @@ jobs:
     #   uses: mxschmitt/action-tmate@v3
     #   if: ${{ failure() }}
 
+  StandardJS:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: "package.json"
+    - uses: actions/cache@v4
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: yarn install --frozen-lockfile
+    - name: StandardJS
+      run: yarn run standard
+
   StandardRB:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# What it does

We added standard to check our front end code in #1472. This extends our existing CI checks to also run that linter.