### PR TITLE
Added filtering by role to the users index page for admins

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -575,6 +577,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,18 +4,7 @@ module Admin
     before_action :require_admin
 
     def index
-      users_query = User.by_creation_date.all
-
-      @users = case params[:filter]
-      when "admin"
-        users_query.admin
-      when "staff"
-        users_query.staff
-      when "members"
-        users_query.member
-      else
-        users_query
-      end
+      @users = users_index_query
     end
 
     def show
@@ -62,6 +51,21 @@ module Admin
       parameters = params.require(:user).permit(:email, :role)
       parameters.delete("role") unless current_user.has_role?(params.dig("user", "role"))
       parameters
+    end
+
+    def users_index_query
+      users_query = User.by_creation_date.all
+
+      case params[:filter]
+      when "admin"
+        users_query.admin
+      when "staff"
+        users_query.staff
+      when "members"
+        users_query.member
+      else
+        users_query
+      end
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,18 @@ module Admin
     before_action :require_admin
 
     def index
-      @users = User.by_creation_date.all
+      users_query = User.by_creation_date.all
+
+      @users = case params[:filter]
+      when "admin"
+        users_query.admin
+      when "staff"
+        users_query.staff
+      when "members"
+        users_query.member
+      else
+        users_query
+      end
     end
 
     def show

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,6 +4,24 @@
   <% end %>
 <% end %>
 
+<div class="sort-controls">
+  showing:
+  <div class="btn-group">
+    <%= link_to_unless params[:filter].blank?, "All Users", {}, class: "btn btn-sm" do %>
+      <span class="btn btn-sm active">All Users</span>
+    <% end %>
+    <%= link_to_unless params[:filter] == "admin", "Admin Only", {filter: "admin"}, class: "btn btn-sm" do %>
+      <span class="btn btn-sm active">Admin Only</span>
+    <% end %>
+    <%= link_to_unless params[:filter] == "staff", "Staff Only", {filter: "staff"}, class: "btn btn-sm" do %>
+      <span class="btn btn-sm active">Staff Only</span>
+    <% end %>
+    <%= link_to_unless params[:filter] == "members", "Members Only", {filter: "members"}, class: "btn btn-sm" do %>
+      <span class="btn btn-sm active">Members Only</span>
+    <% end %>
+  </div>
+</div>
+
 <table class="table">
   <thead>
     <tr>

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -5,6 +5,14 @@ FactoryBot.define do
     email
     password { "password" }
 
+    factory :member_user do
+      role { "member" }
+    end
+
+    factory :staff_user do
+      role { "staff" }
+    end
+
     factory :admin_user do
       role { "admin" }
     end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -7,10 +7,40 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test "visiting the index" do
-    create(:user)
+    member_user = create(:member_user)
+    staff_user = create(:staff_user)
+    admin_user = create(:admin_user)
 
     visit admin_users_url
     assert_selector "h1", text: "Users"
+
+    assert_text member_user.email
+    assert_text staff_user.email
+    assert_text admin_user.email
+
+    click_on "Admin Only"
+
+    refute_text member_user.email
+    refute_text staff_user.email
+    assert_text admin_user.email
+
+    click_on "Staff Only"
+
+    refute_text member_user.email
+    assert_text staff_user.email
+    refute_text admin_user.email
+
+    click_on "Members Only"
+
+    assert_text member_user.email
+    refute_text staff_user.email
+    refute_text admin_user.email
+
+    click_on "All Users"
+
+    assert_text member_user.email
+    assert_text staff_user.email
+    assert_text admin_user.email
   end
 
   test "creating a user" do


### PR DESCRIPTION
# What it does

These changes allow admin users to filter the users index page in the admin interface by role. By default they'll see all users, but they can choose admin only, staff only, or members only.

# Why it is important

This should make some admin tasks easier when it comes to users. See #1251 for more. 

# UI Change Screenshot

With the members only filter active:
<img width="1102" alt="Screenshot 2024-05-15 at 9 46 00 PM" src="https://github.com/chicago-tool-library/circulate/assets/3209502/782275f2-4f99-413f-b750-19f8cef797eb">

With the admin only filter active:
<img width="1096" alt="Screenshot 2024-05-15 at 9 45 41 PM" src="https://github.com/chicago-tool-library/circulate/assets/3209502/07985dce-424e-4603-861d-28ceea5d99f7">

With no filters active (ie all users):
<img width="1161" alt="Screenshot 2024-05-15 at 9 45 29 PM" src="https://github.com/chicago-tool-library/circulate/assets/3209502/1bcec054-0188-4326-a123-e00fae7a99f9">

# Implementation notes

The card didn't specifically mention being able to filter by the member role but I included it anyway. ~~Not sure if pagination or sorting would be helpful here as well.~~ I just went through the pagination card for this page (#1496).
