### PR TITLE
Switch system tests to use playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,10 @@ jobs:
       with:
         bundler-cache: true
 
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: "package.json"
+
     - name: Run bin/setup script
       env:
         PGHOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,22 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
+      - name: Cache Playwright Chromium browser
+        if: matrix.test == 'system'
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Playwright Chromium browser (with deps)
+        if: matrix.test == 'system' && steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn run playwright install --with-deps chromium
+
+      - name: Install Playwright Chromium browser deps
+        if: matrix.test == 'system' && steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn run playwright install-deps chromium
+
       - run: bin/rails assets:precompile
 
       - name: Setup database

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -79,43 +79,15 @@ $ docker-compose exec web rails c
 ```
 
 ## Testing Suite
-Run the testing suite from within the container:
+Run the unit testing suite from within the container:
 
 ```
 $ docker-compose exec web rails test
-$ docker-compose exec web rails test:system
 ```
 
-Run one test (whether system or not) with:
+NOTE: System tests are not currently set up with docker.
+
+Run one test with:
 ```
 $ docker-compose exec web rails test <filepath>
 ```
-
-System tests will generate a screenshot upon failure. The screenshots can be
-found in the local `tmp/screenshots` directory which maps to the
-`/usr/src/app/tmp/screenshots` directory inside the container.
-
-### Watching tests run
-
-You can view the tests in real time by using a VNC client and temporarily
-switching to the `chrome_in_container` driver by setting the `HEADLESS`
-environment variable to `false`. This environment variable is set in the
-`config/docker.env` file. After changing any values in this file, you must
-restart the container:
-
-```
-$ docker-compose up -d --force-recreate web
-```
-
-Mac OS comes with a built-in screen sharing application, "Screen Sharing".
-On Ubuntu-based Linux, the VNC client application "Vinagre" (aka "Remote Desktop Viewer")
-is commonly used, and can be installed with `sudo apt install vinagre`.
-
-You can open the VNC client application and configure it directly, but in both operating systems
-it's probably easier to click on [vnc://localhost:5900](vnc://localhost:5900)
-(or paste that into your browser's address bar) and let the browser launch the VNC client with
- the appropriate parameters for you.
-
-The VNC password is `secret`.
-
-Run the spec(s) from the command line and you can see the test running in the browser through the VNC client.

--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "minitest", "5.24.1"
   gem "capybara", ">= 2.15"
-  gem "selenium-webdriver"
+  gem "capybara-playwright-driver"
   gem "rails-controller-testing"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-playwright-driver (0.5.1)
+      addressable
+      capybara
+      playwright-ruby-client (>= 1.16.0)
     certifi (2018.01.18)
     chartkick (5.0.7)
     childprocess (5.0.0)
@@ -318,6 +322,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
@@ -389,6 +396,9 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    playwright-ruby-client (1.45.0)
+      concurrent-ruby (>= 1.1.6)
+      mime-types (>= 3.0)
     prime (0.1.2)
       forwardable
       singleton
@@ -489,17 +499,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
-    rubyzip (2.3.2)
     safely_block (0.4.0)
     scenic (1.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    selenium-webdriver (4.22.0)
-      base64 (~> 0.2)
-      logger (~> 1.4)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -594,7 +597,6 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.8.1)
-    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -623,6 +625,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.1)
   byebug
   capybara (>= 2.15)
+  capybara-playwright-driver
   chronic
   cssbundling-rails (~> 1.4)
   devise
@@ -655,7 +658,6 @@ DEPENDENCIES
   rails-controller-testing
   reverse_markdown
   scenic
-  selenium-webdriver
   solargraph
   solargraph-rails
   solargraph-standardrb

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   puts "== Installing playwright yarn package =="
-  playwright_version=`bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip'`
+  playwright_version=`bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION'`.strip
   system!("yarn add -D 'playwright@#{playwright_version}'")
 
   if ENV["USING_NIX"] == "1"

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,11 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
+  puts "== Installing playwright =="
+  playwright_version=`bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip'`
+  system!("yarn add -D 'playwright@#{playwright_version}'")
+  system!("yarn run playwright install")
+
   puts '== Drop db connections =='
   system! 'bin/rails db:close_connections'
 

