### PR TITLE
Log the user id when available during the sign up flow

### DIFF
--- a/app/controllers/signup/base_controller.rb
+++ b/app/controllers/signup/base_controller.rb
@@ -3,6 +3,8 @@ module Signup
     before_action :load_steps
     before_action :set_page_title
 
+    attr_reader :member
+
     layout "steps"
 
     def is_membership_enabled?

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Set a few custom parameters on log lines
   config.lograge.custom_payload do |controller|
     {
-      user_id: controller.current_user.try(:id),
+      user_id: controller.current_user.try(:id) || controller.try(:member).try(:user).try(:id),
       request_id: controller.request.request_id
     }
   end


### PR DESCRIPTION
# What it does

This adds the user_id to lograge during the signup process by falling back to the `user` associated with the controller's `member` (if member is defined).

# Why it is important

This addresses [#1546](https://github.com/chicago-tool-library/circulate/issues/1546).

# UI Change Screenshot

It's small, but you can see the `user_id` is `17` in the picture for the `/signup/documents/agreement` path.

![Screenshot 2024-06-14 at 5 01 14 PM](https://github.com/chicago-tool-library/circulate/assets/3209502/455a0b2d-0d4e-4062-9daf-bd789d053c49)


# Implementation notes

`@member` was being set in the signup controllers so I just added an `attr_reader` for it. I leaned on `try` pretty heavily so controllers that don't implement `member` won't be impacted.
