### PR TITLE
Added basic open graph meta tags to the item show page

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,17 @@
+<% content_for :head do %>
+  <meta property="og:title" content="<%= page_attr(:title) %>">
+  <meta property="og:url" content="<%= request.original_url %>">
+
+  <% if @item.description.present? %>
+    <meta name="description" content="<%= @item.description.to_plain_text %>">
+    <meta property="og:description" content="<%= @item.description.to_plain_text %>">
+  <% end %>
+
+  <% if @item.image.attached? %>
+    <meta property="og:image" content="<%= item_image_url(@item.image, resize_to_limit: [600, 600]) %>">
+  <% end %>
+<% end %>
+
 <div class="items-show">
 
   <h1><%= @item.name %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
       <meta name="turbo-cache-control" content="no-cache">
     <% end %>
     <meta name="turbo-prefetch" content="false"> <%# ask turbo not to prefetch links on hover %>
+    <%= yield :head %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   </head>


### PR DESCRIPTION
# What it does

This will make the share preview look a little friendlier when people share links in apps that support Open Graph protocol (facebook, twitter/x, LinkedIn, Slack, Apple Messages, etc)

# Why it is important

This helps with #867 

# UI Change Screenshot

Most of the tools that let you preview this functionality want a URL to scrape the information from which won't really be available until this is deployed to an environment. So for now, here's the tags in the dom:

![Screenshot_2024-07-16_at_4_26_47 PM](https://github.com/user-attachments/assets/3845c8e0-304d-4e98-b107-64d4f5534c33)

# Implementation notes

I actually worked on pretty much the same thing last Friday so I can say that Slack will at least pick up these tags.

I used the [Open Graph protocol site](https://ogp.me/) as a guide and didn't bother adding any platform specific tags for now.