--- a/bin/setup
+++ b/bin/setup
@@ -16,10 +16,17 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
-  puts "== Installing playwright =="
+  puts "== Installing playwright yarn package =="
   playwright_version=`bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip'`
   system!("yarn add -D 'playwright@#{playwright_version}'")
-  system!("yarn run playwright install")
+
+  if ENV["USING_NIX"] == "1"
+    # Nix cannot execute misc downloaded binaries so it brings its own browser
+    puts "== (Skipping playwright browser install for Nix setup) =="
+  else
+    puts "== Installing chromium with playwright =="
+    system!("yarn run playwright install --with-deps chromium")
+  end
 
   puts '== Drop db connections =='
   system! 'bin/rails db:close_connections'

--- a/flake.nix
+++ b/flake.nix
@@ -42,9 +42,10 @@
               # https://github.com/NixOS/nixpkgs/pull/246444
               (imagemagick.override { ghostscriptSupport = true; })
 
-              # for selenium tests
+              # for system tests
               chromium
               chromedriver
+              playwright
 
               # for linters and git hooks
               lefthook
@@ -73,7 +74,7 @@
             # We'll run chromium in headless mode
             HEADLESS = "true";
             PARALLEL_WORKERS = "3";
-            SELENIUM_CHROME_BINARY = "${pkgs.chromium}/bin/chromium";
+            PLAYWRIGHT_CHROME_BINARY = "${pkgs.chromium}/bin/chromium";
           };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,6 @@
               # for system tests
               chromium
               chromedriver
-              playwright
 
               # for linters and git hooks
               lefthook
@@ -71,10 +70,13 @@
             DATABASE_URL = "postgres://localhost:5435";
             PGUSER = "postgres";
 
-            # We'll run chromium in headless mode
+            # We'll run system tests in headless mode
             HEADLESS = "true";
             PARALLEL_WORKERS = "3";
             PLAYWRIGHT_CHROME_BINARY = "${pkgs.chromium}/bin/chromium";
+
+            # Set a general env variable that other setup code can use.
+            USING_NIX = "1";
           };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
 
               # for system tests
               chromium
-              chromedriver
 
               # for linters and git hooks
               lefthook

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "markdown-toc": "^1.2.0",
+    "playwright": "1.45.0\n",
     "standard": "^17.1.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "markdown-toc": "^1.2.0",
