### PR TITLE
Include arm64-darwin-23 in platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,6 +605,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-23
   x86_64-linux
 


### PR DESCRIPTION
# What it does

Adds `arm64-darwin-23` to the list of platforms. I think it corresponds to macOS 14.x (which is what is on my laptop).

# Why it is important

This line keeps getting added to `Gemfile.lock` whenever I install the dependencies for the app.