### PR TITLE
Reorder sass rules to prevent warnings

### DIFF
--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -69,9 +69,9 @@ $pri-btn-color-hover: darken($button-color, 7%);
 
 // BUTTONS
 .primary-btn {
-  @include primary-button;
   letter-spacing: $button-letter-spacing;
   border: none;
+  @include primary-button;
   a {
     height: 50px !important;
   }
@@ -82,8 +82,8 @@ $pri-btn-color-hover: darken($button-color, 7%);
 }
 
 .secondary-btn {
-  @include secondary-button;
   letter-spacing: $button-letter-spacing;
+  @include secondary-button;
 }
 
 .link-btn {
@@ -111,7 +111,7 @@ $pri-btn-color-hover: darken($button-color, 7%);
 //     &.active {
 //       color: $text-color;
 //     }
-    
+
 //       &:visited {
 //         color: $text-color;
 //       }
@@ -164,7 +164,7 @@ $pri-btn-color-hover: darken($button-color, 7%);
     color: $text-color;
     padding-top: 5px;
     text-decoration: none;
-  
+
     &:focus,
     &:hover {
       color: #000 !important;
@@ -172,7 +172,7 @@ $pri-btn-color-hover: darken($button-color, 7%);
     &.active {
       color: $text-color !important;
     }
-  
+
     &:visited {
       color: $text-color !important;
     }

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -117,8 +117,8 @@ trix-toolbar {
   }
 
   .off-canvas-toggle {
-    @include default-button();
     margin-top: 0.5rem;
+    @include default-button();
     .icon {
       color: $dark-color;
     }
@@ -132,10 +132,10 @@ form.button_to {
 
 // Improve contrast on labels
 .label {
+  background-color: lighten($gray-color-light, 1%);
   &, &.label-success, &.label-warning, &.label-error, &.label-primary, &.label-secondary {
     color: inherit;
   }
-  background-color: lighten($gray-color-light, 1%);
 
   &.label-primary { background-color: lighten($primary-color, 40%); }
   &.label-secondary { background-color: $secondary-color-light; }

--- a/app/assets/stylesheets/partials/_admin_appointments.scss
+++ b/app/assets/stylesheets/partials/_admin_appointments.scss
@@ -9,12 +9,12 @@
   }
 
   .card-footer {
+    display: flex;
+    justify-content: flex-end;
+
     button {
       margin-left: 0.5em;
     }
-
-    display: flex;
-    justify-content: flex-end;
   }
 
   table {

--- a/app/assets/stylesheets/public.scss
+++ b/app/assets/stylesheets/public.scss
@@ -30,13 +30,13 @@
   }
 
   .navbar {
+    align-items: center;
     .navbar-brand {
       width: 3rem;
       img {
         width: 100%;
       }
     }
-    align-items: center;
     .navbar-section {
       flex: 1 auto;
     }
@@ -116,7 +116,7 @@
   background: white;
   font-size: 1.2;
   z-index: 1000;
- 
+
   &:focus {
     top: 0;
     transition: 0.1s ease-in;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -220,12 +220,12 @@ $photo-width: 187px;
     grid-column-gap: .6rem;
 
     .items-table-image {
+      grid-column: 1;
+      grid-row: span 1;
       img, .image-placeholder {
         max-width: 100px;
         max-height: 70px;
       }
-      grid-column: 1;
-      grid-row: span 1;
     }
     .items-table-name {
       grid-column: 2/4;
@@ -976,8 +976,8 @@ table.monthly-adjustments {
 
 .app-body, .app-header {
   .btn {
-    @include default-button();
     border-radius: 5px;
+    @include default-button();
     &.btn-default {
       background: $gray-color-dark;
       border-color: $dark-color;


### PR DESCRIPTION
# What it does

This reorders some style rules to prevent deprecation warnings from SASS.

# Why it is important

Reduces noise and surfaces any issues with SASS now instead of when it upgrades.

An example warning:
```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

   ┌──> app/assets/stylesheets/globals.scss
73 │     letter-spacing: $button-letter-spacing;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
   ┌──> app/assets/stylesheets/mixins.scss
64 │ ┌     a {
65 │ │         color: white;
66 │ │         text-decoration: none;
67 │ │     }
   │ └─── nested rule
   ╵
    app/assets/stylesheets/globals.scss 73:3          @import
    app/assets/stylesheets/styles.scss 1:9            @import
    app/assets/stylesheets/application.sass.scss 1:9  root stylesheet
```


# Implementation notes

I just rearranged the lines so that the behavior remains the same post future sass upgrade as it does now. It's possible this changes some attempts at overriding mixins, but didn't notice anything different when I was clicking around. I'll double check, but it'd be great if someone else took a look. 👀 

Also, this PR makes much more sense in the "unified" Github view, instead of "split."