-    "playwright": "1.45.0\n",
+    "playwright": "1.45.0",
     "standard": "^17.1.0"
   },
   "scripts": {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -32,7 +32,10 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Playwright::Driver.new(
     app,
     browser: :chrome,
-    headless: true
+    headless: true,
+    # We only use this env var for the Nix dev environment. For other platforms
+    # we can let playwright use its own downloaded browser.
+    executablePath: ENV.fetch("PLAYWRIGHT_CHROME_BINARY", nil)
   )
 end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "test_helpers/stdout_helpers"
 
 Capybara.default_max_wait_time = 5
 
@@ -87,6 +88,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Warden::Test::Helpers
   include ActionMailer::TestHelper
   include ActiveJob::TestHelper
+  include StdoutHelpers
 
   def fail_on_js_error(error)
     return false if /the server responded with a status of 422/.match?(error.message)

--- a/test/system/admin/holds_test.rb
+++ b/test/system/admin/holds_test.rb
@@ -148,7 +148,9 @@ class HoldsTest < ApplicationSystemTestCase
       assert_text @item.name
     end
 
-    click_on "Holds"
+    within(".member-tabs") do
+      click_on "Holds"
+    end
 
     refute_selector "#current-holds"
     refute_text @item.name
@@ -177,7 +179,10 @@ class HoldsTest < ApplicationSystemTestCase
     hold_ids = all(".item-holds-table tr[data-hold-id]").map { |row| row["data-hold-id"] }
 
     # Make the first hold the last
-    @handles.first.drag_to @handles.last
+    # NOTE: A short delay seems to be required for test to pass under Playwright,
+    # future developers are welcome to try removing it to see if it's no longer
+    # necessary
+    @handles.first.drag_to @handles.last, delay: 0.25
     # Wait for the update to complete
     assert_no_selector "div[data-controller='hold-order'][aria-busy='true']"
 

--- a/test/system/admin/notes_test.rb
+++ b/test/system/admin/notes_test.rb
@@ -6,20 +6,18 @@ class NotesTest < ApplicationSystemTestCase
   end
 
   test "adding a note to an item" do
-    ignore_js_errors(reason: "This intentionally causes a 422 error") do
-      @item = create(:item)
-      visit admin_item_url(@item)
+    @item = create(:item)
+    visit admin_item_url(@item)
 
-      click_on "Add a Note"
-      click_on "Create Note"
+    click_on "Add a Note"
+    click_on "Create Note"
 
-      assert_content "can't be blank"
+    assert_content "can't be blank"
 
-      fill_in_rich_text_area "note_body", with: "Information you should know"
-      click_on "Create Note"
+    fill_in_rich_text_area "note_body", with: "Information you should know"
+    click_on "Create Note"
 
-      assert_selector ".note", text: "Information you should know"
-    end
+    assert_selector ".note", text: "Information you should know"
   end
 
   test "editing a note on an item" do

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -48,6 +48,9 @@ class AdminReservationsTest < ApplicationSystemTestCase
     answers = create_list(:answer, 2, reservation:)
 
     visit admin_reservation_url(reservation)
+    # TODO: This is a somewhat ambiguous selector that I'm dropping in to fix
+    # tests in a sweep. Consider rearranging the view to make it easier to
+    # select between the tab and the global nav.
     within(".tab") do
       click_on "Questions"
     end

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -11,7 +11,7 @@ class AdminReservationsTest < ApplicationSystemTestCase
   end
 
   def date_input_format(datetime)
-    datetime.strftime("%m/%d/%Y")
+    datetime.strftime("%Y-%m-%d")
   end
 
   test "visiting the index" do
@@ -48,7 +48,9 @@ class AdminReservationsTest < ApplicationSystemTestCase
     answers = create_list(:answer, 2, reservation:)
 
     visit admin_reservation_url(reservation)
-    click_on "Questions"
+    within(".tab") do
+      click_on "Questions"
+    end
 
     answers.each do |answer|
       assert_text answer.stem.content

--- a/test/system/appointments_test.rb
+++ b/test/system/appointments_test.rb
@@ -147,7 +147,9 @@ class AppointmentsTest < ApplicationSystemTestCase
 
     visit account_home_url
 
-    click_on "Appointments"
+    within(".navbar-links") do
+      click_on "Appointments"
+    end
 
     assert_text "Appointments"
 

--- a/test/system/membership_renewal_test.rb
+++ b/test/system/membership_renewal_test.rb
@@ -46,38 +46,36 @@ class MembershipRenewalTest < ApplicationSystemTestCase
   end
 
   def complete_square_checkout
-    ignore_js_errors reason: "square site has a couple issues" do
-      click_on "Pay Online Now"
+    click_on "Pay Online Now"
 
-      wait_for_square_sandbox_to_load
+    wait_for_square_sandbox_to_load
 
-      # Checkout API Sandbox Testing Panel
-      # extract order id from page
-      # p.text will be something like "order_id: xyu3Gv1KQic4q93xISrJusrHXa4F\nurl: https://sandbox.square.link/u/xUTx9ykD"
-      p = page.find("p", text: "order_id")
-      data = p.text.split.in_groups_of(2).to_h
-      order_id = data["order_id:"]
+    # Checkout API Sandbox Testing Panel
+    # extract order id from page
+    # p.text will be something like "order_id: xyu3Gv1KQic4q93xISrJusrHXa4F\nurl: https://sandbox.square.link/u/xUTx9ykD"
+    p = page.find("p", text: "order_id")
+    data = p.text.split.in_groups_of(2).to_h
+    order_id = data["order_id:"]
 
-      # advance through and complete the payment
-      click_on "Next"
+    # advance through and complete the payment
+    click_on "Next"
 
-      # complete the payment so we can verify the callback
-      click_on "Test Payment"
-      assert_content "Checkout Complete"
+    # complete the payment so we can verify the callback
+    click_on "Test Payment"
+    assert_content "Checkout Complete"
 
-      # grab redirect URL
-      td = page.find("td", text: /redirected/)
-      url = td.text.sub("Customer redirected to:", "").strip
+    # grab redirect URL
+    td = page.find("td", text: /redirected/)
+    url = td.text.sub("Customer redirected to:", "").strip
 
-      # build redirect URL from url and order id
-      redirect_url = "#{url}?orderId=#{order_id}"
+    # build redirect URL from url and order id
+    redirect_url = "#{url}?orderId=#{order_id}"
 
-      perform_enqueued_jobs do
-        visit redirect_url
+    perform_enqueued_jobs do
+      visit redirect_url
 
-        # Back in the app
-        assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
-      end
+      # Back in the app
+      assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
     end
   end
 

--- a/test/system/membership_renewal_test.rb
+++ b/test/system/membership_renewal_test.rb
@@ -12,6 +12,11 @@ class MembershipRenewalTest < ApplicationSystemTestCase
 
     ActionMailer::Base.deliveries.clear
 
+    # This warning is generated on execution of complete_first_three_steps, and
+    # it seems to be harmless. See
+    # https://github.com/YusukeIwaki/capybara-playwright-driver/issues/51 for
+    # discussion. The fix in the driver involves a puts which is noisy in test
+    # outputs, so we suppress that here.
     suppress_puts([
       /Execution context was destroyed, most likely because of a navigation/
     ])

--- a/test/system/membership_renewal_test.rb
+++ b/test/system/membership_renewal_test.rb
@@ -11,6 +11,14 @@ class MembershipRenewalTest < ApplicationSystemTestCase
     login_as @user
 
     ActionMailer::Base.deliveries.clear
+
+    suppress_puts([
+      /Execution context was destroyed, most likely because of a navigation/
+    ])
+  end
+
+  def teardown
+    restore_puts
   end
 
   def complete_first_three_steps

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -108,7 +108,9 @@ class UserSignupTest < ApplicationSystemTestCase
 
     visit root_url
 
-    click_on "Member Login"
+    within(".navbar-links") do
+      click_on "Member Login"
+    end
 
     fill_in "Email", with: email
     fill_in "Password", with: "password"

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -46,38 +46,36 @@ class UserSignupTest < ApplicationSystemTestCase
   end
 
   def complete_square_checkout
-    ignore_js_errors reason: "square site has a couple issues" do
-      click_on "Pay Online Now"
+    click_on "Pay Online Now"
 
-      wait_for_square_sandbox_to_load
+    wait_for_square_sandbox_to_load
 
-      # Checkout API Sandbox Testing Panel
-      # extract order id from page
-      # p.text will be something like "order_id: xyu3Gv1KQic4q93xISrJusrHXa4F\nurl: https://sandbox.square.link/u/xUTx9ykD"
-      p = page.find("p", text: "order_id")
-      data = p.text.split.in_groups_of(2).to_h
-      order_id = data["order_id:"]
+    # Checkout API Sandbox Testing Panel
+    # extract order id from page
+    # p.text will be something like "order_id: xyu3Gv1KQic4q93xISrJusrHXa4F\nurl: https://sandbox.square.link/u/xUTx9ykD"
+    p = page.find("p", text: "order_id")
+    data = p.text.split.in_groups_of(2).to_h
+    order_id = data["order_id:"]
 
-      # advance through and complete the payment
-      click_on "Next"
+    # advance through and complete the payment
+    click_on "Next"
 
-      # complete the payment so we can verify the callback
-      click_on "Test Payment"
-      assert_content "Checkout Complete"
+    # complete the payment so we can verify the callback
+    click_on "Test Payment"
+    assert_content "Checkout Complete"
 
-      # grab redirect URL
-      td = page.find("td", text: /redirected/)
-      url = td.text.sub("Customer redirected to:", "").strip
+    # grab redirect URL
+    td = page.find("td", text: /redirected/)
+    url = td.text.sub("Customer redirected to:", "").strip
 
-      # build redirect URL from url and order id
-      redirect_url = "#{url}?orderId=#{order_id}"
+    # build redirect URL from url and order id
+    redirect_url = "#{url}?orderId=#{order_id}"
 
-      perform_enqueued_jobs do
-        visit redirect_url
+    perform_enqueued_jobs do
+      visit redirect_url
 
-        # Back in the app
-        assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
-      end
+      # Back in the app
+      assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
     end
   end
 

--- a/test/test_helpers/stdout_helpers.rb
+++ b/test/test_helpers/stdout_helpers.rb
@@ -1,0 +1,34 @@
+# Taken from https://gist.github.com/searls/9caa12f66c45a72e379e7bfe4c48405b
+# Referenced in https://justin.searls.co/posts/running-rails-system-tests-with-playwright-instead-of-selenium/
+#
+# This is a stupid utility to squelch stdout output via puts (could do the same
+#   for warn; could also override stdout entirely)
+#
+# Usage in a test, after requiring and including it:
+#
+#   setup do
+#     suppress_puts([
+#       /Execution context was destroyed, most likely because of a navigation/
+#     ])
+#   end
+#
+#   teardown do
+#     restore_puts
+#   end
+#
+module StdoutHelpers
+  def suppress_puts(only_these_patterns)
+    @__og_puts = og_puts = Kernel.method(:puts)
+    Kernel.define_method(:puts) do |*args|
+      if only_these_patterns.nil?
+        nil
+      elsif only_these_patterns.none? { |pattern| args.first.to_s =~ pattern }
+        og_puts.call(*args)
+      end
+    end
+  end
+
+  def restore_puts
+    Kernel.define_singleton_method(:puts, @__og_puts)
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,7 +2907,7 @@ playwright-core@1.45.0:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.0.tgz#5741a670b7c9060ce06852c0051d84736fb94edc"
   integrity sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==
 
-"playwright@1.45.0\n":
+playwright@1.45.0:
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.45.0.tgz#400c709c64438690f13705cb9c88ef93089c5c27"
   integrity sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==
@@ -3263,7 +3263,7 @@ standard@^17.1.0:
     standard-engine "^15.0.0"
     version-guard "^1.1.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3280,6 +3280,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -3343,7 +3352,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3356,6 +3365,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -3643,7 +3659,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -2902,6 +2902,20 @@ pkg-conf@^3.1.0:
     find-up "^3.0.0"
     load-json-file "^5.2.0"
 
+playwright-core@1.45.0:
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.0.tgz#5741a670b7c9060ce06852c0051d84736fb94edc"
+  integrity sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==
+
+"playwright@1.45.0\n":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.45.0.tgz#400c709c64438690f13705cb9c88ef93089c5c27"
+  integrity sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==
+  dependencies:
+    playwright-core "1.45.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -3249,7 +3263,7 @@ standard@^17.1.0:
     standard-engine "^15.0.0"
     version-guard "^1.1.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3266,15 +3280,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -3338,7 +3343,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3351,13 +3356,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -3645,16 +3643,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# What it does

Changes from Selenium to Playwright to run our browser based system tests.

# Why it is important

The hope is that this is a smidge more reliable / less flaky.

# Implementation notes

* This is mostly based on a [recent blog post](https://justin.searls.co/posts/running-rails-system-tests-with-playwright-instead-of-selenium/) that reported a good experience switching.
* There were a few places that Playwright had trouble with ambiguous links - it seems to "see" both the mobile and desktop nav menus. Fixed these with `within` scopes.
* The drag/drop test needed an extra delay to work... it seemed like it didn't drag far enough w/o it. I guess playwright is slower to move the virtual mouse!? 😂 
* I decided to yank out Docker support for system tests for now. There is a [story for setting this back up](https://playwright-ruby-client.vercel.app/docs/article/guides/playwright_on_alpine_linux), but it's high effort and nobody is using it right now. We can always pick it up down the road.
* Cleaned up unused / unnecessary helpers:
   - Richtext selector: included in Capybara / Rails now
   - JS Error detection: no tests fail without it, so seems fine now
