### PR TITLE
Consolidate setup and reset scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,13 +139,13 @@ jobs:
         PGPORT: ${{ job.services.postgres.ports[5432] }}
       run: ./bin/setup
 
-    - name: Run bin/reset script
+    - name: Run bin/setup script again
       env:
         PGHOST: localhost
         PGUSER: postgres
         PGPASSWORD: postgres
         PGPORT: ${{ job.services.postgres.ports[5432] }}
-      run: ./bin/reset
+      run: ./bin/setup
 
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If `.env.local` doesn't exist in your project directory yet, you will need to cr
 
 ### Resetting the application
 
-During development, you can reset the database to the initial state by running `bin/reset`. This will delete any changes you have made to the database!
+During development, you can reset the database to the initial state by running `bin/setup`. This will delete any changes you have made to the database!
 
 This can be useful if you need to run through a certain scenario multiple times manually, or when switching branches to get back into a known good state.
 
@@ -249,7 +249,7 @@ Circulate leans heavily on a handful of open source frameworks and libraries, th
 
 ### Who to log in as
 
-During development, you will probably want to log into the app as various users (e.g. an admin or a member). [seeds.rb](https://github.com/rubyforgood/circulate/blob/main/db/seeds.rb) creates a set of user accounts when `bin/setup` or `bin/reset` are run. They are:
+During development, you will probably want to log into the app as various users (e.g. an admin or a member). [seeds.rb](https://github.com/rubyforgood/circulate/blob/main/db/seeds.rb) creates a set of user accounts when `bin/setup` are run. They are:
 - Admin `admin@example.com`
 - Verified member `verified_member@example.com`
 - New member `new_member@example.com`

--- a/bin/reset
+++ b/bin/reset
@@ -1,31 +1,9 @@
 #!/usr/bin/env ruby
-require 'fileutils'
 
-# path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+puts <<~WARNING
+    !!! WARNING !!!
+    bin/reset is deprecated and will be removed! Please use bin/setup to reset your environment.
+WARNING
+puts
 
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
-end
-
-FileUtils.chdir APP_ROOT do
-  # This script resets the application to a stable state for development
-
-  puts '== Drop db connections =='
-  system! 'bin/rails db:close_connections'
-
-  puts '== Database reset =='
-  system! 'bin/rails db:reset'
-
-  puts "\n== Loading dev data =="
-  system! 'bin/rails devdata:load'
-
-  puts "\n== Creating loans and holds =="
-  system! 'bin/rails devdata:create_loans_and_holds'
-
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
-
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
-end
+load File.expand_path('setup', File.dirname(__FILE__))

--- a/bin/setup
+++ b/bin/setup
@@ -14,23 +14,23 @@ FileUtils.chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   puts "== Installing dependencies =="
-  system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
+  puts '== Drop db connections =='
+  system! 'bin/rails db:close_connections'
 
-  puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+  puts '== Database reset =='
+  system! 'bin/rails db:reset'
 
   puts "\n== Loading dev data =="
-  system! "bin/rails devdata:load"
+  system! 'bin/rails devdata:load'
+
+  puts "\n== Creating loans and holds =="
+  system! 'bin/rails devdata:create_loans_and_holds'
 
   puts "\n== Removing old logs and tempfiles =="
-  system! "bin/rails log:clear tmp:clear"
+  system! 'bin/rails log:clear tmp:clear'
 
   puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+  system! 'bin/rails restart'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,7 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 
     # Hardcoding this value (the value of which is "password") means that user sessions aren't invalidated when running
-    # bin/reset and you won't have to log in again.
+    # bin/setup and you won't have to log in again.
     User.update_all(encrypted_password: "$2a$11$7iZBpCm6HGkC0B4fSbJCCen2IalyVwtDraM249IArh36CSQyqXuOa")
 
     Time.use_zone "America/Chicago" do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,5 +2,9 @@ namespace :db do
   desc "Closes all other connections to the database"
   task close_connections: :environment do
     ActiveRecord::Base.connection.select_all "select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where datname='circulate_development' AND state='idle';"
+    puts "Connections dropped."
+  rescue ActiveRecord::NoDatabaseError
+    puts "Skipping; no database found!"
+    # fail silently; there's no database to close connections to.
   end
 end


### PR DESCRIPTION
# What it does

Combines `bin/reset` and `bin/setup` into a single idempotent script. `setup` is the default Rails one, and they were minimally different. This way, it's always the same command to get to a workable baseline.

Fixes #1487.