### PR TITLE
Install Blazer for custom analytics dashboards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,5 @@ gem "twilio-ruby", "~> 7.1"
 gem "ahoy_matey", "~> 5.1"
 
 gem "good_job", "~> 3.29"
+
+gem "blazer", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,12 @@ GEM
       smart_properties
     bigdecimal (3.1.8)
     bindex (0.8.1)
+    blazer (3.0.3)
+      activerecord (>= 6.1)
+      chartkick (>= 5)
+      csv
+      railties (>= 6.1)
+      safely_block (>= 0.4)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
@@ -157,6 +163,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     certifi (2018.01.18)
+    chartkick (5.0.7)
     childprocess (5.0.0)
     chronic (0.10.2)
     concurrent-ruby (1.3.3)
@@ -164,6 +171,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     device_detector (1.1.2)
     devise (4.9.4)
@@ -607,6 +615,7 @@ DEPENDENCIES
   audited
   aws-sdk-s3
   barnes
+  blazer (~> 3.0)
   bootsnap (>= 1.4.1)
   byebug
   capybara (>= 2.15)

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -1,0 +1,79 @@
+# see https://github.com/ankane/blazer for more info
+
+data_sources:
+  main:
+    url: <%= ENV["BLAZER_DATABASE_URL"] %>
+
+    # statement timeout, in seconds
+    # none by default
+    # timeout: 15
+
+    # caching settings
+    # can greatly improve speed
+    # off by default
+    # cache:
+    #   mode: slow # or all
+    #   expires_in: 60 # min
+    #   slow_threshold: 15 # sec, only used in slow mode
+
+    # wrap queries in a transaction for safety
+    # not necessary if you use a read-only user
+    # true by default
+    # use_transaction: false
+
+    smart_variables:
+      # zone_id: "SELECT id, name FROM zones ORDER BY name ASC"
+      # period: ["day", "week", "month"]
+      # status: {0: "Active", 1: "Archived"}
+
+    linked_columns:
+      # user_id: "/admin/users/{value}"
+
+    smart_columns:
+      # user_id: "SELECT id, name FROM users WHERE id IN {value}"
+
+# create audits
+audit: true
+
+# change the time zone
+# time_zone: "Pacific Time (US & Canada)"
+
+# class name of the user model
+# user_class: User
+
+# method name for the current user
+# user_method: current_user
+
+# method name for the display name
+# user_name: name
+
+# custom before_action to use for auth
+# before_action_method: require_admin
+
+# email to send checks from
+# from_email: blazer@example.org
+
+# webhook for Slack
+# slack_webhook_url: <%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
+
+check_schedules:
+  - "1 day"
+  - "1 hour"
+  - "5 minutes"
+
+# enable anomaly detection
+# note: with trend, time series are sent to https://trendapi.org
+# anomaly_checks: prophet / trend / anomaly_detection
+
+# enable forecasting
+# note: with trend, time series are sent to https://trendapi.org
+# forecasting: prophet / trend
+
+# enable map
+# mapbox_access_token: <%= ENV["MAPBOX_ACCESS_TOKEN"] %>
+
+# enable uploads
+# uploads:
+#   url: <%= ENV["BLAZER_UPLOADS_URL"] %>
+#   schema: uploads
+#   data_source: main

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,9 +206,10 @@ Rails.application.routes.draw do
 
   post "/twilio/callback", to: "twilio#callback"
 
-  # Mount good_job dashboard for admins
+  # Mount dashboards for admins
   authenticate :user, ->(user) { user.admin? } do
     mount GoodJob::Engine => "good_job"
+    mount Blazer::Engine => "blazer"
   end
 
   root to: "home#index"

--- a/db/migrate/20240625154800_install_blazer.rb
+++ b/db/migrate/20240625154800_install_blazer.rb
@@ -1,0 +1,47 @@
+class InstallBlazer < ActiveRecord::Migration[7.1]
+  def change
+    create_table :blazer_queries do |t|
+      t.references :creator
+      t.string :name
+      t.text :description
+      t.text :statement
+      t.string :data_source
+      t.string :status
+      t.timestamps null: false
+    end
+
+    create_table :blazer_audits do |t|
+      t.references :user
+      t.references :query
+      t.text :statement
+      t.string :data_source
+      t.datetime :created_at
+    end
+
+    create_table :blazer_dashboards do |t|
+      t.references :creator
+      t.string :name
+      t.timestamps null: false
+    end
+
+    create_table :blazer_dashboard_queries do |t|
+      t.references :dashboard
+      t.references :query
+      t.integer :position
+      t.timestamps null: false
+    end
+
+    create_table :blazer_checks do |t|
+      t.references :creator
+      t.references :query
+      t.string :state
+      t.string :schedule
+      t.text :emails
+      t.text :slack_channels
+      t.string :check_type
+      t.text :message
+      t.datetime :last_run_at
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_233510) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_154800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -245,6 +245,62 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_233510) do
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
+  end
+
+  create_table "blazer_audits", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "query_id"
+    t.text "statement"
+    t.string "data_source"
+    t.datetime "created_at"
+    t.index ["query_id"], name: "index_blazer_audits_on_query_id"
+    t.index ["user_id"], name: "index_blazer_audits_on_user_id"
+  end
+
+  create_table "blazer_checks", force: :cascade do |t|
+    t.bigint "creator_id"
+    t.bigint "query_id"
+    t.string "state"
+    t.string "schedule"
+    t.text "emails"
+    t.text "slack_channels"
+    t.string "check_type"
+    t.text "message"
+    t.datetime "last_run_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_checks_on_creator_id"
+    t.index ["query_id"], name: "index_blazer_checks_on_query_id"
+  end
+
+  create_table "blazer_dashboard_queries", force: :cascade do |t|
+    t.bigint "dashboard_id"
+    t.bigint "query_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dashboard_id"], name: "index_blazer_dashboard_queries_on_dashboard_id"
+    t.index ["query_id"], name: "index_blazer_dashboard_queries_on_query_id"
+  end
+
+  create_table "blazer_dashboards", force: :cascade do |t|
+    t.bigint "creator_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_dashboards_on_creator_id"
+  end
+
+  create_table "blazer_queries", force: :cascade do |t|
+    t.bigint "creator_id"
+    t.string "name"
+    t.text "description"
+    t.text "statement"
+    t.string "data_source"
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
   end
 
   create_table "borrow_policies", force: :cascade do |t|


### PR DESCRIPTION
# What it does

* Installs the [Blazer](https://github.com/ankane/blazer) gem
* Admins can now visit the Blazer dashboard at `/blazer`

# Why it is important

* Let non-Heroku-admins arbitrarily query the database
* Lets app admins create dashboards
* Opens up ability for us to explore the data we're recording with Ahoy

# UI Change Screenshot

![2024-06-25 at 11 30 01@2x](https://github.com/chicago-tool-library/circulate/assets/37534/3d1557a8-c1ad-4519-8077-e4d122dfba79)

# Implementation notes

* Blazer recommends creating a readonly user for it to use, but our Heroku database plans do not allow us anything beyond the default user, so we'll have to rely on Blazer's transaction wrapping and our own carefulness to avoid losing data.
* Blazer has several other features controlled via its config file that we can explore once we've had a chance to play with it.
