### PR TITLE
Added a members with overdue loans report

### DIFF
--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -4,6 +4,7 @@ module Admin
   module Reports
     class MembersWithOverdueLoansController < BaseController
       include Pagy::Backend
+      include ActionView::Helpers::DateHelper
 
       def index
         query = Member.all.joins(:overdue_loans).distinct.includes(:user, overdue_loans: :item).order(email: :asc)
@@ -31,7 +32,7 @@ module Admin
               member.full_name,
               member.user.email,
               member.phone_number,
-              member.overdue_loans.map { |loan| loan.item.name }.join(", ")
+              member.overdue_loans.map { |loan| "#{loan.item.name} (#{time_ago_in_words(loan.due_at)})" }.join(", ")
             ]
           end
         end

--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -1,0 +1,41 @@
+require "csv"
+
+module Admin
+  module Reports
+    class MembersWithOverdueLoansController < BaseController
+      include Pagy::Backend
+
+      def index
+        query = Member.all.joins(:overdue_loans).distinct.includes(:user, overdue_loans: :item).order(email: :asc)
+
+        respond_to do |format|
+          format.html do
+            @pagy, @members = pagy_arel(query, items: 100)
+          end
+          format.csv do
+            filename = Time.current.strftime("members_with_overdue_loans_%-m/%-d/%Y.csv")
+            send_data build_csv(query), filename:
+          end
+        end
+      end
+
+      private
+
+      def build_csv(members)
+        CSV.generate(headers: true) do |csv|
+          csv << %w[preferred_name full_name email phone_number overdue_tools]
+
+          members.find_each do |member|
+            csv << [
+              member.preferred_name,
+              member.full_name,
+              member.user.email,
+              member.phone_number,
+              member.overdue_loans.map { |loan| loan.item.name }.join(", ")
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -43,6 +43,7 @@ class Loan < ApplicationRecord
       now, zone, zone, tonight
     )
   }
+  scope :overdue, -> { where(ended_at: nil).where(arel_table[:due_at].lt(Time.current)) }
 
   acts_as_tenant :library
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -5,6 +5,7 @@ class Member < ApplicationRecord
 
   has_many :loans, dependent: :destroy
   has_many :checked_out_loans, -> { checked_out }, class_name: "Loan"
+  has_many :overdue_loans, -> { overdue }, class_name: "Loan"
   has_many :appointments, dependent: :destroy
   has_many :loan_summaries
 

--- a/app/views/admin/reports/members_with_overdue_loans/index.html.erb
+++ b/app/views/admin/reports/members_with_overdue_loans/index.html.erb
@@ -1,0 +1,40 @@
+<%= content_for :header do %>
+  <%= index_header "Members with Overdue Loans" do %>
+    <%= link_to "Download as CSV", admin_reports_members_with_overdue_loans_path(format: "csv"), class: "btn" %>
+  <% end %>
+<% end %>
+
+<div class="columns">
+  <div class="column col-12">
+
+    <table class="table">
+      <tr>
+        <th>Member</th>
+        <th>Overdue Tools</th>
+        <th>Email</th>
+        <th>Phone</th>
+      </tr>
+      <% @members.each do |member| %>
+        <tr>
+          <td>
+            <%= link_to preferred_or_default_name(member), [:admin, member] %>
+          </td>
+          <td>
+            <% member.overdue_loans.each do |loan| %>
+              <%= link_to loan.item.name, [:admin, loan.item] %>
+              <br>
+            <% end %>
+          </td>
+          <td>
+            <%= member.user.email %>
+          </td>
+          <td>
+            <%= format_phone_number(member.phone_number) %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+
+   <%== pagy_bootstrap_nav(@pagy) %>
+  </div>
+</div>

--- a/app/views/admin/reports/members_with_overdue_loans/index.html.erb
+++ b/app/views/admin/reports/members_with_overdue_loans/index.html.erb
@@ -21,7 +21,7 @@
           </td>
           <td>
             <% member.overdue_loans.each do |loan| %>
-              <%= link_to loan.item.name, [:admin, loan.item] %>
+              <%= link_to loan.item.name, [:admin, loan.item] %> (<%= time_ago_in_words(loan.due_at) %>)
               <br>
             <% end %>
           </td>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -48,6 +48,7 @@
             <ul class="nav">
               <li class="nav-item"><%= link_to "Activity", admin_reports_monthly_activities_path %></li>
               <li class="nav-item"><%= link_to "Member Requests", admin_reports_member_requests_path %></li>
+              <li class="nav-item"><%= link_to "Members with Overdue Loans", admin_reports_members_with_overdue_loans_path %></li>
               <li class="nav-item"><%= link_to "Memberships", admin_reports_memberships_path %></li>
               <li class="nav-item"><%= link_to "Money", admin_reports_money_path %></li>
               <li class="nav-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>
@@ -148,6 +149,7 @@
               <ul class="menu">
                 <li class="menu-item"><%= link_to "Activity", admin_reports_monthly_activities_path %></li>
                 <li class="menu-item"><%= link_to "Member Requests", admin_reports_member_requests_path %></li>
+                <li class="menu-item"><%= link_to "Members with Overdue Loans", admin_reports_members_with_overdue_loans_path %></li>
                 <li class="menu-item"><%= link_to "Memberships", admin_reports_memberships_path %></li>
                 <li class="menu-item"><%= link_to "Money", admin_reports_money_path %></li>
                 <li class="menu-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
       resources :items_with_holds, only: :index
       resources :zipcodes, only: :index
       get "money", to: "money#index"
