### PR TITLE
Added pagination to the admin users index page under settings

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,10 +1,12 @@
 module Admin
   class UsersController < BaseController
+    include Pagy::Backend
+
     before_action :set_user, only: [:show, :edit, :update, :destroy]
     before_action :require_admin
 
     def index
-      @users = users_index_query
+      @pagy, @users = pagy(User.by_creation_date.all)
     end
 
     def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :require_admin
 
     def index
-      @pagy, @users = pagy(User.by_creation_date.all)
+      @pagy, @users = pagy(users_index_query)
     end
 
     def show

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -45,4 +45,6 @@
   </tbody>
 </table>
 
+<%== pagy_bootstrap_nav(@pagy) %>
+
 <br>


### PR DESCRIPTION
# What it does

Adds pagination with pagy to the users index page under settings.

# Why it is important

Currently this page takes just over 2 seconds to load so this should speed things up significantly. See #1249 for more.

# UI Change Screenshot
![Screenshot 2024-05-16 at 10 55 35 AM](https://github.com/chicago-tool-library/circulate/assets/3209502/ac13834f-d733-4909-84c2-8ca4f3f4f9cd)



# Implementation notes

Just as basic a pagy implementation as I could manage. I also worked on #1495 which involves filtering this same page. Once one of these is merged it might take a little work on the other to make sure the filters and pagination don't cause any issues with one another, which I'm happy to take care of. Alternatively, these two could be combined? Depends on how useful one is without the other.
