### PR TITLE
Added pagination to account holds history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -575,6 +577,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -1,5 +1,7 @@
 module Account
   class HoldsController < BaseController
+    include Pagy::Backend
+
     def index
       @holds = current_member.active_holds.recent_first.includes(:item)
     end
@@ -27,7 +29,7 @@ module Account
     end
 
     def history
-      @holds = current_member.inactive_holds.recent_first.includes(:item)
+      @pagy, @holds = pagy(current_member.inactive_holds.recent_first.includes(:item))
     end
   end
 end

--- a/app/views/account/holds/history.html.erb
+++ b/app/views/account/holds/history.html.erb
@@ -34,7 +34,7 @@
             </li>
           <% end %>
         </ul>
-
+        <%== pagy_bootstrap_nav(@pagy) %>
       <% else %>
         <%= empty_state "You have put no items on hold" %>
       <% end %>

--- a/test/system/holds_test.rb
+++ b/test/system/holds_test.rb
@@ -113,4 +113,24 @@ class HoldsTest < ApplicationSystemTestCase
     assert_text @item.complete_number
     assert_text @item.name
   end
+
+  test "hold history only shows inactive holds" do
+    login_as @member.user
+
+    @started_hold_item = create(:item)
+    @expired_hold_item = create(:item)
+    @ended_hold_item = create(:item)
+
+    @started_hold = create(:started_hold, member: @member, item: @started_hold_item)
+    @expired_hold = create(:expired_hold, member: @member, item: @expired_hold_item)
+    @ended_hold = create(:ended_hold, member: @member, item: @ended_hold_item)
+
+    visit history_account_holds_path
+    refute_text @started_hold.item.name
+    refute_text @started_hold.item.complete_number
+    assert_text @expired_hold.item.name
+    assert_text @expired_hold.item.complete_number
+    assert_text @ended_hold.item.name
+    assert_text @ended_hold.item.complete_number
+  end
 end


### PR DESCRIPTION
# What it does

Adds pagination to the accounts hold history page.

# Why it is important

This will prevent long page load times for long time users. See #1475. 

# UI Change Screenshot

![Screenshot 2024-05-12 at 3 01 48 AM](https://github.com/chicago-tool-library/circulate/assets/3209502/eb00ed9d-0f97-44c6-b9fe-4c681fa00a14)

# Implementation notes

I wasn't sure how many holds should be shown on each page, so I just left it as the pagy default. 

The test I added might be considered redundant, but I figured I'd leave it in for now. It technically doesn't test the pagination functionality itself. I'm happy to make it do so, but I decided to hold off after I couldn't find a similar test for the other uses of pagy in the app.

I also left a small change in the Gemfile.lock regarding the installation of Nokogiri on laptops like mine. 
