### PR TITLE
Fix loan history link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
     resources :items do
       scope module: "items" do
         resources :attachments
+        resource :loan_history, only: :show
         resource :history, only: :show
         resources :holds, only: :index do
           scope module: "holds" do
@@ -96,7 +97,6 @@ Rails.application.routes.draw do
 
       get :number
       resource :image, only: [:edit, :update]
-      resource :loan_history, only: :show
       # resource :manual_import, only: [:edit, :update]
     end
     resources :loan_summaries, only: :index


### PR DESCRIPTION

# What it does

Fixes https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/3132

# Why it is important

It's a bug! 🐛 

# Implementation notes

It was updated in https://github.com/chicago-tool-library/circulate/commit/c588831d07486a30e12f2cee37d007b5a6d51573

But then it was accidentally moved back in https://github.com/chicago-tool-library/circulate/commit/16ab700e3ed9a6c01853711bc8689add6dfc2ec2#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5L82-R99

