### PR TITLE
Added a review notes tab to the reservation show page

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -4,12 +4,12 @@ body.admin {
   }
 
   table .table-stripe {
-    background: rgba(255,255,255,.7);
+    background: rgba(255, 255, 255, 0.7);
   }
 
   .admin-search-form {
     margin-top: 0.6rem;
-  } 
+  }
 
   .off-canvas-sidebar .nav-item {
     margin-top: 0.2rem;
@@ -25,7 +25,7 @@ body.admin {
     }
   }
 
- .app-header {
+  .app-header {
     background: $primary-color;
     color: white;
     padding-top: 1rem;
@@ -37,7 +37,7 @@ body.admin {
       padding-bottom: 0;
     }
     ul.breadcrumb {
-      margin: -.3rem 0 0 0;
+      margin: -0.3rem 0 0 0;
       padding: 0;
       a {
         color: white;
@@ -45,7 +45,8 @@ body.admin {
       .breadcrumb-item {
         padding-right: 0.2rem;
       }
-      .breadcrumb-item:not(:first-child)::before, .breadcrumb-item {
+      .breadcrumb-item:not(:first-child)::before,
+      .breadcrumb-item {
         color: white;
       }
       .breadcrumb-item:last-child::after {
@@ -71,32 +72,33 @@ body.admin {
       padding-bottom: 0;
     }
   }
+
+  .reservation-review {
+    padding: 1rem 0;
+  }
 }
 
-  .admin-dashboard {
-    dl {
-    }
-    .pair {
-      width: 19%;
-      display: inline-block;
-    }
-    dt {
-    }
-    dd {
-      font-size: 3rem;
-      line-height: 1;
-      font-weight: 300;
-      margin-top: 0;
-    }
+.admin-dashboard {
+  .pair {
+    width: 19%;
+    display: inline-block;
   }
+
+  dd {
+    font-size: 3rem;
+    line-height: 1;
+    font-weight: 300;
+    margin-top: 0;
+  }
+}
 
 .member-notes {
   .note {
     position: relative;
     .edit-button {
       position: absolute;
-      bottom: .4rem;
-      right: .4rem;
+      bottom: 0.4rem;
+      right: 0.4rem;
     }
   }
 }
@@ -113,5 +115,5 @@ body.admin {
 
 .ticket-edit-button {
   padding-left: 1rem;
-  padding-top: .3rem;
+  padding-top: 0.3rem;
 }

--- a/app/views/admin/reservations/_profile.html.erb
+++ b/app/views/admin/reservations/_profile.html.erb
@@ -42,13 +42,14 @@
   <div class="column col-sm-12 col-8">
 
     <% if Reservation.statuses.values_at(:requested, :approved, :building).include?(@reservation.status) %>
-      <%= render partial: "reservation_policies_warnings", locals: {reservation: @reservation} %>
+      <%= render partial: "admin/reservations/reservation_policies_warnings", locals: {reservation: @reservation} %>
     <% end %>
 
     <ul class="tab">
       <%= tab_link "Items", admin_reservation_path(@reservation) %>
       <%= tab_link "Pickup", admin_reservation_pickup_path(@reservation) %>
       <%= tab_link "Questions", admin_reservation_questions_path(@reservation) %>
+      <%= tab_link("Review Notes", admin_reservation_review_path(@reservation)) if @reservation.notes? %>
     </ul>
 
     <%= yield %>

--- a/app/views/admin/reservations/reviews/show.html.erb
+++ b/app/views/admin/reservations/reviews/show.html.erb
@@ -1,0 +1,5 @@
+<%= render "admin/reservations/profile" do %>
+  <p class="reservation-review">
+    <%= @reservation.notes %>
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Rails.application.routes.draw do
           resources :reservation_loans, only: [:create, :destroy]
           resources :reservation_holds
           resource :status, only: :update
-          resource :review, only: [:edit, :update]
+          resource :review, only: [:edit, :update, :show]
           resource :pickup, only: :show
           resource :item_pool_search, only: :show
           resource :questions, only: :show

--- a/test/factories/reservations.rb
+++ b/test/factories/reservations.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     sequence(:name) { |n| "A reservation ##{n}" }
     started_at { Time.current.at_beginning_of_day }
     ended_at { 1.week.since.at_beginning_of_day }
+
+    trait :approved do
+      status { "approved" }
+      notes { "Excited to approve #{name}!" }
+    end
   end
 end

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -56,6 +56,22 @@ class AdminReservationsTest < ApplicationSystemTestCase
     end
   end
 
+  test "viewing a reservation's review notes after review" do
+    reservation = create(:reservation, :approved)
+
+    visit admin_reservation_url(reservation)
+    click_on "Review Notes"
+
+    assert_text reservation.notes
+  end
+
+  test "viewing a reservation's review notes before review" do
+    reservation = create(:reservation, notes: "")
+    visit admin_reservation_url(reservation)
+
+    refute_text "Review Notes"
+  end
+
   test "creating a reservation successfully" do
     visit new_admin_reservation_path
 


### PR DESCRIPTION
# What it does

After a reservation is reviewed (approved or rejected) a tab called "Review Notes" appears that lets admins see the review notes.

# Why it is important

Takes care of #1533 

# UI Change Screenshot

![Screenshot 2024-07-16 at 1 00 50 AM](https://github.com/user-attachments/assets/a6eb9480-ebd8-4044-b929-d2ebb1682fae)

# Implementation notes

My text editor auto-formatted the scss. I can undo that so it's only the class I added, but since the code and the HTML have their own linters the changes seem reasonable to me. 

I continued the pattern for the other tabs on the reservation show page. Feels a little heavy to make a full request just for the review notes, but I think keeping the tab implementations consistent is probably more important. 
