### PR TITLE
Tweak appointment required language

### DIFF
--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -95,7 +95,7 @@
       <div class="rule-list">
         <h3>How do appointments work?</h3>
         <ul>
-          <li>Currently, all library members need to make an appointment anytime they want to pick up or drop off items.</li>
+          <li>We encourage all library members to make an appointment anytime they want to pick up or drop off items.</li>
           <li>When you create an appointment, all of your Holds that you are eligible to borrow will be available for you select to add to your pick ups.  Similarly, items that you have already borrowed will be available for you to select to return.</li>
           <li>Use the "Modify Appointment" button if you need to change an appointment by adding or removing items, moving it to a new date/time, or canceling it altogether.</li>
           <li>Please let us know in the notes what you're working on so we can make sure you get the best tool we have for the task and also whether the tools you're returning worked as expected.</li>


### PR DESCRIPTION
# What it does

Updates language on appointments page to indicate that appointments are encouraged but not required.

# Why it is important

Reflects reality! According to our librarians "we love when ppl make appointments but its not required anymore."