### PR TITLE
Fix undefined method error in CSRF handler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,7 +98,7 @@ class ApplicationController < ActionController::Base
   def handle_invalid_authenticity_token(error)
     # Track the error so we can continue investigating why this is happening to folks
     Appsignal.report_error(error) do |transaction|
-      transaction.Appsignal.set_custom_data(
+      transaction.set_custom_data(
         authenticity_token: params[:authenticity_token],
         csrf_cookie: request.cookies["csrf_token"]
       )


### PR DESCRIPTION
# What it does

There is still a bug in the custom CSRF handling code:

```
undefined method `Appsignal' for #<Appsignal::Transaction:0x00007f8f23094ae8 ...>

      transaction.Appsignal.set_custom_data(
                 ^^^^^^^^^^
```

I added a test for `ApplicationController#handle_invalid_authenticity_token`. It's worth noting that the block passed to `Appsignal.report_error` in that method isn't executed in the test environment, but I manually hacked things up and validated that at least the exception shown above (nor one like it) is no longer happening.