### PR TITLE
Create Notifications whenever Devise sends an email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,19 +2,13 @@ class UserMailer < Devise::Mailer
   default from: "Chicago Tool Library <team@chicagotoollibrary.org>"
   after_action :store_notification
 
-  def reset_password_instructions(record, token, opts = {})
-    @user = record
-    @subject = "You requested a password reset"
-    super
-  end
-
   def store_notification
     Notification.create!(
-      member: @user.member,
-      uuid: SecureRandom.uuid,
       action: action_name,
       address: @user.email,
-      subject: @subject.presence || mail.subject
+      member: @user.member,
+      subject: mail.subject,
+      uuid: SecureRandom.uuid
     )
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 class UserMailer < Devise::Mailer
   default from: "Chicago Tool Library <team@chicagotoollibrary.org>"
-  after_action :store_notification, only: [:reset_password_instructions]
+  after_action :store_notification
 
   def reset_password_instructions(record, token, opts = {})
     @user = record
@@ -9,6 +9,12 @@ class UserMailer < Devise::Mailer
   end
 
   def store_notification
-    Notification.create!(member: @user.member, uuid: SecureRandom.uuid, action: action_name, address: @user.email, subject: @subject)
+    Notification.create!(
+      member: @user.member,
+      uuid: SecureRandom.uuid,
+      action: action_name,
+      address: @user.email,
+      subject: @subject.presence || mail.subject
+    )
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -20,4 +20,26 @@ class UserMailerTest < ActionMailer::TestCase
     assert_includes mail.html_part.body.to_s, expected_link, "mail should include reset link in html part"
     assert_includes mail.text_part.body.to_s, expected_link, "mail should include reset link in text part"
   end
+
+  test "stores a notification whenever it sends an email" do
+    user = create(:user)
+
+    assert_equal Notification.count, 0
+
+    user.send_reset_password_instructions
+
+    assert_equal Notification.count, 1
+
+    user.send_email_changed_notification
+
+    assert_equal Notification.count, 2
+
+    subjects = ActionMailer::Base.deliveries.map(&:subject)
+    assert_includes subjects, "Reset password instructions"
+    assert_includes subjects, "Email Changed"
+
+    actions = Notification.pluck(:action)
+    assert_includes actions, "reset_password_instructions"
+    assert_includes actions, "email_changed"
+  end
 end


### PR DESCRIPTION
# What it does

This creates `Notification`s whenever the Devise mailer is used (`UserMailer`). It uses the set `@subject` when present and falls back to the mail object's subject.

# Why it is important

This takes care of [#1542](https://github.com/chicago-tool-library/circulate/issues/1542) (this was a draft issue when I started so I converted it into an issue).

# UI Change Screenshot

Nothing much to see here.

# Implementation notes

I used the `@subject` instance variable as the default but fell back to `mail.subject` because the emails that are not overridden lack `@subject`. 

When I was first looking at this I assumed that Devise or Rails just automatically picked up on `@subject` and used that as the email's subject line but that doesn't seem to be the case. The email's actual subject in this case is "Reset password instructions" and `@subject` is only used for the `Notification`. Not calling this out because it's wrong or anything, it just confused me for a moment so I wonder if maybe there's a better name or if the original intent was for `@subject` to be the email's subject line.
