### PR TITLE
Switch to GoodJob for background work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:15
         env:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres

--- a/Gemfile
+++ b/Gemfile
@@ -105,3 +105,5 @@ gem "cssbundling-rails", "~> 1.4"
 gem "twilio-ruby", "~> 7.1"
 
 gem "ahoy_matey", "~> 5.1"
+
+gem "good_job", "~> 3.29"

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem "image_processing", "~> 1.12"
 gem "mini_magick"
 
 gem "barnes"
-gem "sucker_punch"
 gem "dotenv"
 gem "appsignal"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.13.0)
+    et-orbi (1.2.11)
+      tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -216,6 +218,9 @@ GEM
       concurrent-ruby (~> 1.0)
       sync (~> 0.5)
     forwardable (1.3.3)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     gettext (3.4.9)
       erubi
       locale (>= 2.0.5)
@@ -224,6 +229,13 @@ GEM
       text (>= 1.3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    good_job (3.29.3)
+      activejob (>= 6.0.0)
+      activerecord (>= 6.0.0)
+      concurrent-ruby (>= 1.0.2)
+      fugit (>= 1.1)
+      railties (>= 6.0.0)
+      thor (>= 0.14.1)
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
     googleauth (1.11.0)
@@ -377,6 +389,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.2)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.8.0)
     rack (2.2.9)
     rack-protection (3.2.0)
@@ -606,6 +619,7 @@ DEPENDENCIES
   erb_lint (~> 0.5.0)
   factory_bot_rails
   finite_machine
+  good_job (~> 3.29)
   googleauth
   http
   image_processing (~> 1.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,8 +555,6 @@ GEM
       activerecord (>= 5.2)
     stringio (3.1.0)
     strscan (3.1.0)
-    sucker_punch (3.2.0)
-      concurrent-ruby (~> 1.0)
     sync (0.5.0)
     text (1.3.1)
     thor (1.3.1)
@@ -655,7 +653,6 @@ DEPENDENCIES
   standard-rails (~> 1.0.2)
   stimulus-rails
   store_model
-  sucker_punch
   translation
   turbo-rails
   twilio-ruby (~> 7.1)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: jemalloc.sh bundle exec puma -C config/puma.rb
+worker: bundle exec good_job start
 release: rails db:migrate

--- a/app/jobs/neon_member_job.rb
+++ b/app/jobs/neon_member_job.rb
@@ -1,6 +1,4 @@
 class NeonMemberJob < ApplicationJob
-  include SuckerPunch::Job
-
   def perform(member_id)
     member = Member.find(member_id)
     organization_id, api_key = Neon.credentials_for_library(member.library)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -151,7 +151,7 @@ class Member < ApplicationRecord
   end
 
   def update_neon_crm
-    NeonMemberJob.perform_async(id)
+    NeonMemberJob.perform_later(id)
   end
 
   def can_update_neon_crm?

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module Circulate
     config.active_storage.track_variants = true
     config.active_storage.queues.analysis = :active_storage_analysis
     config.active_storage.variant_processor = :vips
-    config.active_job.queue_adapter = :sucker_punch
+    config.active_job.queue_adapter = :good_job
     config.action_dispatch.cookies_same_site_protection = :lax
     config.action_view.form_with_generates_remote_forms = false
     ActiveSupport.utc_to_local_returns_utc_offset_times = false

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,6 @@
+ActsAsTenant.configure do |config|
+  # This is the default, but explicitly making it false because it's required
+  # for images to work
+  # See: https://github.com/ErwinM/acts_as_tenant/issues/330
+  config.require_tenant = false
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,8 @@
+Rails.application.configure do
+  # Send errors to Appsignal
+  config.good_job.on_thread_error = ->(exception) { Appsignal.send_error(exception) }
+
+  # Soon we will transition from Heroku Scheduler to scheduled jobs here
+  config.good_job.enable_cron = ENV["DYNO"] == "worker.1"
+  config.good_job.cron = {}
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,11 @@ Rails.application.routes.draw do
 
   post "/twilio/callback", to: "twilio#callback"
 
+  # Mount good_job dashboard for admins
+  authenticate :user, ->(user) { user.admin? } do
+    mount GoodJob::Engine => "good_job"
+  end
+
   root to: "home#index"
 
   if Rails.env.test?

--- a/db/migrate/20240617233510_create_good_jobs.rb
+++ b/db/migrate/20240617233510_create_good_jobs.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class CreateGoodJobs < ActiveRecord::Migration[7.1]
+  def change
+    # Uncomment for Postgres v12 or earlier to enable gen_random_uuid() support
+    # enable_extension 'pgcrypto'
+
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.timestamps
+
+      t.uuid :active_job_id
+      t.text :concurrency_key
+      t.text :cron_key
+      t.uuid :retried_good_job_id
+      t.datetime :cron_at
+
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+      t.integer :error_event, limit: 2
+      t.text :labels, array: true
+      t.uuid :locked_by_id
+      t.datetime :locked_at
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+      t.integer :error_event, limit: 2
+      t.text :error_backtrace, array: true
+      t.uuid :process_id
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+      t.integer :lock_type, limit: 2
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
+    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)", name: :index_good_jobs_on_cron_key_and_created_at_cond
+    add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+    add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "ASC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup
+    add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL"
+    add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL"
+    add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
+
+    add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at], order: {priority: "ASC NULLS LAST", scheduled_at: :asc},
+      where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    add_index :good_jobs, :locked_by_id,
+      where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
+    add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_045018) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_233510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -327,6 +327,93 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_045018) do
     t.integer "library_id"
     t.index ["library_id", "code"], name: "index_gift_memberships_on_library_id_and_code", unique: true
     t.index ["membership_id"], name: "index_gift_memberships_on_membership_id"
