### PR TITLE
log additional information for search and view events

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
     # Track that a search was performed if we are on the first page
     if @query && @pagy.page == 1
-      ahoy.track "Searched", query: @query, params: (@filter_params || {}), n_results: @pagy.count, first_page_results: @items.map(&:id)
+      ahoy.track "Searched", query: @query, params: @filter_params || {}, n_results: @pagy.count, first_page_results: @items.map(&:id)
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
     # Track that a search was performed if we are on the first page
     if @query && @pagy.page == 1
-      ahoy.track "Searched", query: @query, params: @filter_params || {}, n_results: @pagy.count, first_page_results: @items.map(&:id)
+      ahoy.track "Searched", query: @query, params: @filter_params || {}, n_results: @pagy.count
     end
   end
 
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
     # the `request.referer != request.url` condition prevents logging the view after
     # placing a hold redirects back to the item page
     if request.referer != request.url
-      ahoy.track "Item viewed", item_id: @item.id, referrer_url: request.referer
+      ahoy.track "Item viewed", item_id: @item.id, referrer_url: request.referer, search_result_index: params[:search_result_index].to_i + 1
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
     # Track that a search was performed if we are on the first page
     if @query && @pagy.page == 1
-      ahoy.track "Searched", query: @query
+      ahoy.track "Searched", query: @query, params: @filter_params, n_results: @pagy.count, first_page_results: @items.map(&:id)
     end
   end
 
@@ -34,7 +34,11 @@ class ItemsController < ApplicationController
       @current_hold_count = current_member.active_holds.active_hold_count_for_item(@item).to_i
     end
 
-    ahoy.track "Item viewed", item_id: @item.id
+    # the `request.referer != request.url` condition prevents logging the view after
+    # placing a hold redirects back to the item page
+    if request.get? && (request.referer != request.url)
+      ahoy.track "Item viewed", item_id: @item.id, referrer_url: request.referer
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
     # Track that a search was performed if we are on the first page
     if @query && @pagy.page == 1
-      ahoy.track "Searched", query: @query, params: @filter_params, n_results: @pagy.count, first_page_results: @items.map(&:id)
+      ahoy.track "Searched", query: @query, params: (@filter_params || {}), n_results: @pagy.count, first_page_results: @items.map(&:id)
     end
   end
 
@@ -36,7 +36,7 @@ class ItemsController < ApplicationController
 
     # the `request.referer != request.url` condition prevents logging the view after
     # placing a hold redirects back to the item page
-    if request.get? && (request.referer != request.url)
+    if request.referer != request.url
       ahoy.track "Item viewed", item_id: @item.id, referrer_url: request.referer
     end
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -72,10 +72,10 @@
 
     <% if @items.any? %>
       <div class="items-table">
-        <% @items.each do |item| %>
+        <% @items.each.with_index do |item, index| %>
           <%= tag.div class: "items-table-image" do %>
             <% if item.image.attached? %>
-              <%= link_to item_path(item) do %>
+              <%= link_to item_path(item, search_result_index: index) do %>
                 <%= image_tag item_image_url(item.image, resize_to_limit: [200, 140]), class: "p-centered" %>
               <% end %>
             <% else %>
@@ -90,7 +90,7 @@
               <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
             <% end %>
             <br>
-            <%= link_to item.name, item_path(item) %>
+            <%= link_to item.name, item_path(item, search_result_index: index) %>
             <%#= item.added %>
             <% if item.size.present? %>
               <span class="label"><%= item.size %></span>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -37,7 +37,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     get items_url(category: category.id)
 
-    assert_select "a[href='#{item_path(item)}']", count: 1
+    assert_select "a[href='#{item_path(item)}?search_result_index=0']", count: 1
   end
 
   [:retired, :pending].each do |status|


### PR DESCRIPTION
# What it does

Add more useful information to the "Search" and "Item Viewed" events logged by ahoy.

Specifically, this PR adds the following information:
* Search
  + "params": any parameters included with the search, such as "sort" and "category" (this will also include "query", which we're already logging, but it's probably not too big a deal to include it here too)
  + "n_results": number of results returned by the query
  + "first_page_results": a list of the ordered item IDs on the first page results
    + I'm not sure whether this will be useful/necessary. **See implementation note below.**
* Item Viewed
  + "referrer_url": add the referrer URL so we can connect Item Viewed events to search queries, or see which other places are leading to item views

# Why it is important

The additional information will help us understand how users are interacting with the site, specifically related to search.

# UI Change Screenshot

No UI changes, but here's what the `ahoy_events` table looks like after performing a few actions in the dev app:

<img width="1880" alt="image" src="https://github.com/user-attachments/assets/1e1e961f-b2c3-4996-98db-1d54e063a49c">

# Implementation notes

### first_page_results

First I tried to figure out a way to add an "item_index" field to the Item Viewed event that would tell us whether the user clicked on the 1st, 2nd, ... item in the results. But I couldn't figure out how to do that. Instead, I decided to add the "first_page_results" field to the Search event -- we can theoretically connect the Item Viewed event to the Search event, and then look up the item ID in "first_page_results" to figure out the item index.

Another benefit is that we get (quasi-)impression data for search results. We can assume that the user saw at least the first several results from the list. This could possibly be useful in some search analysis (for example, if we find that item *X* is always the first result for query *Q* but it never gets clicked on, that indicates that item *X* is not relevant to query *Q*).

The downside is we're logging a lot more data (relative to what we were previously logging), and this is probably the least important field.

**Questions:**
1. Is the volume of data (a list of 20 item IDs per search event) too large to justify keeping this field? I'm not sure what kind of table size constraints we're working with.
2. Does anyone know how we might add an "item_index" field to the Item Viewed event instead? That accomplish the same thing (minus the impression data) with a much smaller footprint and would make analysis easier.

### referrer_url

I noticed this field doesn't behave the same way in all browsers. Specifically, if I'm using Safari and I open the link in a new tab, the referrer URL is null (but if I open the link in the same tab the referrer URL is populated). In Chrome, the referrer URL was always populated, whether I opened the link in the same tab or a new tab. 

Let me know if anyone knows a way to ensure the referrer URL is always included in Safari -- but that would be super low priority.