+      get "members-with-overdue-loans", to: "members_with_overdue_loans#index"
     end
 
     namespace :settings do

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -221,4 +221,15 @@ class LoanTest < ActiveSupport::TestCase
       loan.upcoming_appointment
     end
   end
+
+  test "scope #overdue contains only overdue loans" do
+    create(:ended_loan) # ignored
+    overdue_loans = create_list(:overdue_loan, 3)
+    create(:loan) # active loan - ignored
+
+    query = Loan.all.overdue
+
+    assert_equal overdue_loans.size, query.count
+    assert_equal overdue_loans, query.order(id: :asc)
+  end
 end

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -1,12 +1,12 @@
 require "application_system_test_case"
 
-class Admin::MonthlyActivitiesTest < ApplicationSystemTestCase
+class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
   include AdminHelper
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::NumberHelper
   include MembersHelper
 
-  def setup
+  setup do
     sign_in_as_admin
 
     @member_without_loans = create(:member, preferred_name: "Loanless Lane")

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -1,0 +1,46 @@
+require "application_system_test_case"
+
+class Admin::MonthlyActivitiesTest < ApplicationSystemTestCase
+  include AdminHelper
+  include ActionView::Helpers::NumberHelper
+  include MembersHelper
+
+  def setup
+    sign_in_as_admin
+
+    @member_without_loans = create(:member, preferred_name: "Loanless Lane")
+
+    @member_with_non_overdue_loans = create(:member, preferred_name: "Mr. Ontime")
+    create(:loan, member: @member_with_non_overdue_loans)
+    create(:ended_loan, member: @member_with_non_overdue_loans)
+
+    member_with_one_overdue_loan = create(:member, preferred_name: "(Over)Drew")
+    create(:overdue_loan, member: member_with_one_overdue_loan)
+    create(:loan, member: member_with_one_overdue_loan)
+
+    member_with_multiple_overdue_loans = create(:member, preferred_name: "(Mul)Timothy")
+    create_list(:overdue_loan, 3, member: member_with_multiple_overdue_loans)
+    create(:loan, member: member_with_multiple_overdue_loans)
+    create(:ended_loan, member: member_with_multiple_overdue_loans)
+
+    @overdue_loan_members = [member_with_one_overdue_loan, member_with_multiple_overdue_loans]
+  end
+
+  test "the table lists the member's name, contact information, and overdue tools" do
+    visit admin_reports_members_with_overdue_loans_url
+
+    refute_text @member_without_loans.preferred_name
+    refute_text @member_with_non_overdue_loans.preferred_name
+
+    @overdue_loan_members.each do |member|
+      assert_text member.preferred_name
+      assert_text member.user.email
+      assert_text format_phone_number(member.phone_number)
+
+      member.overdue_loans.each do |loan|
+        assert_text loan.item.name
+      end
+    end
+    assert_equal 3, all("tr").size # 2 for members, 1 for the header
+  end
+end

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -2,6 +2,7 @@ require "application_system_test_case"
 
 class Admin::MonthlyActivitiesTest < ApplicationSystemTestCase
   include AdminHelper
+  include ActionView::Helpers::DateHelper
   include ActionView::Helpers::NumberHelper
   include MembersHelper
 
@@ -15,11 +16,13 @@ class Admin::MonthlyActivitiesTest < ApplicationSystemTestCase
     create(:ended_loan, member: @member_with_non_overdue_loans)
 
     member_with_one_overdue_loan = create(:member, preferred_name: "(Over)Drew")
-    create(:overdue_loan, member: member_with_one_overdue_loan)
+    create(:overdue_loan, member: member_with_one_overdue_loan, due_at: 3.weeks.ago)
     create(:loan, member: member_with_one_overdue_loan)
 
     member_with_multiple_overdue_loans = create(:member, preferred_name: "(Mul)Timothy")
-    create_list(:overdue_loan, 3, member: member_with_multiple_overdue_loans)
+    1.upto(3).each do |n|
+      create(:overdue_loan, member: member_with_multiple_overdue_loans, due_at: n.weeks.ago)
+    end
     create(:loan, member: member_with_multiple_overdue_loans)
     create(:ended_loan, member: member_with_multiple_overdue_loans)
 
@@ -39,6 +42,7 @@ class Admin::MonthlyActivitiesTest < ApplicationSystemTestCase
 
       member.overdue_loans.each do |loan|
         assert_text loan.item.name
+        assert_text time_ago_in_words(loan.due_at)
       end
     end
     assert_equal 3, all("tr").size # 2 for members, 1 for the header


### PR DESCRIPTION
# What it does

Adds a report that shows each member with overdue loans.

# Why it is important

Takes care of #1593 

# UI Change Screenshot

Report page:
![Screenshot 2024-07-24 at 10 32 49 AM](https://github.com/user-attachments/assets/a837fa3b-3f62-4b81-ae78-a907d883b307)

CSV:
![Screenshot 2024-07-24 at 10 33 07 AM](https://github.com/user-attachments/assets/d77d09d6-087a-40aa-bd66-8867e3fa52d2)


# Implementation notes

More or less copied the pattern from the memberships report.
