### PR TITLE
Fixes the sort buttons on the items index page when there's a search query

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -101,7 +101,7 @@ class ItemsController < ApplicationController
   end
 
   def apply_order(query)
-    params.delete(:sort) if params[:sort] == "relevancy"
+    params.delete(:sort) if params[:sort] == "relevance"
 
     if params[:sort].blank? && params[:query].present?
       query # we don't need to apply the ordering ourselves since pg_search has already done it

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -114,7 +114,7 @@ class ItemsController < ApplicationController
     options = {
       "name" => "items.name ASC",
       "number" => "items.number ASC",
-      "added" => "items.created_at DESC",
+      "added" => "items.created_at DESC"
     }
     options.fetch(params[:sort]) { options["added"] }
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
     # One of the filtering methods above may have already redirected
     return if performed?
 
-    item_scope = item_scope.with_attached_image.order(index_order)
+    item_scope = item_scope.with_attached_image.reorder(index_order)
 
     set_index_page_title
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -58,8 +58,13 @@
           <%= link_to_unless_current "Number", add_filter_param(:sort, "number"), class: "btn btn-sm" do %>
             <button class="btn btn-sm active">Number</button>
           <% end %>
-          <%= link_to_unless params[:sort] == "added" || params[:sort].blank?, "Date Added", add_filter_param(:sort, "added"), class: "btn btn-sm" do %>
+          <%= link_to_unless params[:sort] == "added" || (params[:sort].blank? && params[:query].blank?), "Date Added", add_filter_param(:sort, "added"), class: "btn btn-sm" do %>
             <button class="btn btn-sm active">Date Added</button>
+          <% end %>
+          <% if params[:query].present? %>
+            <%= link_to_unless params[:sort] == "relevancy" || params[:sort].blank?, "Relevancy", add_filter_param(:sort, "relevancy"), class: "btn btn-sm" do %>
+              <button class="btn btn-sm active">Relevancy</button>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -62,8 +62,8 @@
             <button class="btn btn-sm active">Date Added</button>
           <% end %>
           <% if params[:query].present? %>
-            <%= link_to_unless params[:sort] == "relevancy" || params[:sort].blank?, "Relevancy", add_filter_param(:sort, "relevancy"), class: "btn btn-sm" do %>
-              <button class="btn btn-sm active">Relevancy</button>
+            <%= link_to_unless params[:sort] == "relevance" || params[:sort].blank?, "Relevance", add_filter_param(:sort, "relevance"), class: "btn btn-sm" do %>
+              <button class="btn btn-sm active">Relevance</button>
             <% end %>
           <% end %>
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -52,14 +52,14 @@
       <div>
         <span>Sort by</span>
         <div class="ml-1 btn-group">
-          <%= link_to_unless_current "name", add_filter_param(:sort, "name"), class: "btn btn-sm" do %>
-            <button class="btn btn-sm active">name</button>
+          <%= link_to_unless_current "Name", add_filter_param(:sort, "name"), class: "btn btn-sm" do %>
+            <button class="btn btn-sm active">Name</button>
           <% end %>
-          <%= link_to_unless_current "number", add_filter_param(:sort, "number"), class: "btn btn-sm" do %>
-            <button class="btn btn-sm active">number</button>
+          <%= link_to_unless_current "Number", add_filter_param(:sort, "number"), class: "btn btn-sm" do %>
+            <button class="btn btn-sm active">Number</button>
           <% end %>
-          <%= link_to_unless params[:sort] == "added" || params[:sort].blank?, "added", add_filter_param(:sort, "added"), class: "btn btn-sm" do %>
-            <button class="btn btn-sm active">date added</button>
+          <%= link_to_unless params[:sort] == "added" || params[:sort].blank?, "Date Added", add_filter_param(:sort, "added"), class: "btn btn-sm" do %>
+            <button class="btn btn-sm active">Date Added</button>
           <% end %>
         </div>
       </div>

