### PR TITLE
GoodJob 4.0 migrations

### DIFF
--- a/db/migrate/20240720134319_create_good_job_settings.rb
+++ b/db/migrate/20240720134319_create_good_job_settings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateGoodJobSettings < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_settings)
+      end
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+  end
+end

--- a/db/migrate/20240720134320_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/db/migrate/20240720134320_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_jobs_on_priority_created_at_when_unfinished)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240720134321_create_good_job_batches.rb
+++ b/db/migrate/20240720134321_create_good_job_batches.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateGoodJobBatches < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_batches)
+      end
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+    end
+
+    change_table :good_jobs do |t|
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.index :batch_id, where: "batch_id IS NOT NULL"
+      t.index :batch_callback_id, where: "batch_callback_id IS NOT NULL"
+    end
+  end
+end

--- a/db/migrate/20240720134322_create_good_job_executions.rb
+++ b/db/migrate/20240720134322_create_good_job_executions.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutions < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_executions)
+      end
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    end
+
+    change_table :good_jobs do |t|
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+    end
+  end
+end

--- a/db/migrate/20240720134323_create_good_jobs_error_event.rb
+++ b/db/migrate/20240720134323_create_good_jobs_error_event.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :error_event)
+      end
+    end
+
+    add_column :good_jobs, :error_event, :integer, limit: 2
+    add_column :good_job_executions, :error_event, :integer, limit: 2
+  end
+end

--- a/db/migrate/20240720134324_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/migrate/20240720134324_recreate_good_job_cron_indexes_with_conditional.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
+            name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
+            name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          add_index :good_jobs, [:cron_key, :created_at],
+            name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
+            name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at_cond
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240720134325_create_good_job_labels.rb
+++ b/db/migrate/20240720134325_create_good_job_labels.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabels < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :labels)
+      end
+    end
+
+    add_column :good_jobs, :labels, :text, array: true
+  end
+end

--- a/db/migrate/20240720134326_create_good_job_labels_index.rb
+++ b/db/migrate/20240720134326_create_good_job_labels_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
+            name: :index_good_jobs_on_labels, algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          remove_index :good_jobs, name: :index_good_jobs_on_labels
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240720134327_remove_good_job_active_id_index.rb
+++ b/db/migrate/20240720134327_remove_good_job_active_id_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240720134328_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/migrate/20240720134328_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "ASC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240720134329_create_good_job_execution_error_backtrace.rb
+++ b/db/migrate/20240720134329_create_good_job_execution_error_backtrace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :error_backtrace)
+      end
+    end
+
+    add_column :good_job_executions, :error_backtrace, :text, array: true
+  end
+end

--- a/db/migrate/20240720134330_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20240720134330_create_good_job_process_lock_ids.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end

--- a/db/migrate/20240720134331_create_good_job_process_lock_indexes.rb
+++ b/db/migrate/20240720134331_create_good_job_process_lock_indexes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, [:priority, :scheduled_at],
+            order: {priority: "ASC NULLS LAST", scheduled_at: :asc},
+            where: "finished_at IS NULL AND locked_by_id IS NULL",
+            name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+            algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+            where: "locked_by_id IS NOT NULL",
+            name: :index_good_jobs_on_locked_by_id,
+            algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, [:process_id, :created_at],
+            name: :index_good_job_executions_on_process_id_and_created_at,
+            algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+        remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at) if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+      end
+    end
+  end
+end

--- a/db/migrate/20240720134332_create_good_job_execution_duration.rb
+++ b/db/migrate/20240720134332_create_good_job_execution_duration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionDuration < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :duration)
+      end
+    end
+
+    add_column :good_job_executions, :duration, :interval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_051930) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_20_134332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -424,6 +424,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_051930) do
     t.integer "error_event", limit: 2
     t.text "error_backtrace", array: true
     t.uuid "process_id"
+    t.interval "duration"
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
     t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end


### PR DESCRIPTION
# What it does

Adds missing GoodJob migrations as I didn't notice that Dependabot took us over the major boundary in #1582.

# Why it is important

Fixes job errors we're seeing in production that look like https://github.com/bensheldon/good_job/issues/1404

# Implementation notes

Generated by pinning good_job to 3.99 and running

```
bin/rails good_job:update
bin/rails db:migrate
```

Follow up tasks to consider: 

 * Smoke testing GoodJob in tests (I think we'll get this as a matter of course once we start converting some of our cron tasks over)
 * Splitting out major version upgrades to separate dependabot group