+  end
+
+  create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.jsonb "serialized_properties"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_discard"
+    t.text "callback_queue_name"
+    t.integer "callback_priority"
+    t.datetime "enqueued_at"
+    t.datetime "discarded_at"
+    t.datetime "finished_at"
+  end
+
+  create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id", null: false
+    t.text "job_class"
+    t.text "queue_name"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
+    t.uuid "process_id"
+    t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
+  end
+
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "state"
+    t.integer "lock_type", limit: 2
+  end
+
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "key"
+    t.jsonb "value"
+    t.index ["key"], name: "index_good_job_settings_on_key", unique: true
+  end
+
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id"
+    t.text "concurrency_key"
+    t.text "cron_key"
+    t.uuid "retried_good_job_id"
+    t.datetime "cron_at"
+    t.uuid "batch_id"
+    t.uuid "batch_callback_id"
+    t.boolean "is_discrete"
+    t.integer "executions_count"
+    t.text "job_class"
+    t.integer "error_event", limit: 2
+    t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
+    t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
   create_table "holds", force: :cascade do |t|

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -59,15 +59,19 @@ namespace :devdata do
           load_models BorrowPolicy, id_offset: offset
           load_models Category, id_offset: offset
           load_models Item, id_offset: offset
-          Item.find_each do |item|
-            # create attachment
-            item.image.attach(io: image, filename: "tool-image.jpg")
-            image.rewind
-          end
           load_models ActionText::RichText, id_offset: offset
           load_models ItemPool, id_offset: offset, creator: admin
           load_models ReservableItem, id_offset: offset, creator: admin
         end
+      end
+
+      # Need to do this outside of with_tenant because of bug with tenant
+      # being reset when an ActiveJob is completed inline
+      # See: https://github.com/ErwinM/acts_as_tenant/issues/335
+      Item.find_each do |item|
+        # create attachment
+        item.image.attach(io: image, filename: "tool-image.jpg")
+        image.rewind
       end
     end
   end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -185,7 +185,7 @@ class MemberTest < ActiveSupport::TestCase
     mock = Minitest::Mock.new
     mock.expect :call, true, [Integer]
 
-    NeonMemberJob.stub :perform_async, mock do
+    NeonMemberJob.stub :perform_later, mock do
       member.stub :can_update_neon_crm?, true do
         member.update(city: "#{member.city} Test")
       end


### PR DESCRIPTION
# What it does

* Switches job system from [Sucker Punch](https://github.com/brandonhilkert/sucker_punch) to [GoodJob](https://github.com/bensheldon/good_job)

# Why it is important

* GoodJob gives us a few implementation benefits over Sucker Punch
  - It's Postgres-backed, so in-flight jobs won't be lost on server restart
  - It can be configured with an external worker, which will reduce memory pressure on the web dyno
  - It includes scheduled job features, which will let us migrate from Heroku Scheduler to jobs defined in code
  - It includes a dashboard we can use to debug potential issues with background jobs

# Implementation notes

* We will now have a persistent worker dyno running in both staging and production, which will add $14/mo ($168/yr) to our hosting costs. Initial discussion amongst the team has concluded this is a worthwhile tradeoff for the above benefits.
* The Heroku Scheduler to GoodJob Cron conversion will come in a future PR, assuming this transition goes well.
