### PR TITLE
Staff can create holds or loans for members even if that member has overdue loans

### DIFF
--- a/app/views/admin/members/_lookup.html.erb
+++ b/app/views/admin/members/_lookup.html.erb
@@ -1,15 +1,6 @@
 <div class="columns member-lookup-items">
   <div class="column col-12">
     <h2 id="checkout" class="h4">Lend or Hold Item</h2>
-    <% if member.loan_summaries.overdue.count > 0 %>
-      <div class="toast">
-        <p>
-          <i class="icon icon-stop"></i>
-            Overdue items must be returned before additional items can be checked out or on hold.
-          </p>
-      </div>
-    <% else %>
-      <%= render partial: "admin/members/lookups/form" %>
-    <% end %>
+    <%= render partial: "admin/members/lookups/form" %>
   </div>
 </div>

--- a/test/system/admin/check_in_check_out_test.rb
+++ b/test/system/admin/check_in_check_out_test.rb
@@ -76,7 +76,8 @@ class CheckInCheckOutTest < ApplicationSystemTestCase
     assert_text "currently on loan"
   end
 
-  test "can't check out item to member with overdue item" do
+  test "can check out item to member with overdue item" do
+    @item = create(:item)
     @overdue_item = create(:item)
     @member = create(:verified_member_with_membership)
 
@@ -89,10 +90,10 @@ class CheckInCheckOutTest < ApplicationSystemTestCase
       assert_text "Overdue"
     end
 
-    assert_text "Overdue items must be returned"
-
     within ".member-lookup-items" do
-      refute_selector "input"
+      fill_in :admin_lookup_item_number, with: @item.number
+      click_on "Lookup"
+      assert_button "Lend", disabled: false
     end
   end
 

--- a/test/system/admin/holds_test.rb
+++ b/test/system/admin/holds_test.rb
@@ -115,7 +115,8 @@ class HoldsTest < ApplicationSystemTestCase
     assert_text @member.preferred_name
   end
 
-  test "can't reserve an item for member with overdue item" do
+  test "can reserve an item for member with overdue item" do
+    @item = create(:item)
     @overdue_item = create(:item)
     @member = create(:verified_member_with_membership)
 
@@ -123,10 +124,10 @@ class HoldsTest < ApplicationSystemTestCase
 
     visit admin_member_holds_url(@member)
 
-    assert_text "Overdue items must be returned"
-
     within ".member-lookup-items" do
-      refute_selector "input"
+      fill_in :admin_lookup_item_number, with: @item.number
+      click_on "Lookup"
+      assert_button "Hold", disabled: false
     end
   end
 

--- a/test/system/admin/members_test.rb
+++ b/test/system/admin/members_test.rb
@@ -35,14 +35,4 @@ class Admin::MembersTest < ApplicationSystemTestCase
     assert_content "he/him"
     assert_no_content "she/her"
   end
-
-  test "staff can lookup regardless of a member's overdue loans" do
-    @user.update!(role: :staff)
-
-    create(:overdue_loan, member: @member)
-
-    visit admin_member_url(@member)
-
-    assert_content "Lookup"
-  end
 end

--- a/test/system/admin/members_test.rb
+++ b/test/system/admin/members_test.rb
@@ -35,4 +35,14 @@ class Admin::MembersTest < ApplicationSystemTestCase
     assert_content "he/him"
     assert_no_content "she/her"
   end
+
+  test "staff can lookup regardless of a member's overdue loans" do
+    @user.update!(role: :staff)
+
+    create(:overdue_loan, member: @member)
+
+    visit admin_member_url(@member)
+
+    assert_content "Lookup"
+  end
 end


### PR DESCRIPTION
# What it does

This allows anyone with staff/admin access to create a hold or a loan for a member that already has an overdue loan. It removes a check that prevented this.

# Why it is important

It addresses [#665](https://github.com/chicago-tool-library/circulate/issues/665) by removing a roadblock for staff.

# UI Change Screenshot
Before this change, staff would see this toast message regarding the overdue loan.

![Screenshot 2024-06-13 at 11 26 32 AM](https://github.com/chicago-tool-library/circulate/assets/3209502/2f1290c7-d435-4268-9372-805efd73938a)

After this change, staff will see the usual item "Lend or Hold Item" form.

![Screenshot 2024-06-13 at 11 26 14 AM](https://github.com/chicago-tool-library/circulate/assets/3209502/6f6032a5-2651-4730-849e-20998c1cb8c9)

# Implementation notes

I just exposed the form in the HTML and didn't have to change any validations or controller checks.