--- a/test/system/items_sorting_test.rb
+++ b/test/system/items_sorting_test.rb
@@ -1,0 +1,168 @@
+require "application_system_test_case"
+
+class ItemSortingTest < ApplicationSystemTestCase
+  def setup
+    @drill1 = create(:item, name: "Power Rad Drill", brand: "Rad Drill", number: 300, created_at: 2.days.ago)
+    @drill2 = create(:item, name: "Sour Drill Rad", brand: "Rad", number: 500, created_at: 5.days.ago)
+    @drill3 = create(:item, name: "Shower Random Drill", brand: "Shower", number: 200, created_at: 3.days.ago)
+    @saw = create(:item, name: "Tile Rad Saw", number: 1000, created_at: 4.days.ago)
+
+    @member = create(:verified_member_with_membership)
+    @user = @member.user
+
+    login_as @user
+  end
+
+  test "items are ordered by date added when no query or sort are provided" do
+    visit items_url
+
+    assert_selector ".btn.active", text: "Date Added"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 4, item_links.size
+
+    expected_item_names_order = [@drill1, @drill3, @saw, @drill2].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking date added sorts the items by date added" do
+    visit items_url
+    # Have to navigate to a different sort, assert the button changed, then navigate
+    # back since date added is the default sort order
+    click_on "Name"
+
+    assert_selector ".btn.active", text: "Name"
+
+    click_on "Date Added"
+
+    assert_selector ".btn.active", text: "Date Added"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 4, item_links.size
+
+    expected_item_names_order = [@drill1, @drill3, @saw, @drill2].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking name sorts the items by name" do
+    visit items_url
+    click_on "Name"
+
+    assert_selector ".btn.active", text: "Name"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 4, item_links.size
+
+    expected_item_names_order = [@drill1, @drill3, @drill2, @saw].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking number sorts the items by number" do
+    visit items_url
+    click_on "Number"
+
+    assert_selector ".btn.active", text: "Number"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 4, item_links.size
+
+    expected_item_names_order = [@drill3, @drill1, @drill2, @saw].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking date added sorts the items by date added (with a query)" do
+    visit items_url
+    fill_in "search items", with: "dri\n"
+
+    assert_selector ".btn.active", text: "Relevancy"
+
+    click_on "Date Added"
+
+    assert_selector ".btn.active", text: "Date Added"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 3, item_links.size
+
+    expected_item_names_order = [@drill1, @drill3, @drill2].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking name sorts the items by name (with a query)" do
+    visit items_url
+    fill_in "search items", with: "dri\n"
+
+    assert_selector ".btn.active", text: "Relevancy"
+
+    click_on "Name"
+
+    assert_selector ".btn.active", text: "Name"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 3, item_links.size
+
+    expected_item_names_order = [@drill1, @drill3, @drill2].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "clicking number sorts the items by number (with a query)" do
+    visit items_url
+    fill_in "search items", with: "dri\n"
+
+    assert_selector ".btn.active", text: "Relevancy"
+
+    click_on "Number"
+
+    assert_selector ".btn.active", text: "Number"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 3, item_links.size
+
+    expected_item_names_order = [@drill3, @drill1, @drill2].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "there is no relevancy sort button when there is no query" do
+    visit items_url
+
+    refute_text "Relevancy"
+
+    fill_in "search items", with: "Drill\n"
+
+    assert_text "Relevancy"
+  end
+
+  test "items are ordered by relevancy when a query is provided but no sort is provided" do
+    visit items_url
+    fill_in "search items", with: "Ra Drill\n"
+
+    assert_selector ".btn.active", text: "Relevancy"
+
+    item_links = all(".items-table-name a").map(&:text)
+
+    assert_equal 3, item_links.size
+
+    expected_item_names_order = [@drill1, @drill2, @drill3].map(&:name)
+
+    assert_equal expected_item_names_order, item_links
+  end
+
+  test "when there is no query but the sort is still set to relevancy it falls back to its default" do
+    visit items_url sort: "relevancy"
+
+    assert_selector ".btn.active", text: "Date Added"
+  end
+end

