### PR TITLE
Prevent codescanning warnings by ensuring methods return constant values and not technically user input

### DIFF
--- a/app/controllers/admin/loan_summaries_controller.rb
+++ b/app/controllers/admin/loan_summaries_controller.rb
@@ -13,10 +13,23 @@ module Admin
 
     private
 
+    INDEX_FILTERS = [
+      CHECKED_OUT = "checked_out",
+      OVERDUE = "overdue",
+      RETURNED = "returned"
+    ]
+
     def index_filter
-      allowed = %w[checked_out overdue returned]
-      return params[:filter] if allowed.include? params[:filter]
-      "checked_out"
+      case params[:filter]
+      when CHECKED_OUT
+        CHECKED_OUT
+      when OVERDUE
+        OVERDUE
+      when RETURNED
+        RETURNED
+      else
+        CHECKED_OUT
+      end
     end
   end
 end

--- a/app/controllers/admin/renewal_requests_controller.rb
+++ b/app/controllers/admin/renewal_requests_controller.rb
@@ -33,10 +33,23 @@ module Admin
 
     private
 
+    INDEX_FILTERS = [
+      ALL = "all",
+      REJECTED = "rejected",
+      REQUESTED = "requested"
+    ]
+
     def index_filter
-      allowed = %w[requested rejected all]
-      return params[:filter] if allowed.include? params[:filter]
-      "requested"
+      case params[:filter]
+      when ALL
+        ALL
+      when REJECTED
+        REJECTED
+      when REQUESTED
+        REQUESTED
+      else
+        REQUESTED
+      end
     end
 
     def renewal_request_params


### PR DESCRIPTION
# What it does

Refactors some filtering methods to use `case` statements and constants to so that user input is never technically passed to the `send` method.

# Why it is important

Addresses [#1507](https://github.com/chicago-tool-library/circulate/issues/1507). Even if the code was safe before, it's nice to have less noise.

# UI Change Screenshot

Nothing to see here.

# Implementation notes

I added an `INDEX_FILTERS` constant so all of the values are grouped in an array but nothing uses it. I've seen other patterns for managing constants and kind of just went with this one, but if there's a preferred way to do this I'm happy to make those changes.
