### PR TITLE
More attempts to fix InvalidAuthenticityToken issues

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,6 +1,24 @@
 default: &defaults
   push_api_key: "<%= ENV["APPSIGNAL_PUSH_API_KEY"] %>"
   name: "Circulate"
+  request_headers:
+    - HTTP_ACCEPT
+    - HTTP_ACCEPT_CHARSET
+    - HTTP_ACCEPT_ENCODING
+    - HTTP_ACCEPT_LANGUAGE
+    - HTTP_CACHE_CONTROL
+    - HTTP_CONNECTION
+    - CONTENT_LENGTH
+    - PATH_INFO
+    - HTTP_RANGE
+    - REQUEST_METHOD
+    - REQUEST_PATH
+    - SERVER_NAME
+    - SERVER_PORT
+    - SERVER_PROTOCOL
+    # The above are the default. The following is to help us narrow down if
+    # only certain clients are encountering InvalidAuthenticityToken errors.
+    - HTTP_USER_AGENT
 
   # Errors that should not be recorded by AppSignal
   # For more information see our docs:


### PR DESCRIPTION
# What it does

1. Configures AppSignal to track the `USER_AGENT` header so we know if the issue affect only certain clients. Mobile Safari is a mentioned a lot in the prior art here, but we don't know if our problems also match that pattern.
2. Handle InvalidAuthenticityToken errors by redirecting folks back to where they came from and asking them to try again. In theory this will help if it turns out that folks are hitting this issue by using a cached page that's lost its session, although I think the work done in #1478 should have fixed that.

I couldn't figure out how to succinctly trigger an `InvalidAuthenticityToken` in a controller test, but this code should only affect folks who have already hit an error anyway.