--- a/test/system/items_sorting_test.rb
+++ b/test/system/items_sorting_test.rb
@@ -82,7 +82,7 @@ class ItemSortingTest < ApplicationSystemTestCase
     visit items_url
     fill_in "search items", with: "dri\n"
 
-    assert_selector ".btn.active", text: "Relevancy"
+    assert_selector ".btn.active", text: "Relevance"
 
     click_on "Date Added"
 
@@ -101,7 +101,7 @@ class ItemSortingTest < ApplicationSystemTestCase
     visit items_url
     fill_in "search items", with: "dri\n"
 
-    assert_selector ".btn.active", text: "Relevancy"
+    assert_selector ".btn.active", text: "Relevance"
 
     click_on "Name"
 
@@ -120,7 +120,7 @@ class ItemSortingTest < ApplicationSystemTestCase
     visit items_url
     fill_in "search items", with: "dri\n"
 
-    assert_selector ".btn.active", text: "Relevancy"
+    assert_selector ".btn.active", text: "Relevance"
 
     click_on "Number"
 
@@ -135,21 +135,21 @@ class ItemSortingTest < ApplicationSystemTestCase
     assert_equal expected_item_names_order, item_links
   end
 
-  test "there is no relevancy sort button when there is no query" do
+  test "there is no relevance sort button when there is no query" do
     visit items_url
 
-    refute_text "Relevancy"
+    refute_text "Relevance"
 
     fill_in "search items", with: "Drill\n"
 
-    assert_text "Relevancy"
+    assert_text "Relevance"
   end
 
-  test "items are ordered by relevancy when a query is provided but no sort is provided" do
+  test "items are ordered by relevance when a query is provided but no sort is provided" do
     visit items_url
     fill_in "search items", with: "Ra Drill\n"
 
-    assert_selector ".btn.active", text: "Relevancy"
+    assert_selector ".btn.active", text: "Relevance"
 
     item_links = all(".items-table-name a").map(&:text)
 
@@ -160,8 +160,8 @@ class ItemSortingTest < ApplicationSystemTestCase
     assert_equal expected_item_names_order, item_links
   end
 
-  test "when there is no query but the sort is still set to relevancy it falls back to its default" do
-    visit items_url sort: "relevancy"
+  test "when there is no query but the sort is still set to relevance it falls back to its default" do
+    visit items_url sort: "relevance"
 
     assert_selector ".btn.active", text: "Date Added"
   end


### PR DESCRIPTION
# What it does

Forces the given sort order on the query and capitalized the sort by buttons. 

# Why it is important

Addresses #1425 

# UI Change Screenshot

Without a query, there is no Relevance sort button:
![Screenshot 2024-07-18 at 12 07 27 PM](https://github.com/user-attachments/assets/863ebb48-7dba-4078-922a-8fae0a6c529b)

Relevance:
![Screenshot 2024-07-18 at 12 07 38 PM](https://github.com/user-attachments/assets/aa692f90-a2c5-4378-8372-31f6bce26196)

Date Added:
![Screenshot 2024-07-18 at 12 07 45 PM](https://github.com/user-attachments/assets/e3ba497e-c445-42fd-be46-c9d05b855d3f)

Number:
![Screenshot 2024-07-18 at 12 07 51 PM](https://github.com/user-attachments/assets/bb296aa0-ce07-4c5c-bc97-8810f46c3345)

Name: 
![Screenshot 2024-07-18 at 12 07 59 PM](https://github.com/user-attachments/assets/1cdfa1d1-ea7f-4e86-8f40-2a2fcde9c45b)

# Implementation notes

For the sorting, I just changed `order` to `reorder`. The issue was that PGSearch would add a default order by rank that would take priority ahead of any other ordering applied. `reorder` disregards the previous orders on the query and applies our new one. 

For the Relevancy sort I tried always using `reorder` and adding relevance to the hash of sort orders using this [PGSearch utility](https://github.com/Casecommons/pg_search?tab=readme-ov-file#search-rank-and-chained-scopes) but the rank results were different then what PGSearch applies by default. 

I think there's likely a good way to refactor this index action overall, but that's probably left for later. This works for now and it gets some more testing around this behavior.

