### PR TITLE
Image processing: switch to vips and track variants

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,11 +40,9 @@ module Circulate
     # in config/environments, which are processed later.
     #
     config.active_record.has_many_inversing = false
-    config.active_storage.track_variants = false
+    config.active_storage.track_variants = true
     config.active_storage.queues.analysis = :active_storage_analysis
-    # Rails 7 changed the default image processor to :vips; we will have to
-    # get it installed in our Heroku environment before we can switch.
-    config.active_storage.variant_processor = :mini_magick
+    config.active_storage.variant_processor = :vips
     config.active_job.queue_adapter = :sucker_punch
     config.action_dispatch.cookies_same_site_protection = :lax
     config.action_view.form_with_generates_remote_forms = false


### PR DESCRIPTION
# What it does

Configures ActiveStorage to use vips instead of imagemagick as its underlying image processor. Vips should use a lot less memory than imagemagick. See https://github.com/chicago-tool-library/circulate/pull/1164#issuecomment-1786219584 for more information and background.

# Why it is important

Currently an esoteric user traffic pattern has triggered ImageKit's throttling so images are broken on the site.

# Implementation notes

* My plan is to merge this, test it on staging, deploy it to production, and then remove IMAGEKIT_URL to see if the site works okay enough without any fancy variant preprocessing. The images will be a little slow on first load but I think this is better than no images! If it's super slow we can also run a loop in a rails console to manually preprocess all the existing items.
* I'm not removing the IMAGEKIT_URL conditional yet which means we'll be able to quickly revert by restoring the environment variable.
* My research suggests we can rely on the version of vips that comes preinstalled on Heroku rather than installing it ourselves. See https://github.com/dhui5394/heroku-buildpack-vips/issues/36 for discussion. (There are some security implications of not being on the latest version, but we only have trusted users uploading images so I think we can afford to choose the simpler deployment option of using the existing package.)
