### PR TITLE
Added toggle to limit admin search results to available items only

### DIFF
--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -3,12 +3,6 @@ module Admin
     def create
       query = params[:query]
 
-      # item = Item.where(number: query).first
-      # redirect_to(admin_item_path(item)) && return if item
-
-      # member = Member.matching(query).first
-      # redirect_to(admin_member_path(member)) && return if member
-
       redirect_to admin_search_path(query: query), status: :see_other
     end
 
@@ -24,10 +18,17 @@ module Admin
       end
 
       if !@exact && @query.size >= 2
-        # @items_by_number = Item.number_contains(query)
-        @items = Item.search_by_anything(@query).by_name
+        @items = search_items
         @members = Member.matching(@query).open.by_full_name
       end
+    end
+
+    private
+
+    def search_items
+      query = Item.search_by_anything(@query).by_name
+      query = query.available_now if params[:available].present?
+      query
     end
   end
 end

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,11 +1,5 @@
 module Admin
   class SearchesController < BaseController
-    def create
-      query = params[:query]
-
-      redirect_to admin_search_path(query: query), status: :see_other
-    end
-
     def show
       @query = params[:query]
       @exact = params[:exact] != "false"

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -30,6 +30,7 @@
     <% if @items.present? %>
       <div class="search-result-type">
         <h2>Items</h2>
+        <%= render partial: "items/available_now_filter", locals: {url: admin_search_path, params: params} %>
         <%= render partial: "admin/items/items", locals: {items: @items} %>
       </div>
     <% end %>

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -27,14 +27,14 @@
       <% end %>
     </div>
 
-    <% unless @items.blank? %>
+    <% if @items.present? %>
       <div class="search-result-type">
         <h2>Items</h2>
         <%= render partial: "admin/items/items", locals: {items: @items} %>
       </div>
     <% end %>
 
-    <% unless @members.blank? %>
+    <% if @members.present? %>
       <div class="search-result-type">
         <h2>Members</h2>
         <%= render partial: "admin/members/members", locals: {members: @members} %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -100,7 +100,7 @@
           <%= link_to "Circulate", admin_items_path %>
         </span>
         <div class="float-right mr-1 admin-search-form">
-          <%= form_with url: admin_search_path do |form| %>
+          <%= form_with url: admin_search_path, method: :get do |form| %>
             <div class="has-icon-left">
               <%= form.text_field :query, class: "form-input input-sm", placeholder: "search", type: "search" %>
               <i class="form-icon icon icon-search"></i>
@@ -185,7 +185,7 @@
             </div>
           </section>
           <section class="navbar-section">
-            <%= form_with url: admin_search_path do |form| %>
+            <%= form_with url: admin_search_path, method: :get do |form| %>
                 <div class="has-icon-left">
                   <%= form.text_field :query, class: "form-input input-sm", placeholder: "search" %>
                   <i class="form-icon icon icon-search"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,6 @@ Rails.application.routes.draw do
 
     resource :map, only: :show
 
-    post "search", to: "searches#create"
     get "search", to: "searches#show"
 
     get "/ui/names", to: "ui#names"

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -31,5 +31,13 @@ FactoryBot.define do
     trait :with_image do
       image { Rack::Test::UploadedFile.new(Rails.root.join("test", "fixtures", "files", "tool-image.jpg"), "image/jpeg") }
     end
+
+    trait :active do
+      status { Item.statuses[:active] }
+    end
+
+    trait :maintenance do
+      status { Item.statuses[:maintenance] }
+    end
   end
 end

--- a/test/system/admin/searches_test.rb
+++ b/test/system/admin/searches_test.rb
@@ -52,6 +52,31 @@ class AdminSearchesTest < ApplicationSystemTestCase
     assert_text sander.name
   end
 
+  test "items list can be filtered by available" do
+    drill = create(:item, :active, name: "Power Drill")
+    saw = create(:item, :maintenance, name: "Power Saw")
+    sander = create(:item, :active, name: "Power Sander")
+
+    visit admin_dashboard_path
+    fill_in "query", with: "Power\n"
+
+    assert_text drill.name
+    assert_text sander.name
+    assert_text saw.name
+
+    find("label", text: "Only show items available now").click # check available only
+
+    refute_text saw.name
+    assert_text drill.name
+    assert_text sander.name
+
+    find("label", text: "Only show items available now").click # uncheck available only
+
+    assert_text drill.name
+    assert_text sander.name
+    assert_text saw.name
+  end
+
   test "lists members that match anything" do
     jamie_surname = create(:verified_member, full_name: "Jamie Surname")
     jamie = create(:verified_member, preferred_name: "Jamie")

--- a/test/system/admin/searches_test.rb
+++ b/test/system/admin/searches_test.rb
@@ -1,0 +1,67 @@
+require "application_system_test_case"
+
+class AdminSearchesTest < ApplicationSystemTestCase
+  setup do
+    sign_in_as_admin
+  end
+
+  test "lists a member by number (exact by default)" do
+    member = create(:verified_member)
+    other_member = create(:verified_member)
+
+    visit admin_dashboard_path
+    fill_in "query", with: "#{member.number}\n"
+
+    assert_text member.email
+    refute_text other_member.email
+
+    fill_in "query", with: "#{member.number}123\n"
+
+    refute_text member.email
+    refute_text other_member.email
+    assert_text "No member with number"
+  end
+
+  test "lists an item by number (exact by default)" do
+    item = create(:item)
+    other_item = create(:item)
+
+    visit admin_dashboard_path
+    fill_in "query", with: "#{item.number}\n"
+
+    assert_text item.name
+    refute_text other_item.name
+
+    fill_in "query", with: "#{item.number}123\n"
+
+    refute_text item.name
+    refute_text other_item.name
+    assert_text "No item with number"
+  end
+
+  test "lists items that match anything" do
+    drill = create(:item, name: "Power Drill")
+    saw = create(:item, name: "Power Saw")
+    sander = create(:item, name: "Power Sander")
+
+    visit admin_dashboard_path
+    fill_in "query", with: "Power Sa\n"
+
+    refute_text drill.name
+    assert_text saw.name
+    assert_text sander.name
+  end
+
+  test "lists members that match anything" do
+    jamie_surname = create(:verified_member, full_name: "Jamie Surname")
+    jamie = create(:verified_member, preferred_name: "Jamie")
+    parker = create(:verified_member, full_name: "Parker Car")
+
+    visit admin_dashboard_path
+    fill_in "query", with: "Jami\n"
+
+    assert_text jamie_surname.email
+    assert_text jamie.email
+    refute_text parker.email
+  end
+end


### PR DESCRIPTION
# What it does

Added toggle to limit admin search results to available items only.

# Why it is important

Takes care of #1439

# UI Change Screenshot

With the toggle off:
![Screenshot 2024-07-18 at 4 10 01 PM](https://github.com/user-attachments/assets/72c6cf37-a71c-4d59-806f-03f262d57770)

With the toggle on:
![Screenshot 2024-07-18 at 4 10 12 PM](https://github.com/user-attachments/assets/2b404a1a-7286-458b-a779-9f55f4a40ce7)

# Implementation notes

I reused the partial from the items#index and admin/items#index even though it has some hidden field tags we don't really need in this context.

I also removed searches#create since it just passed through to searches#show anyway. Just had to change the forms to be `get` requests.
