### PR TITLE
Move development and CI postgres to tmpfs ramdisk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+        volumes:
+          - /dev/shm/pgdata:/var/lib/postgresql/data
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
@@ -138,6 +140,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+        volumes:
+          - /dev/shm/pgdata:/var/lib/postgresql/data
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,12 @@ services:
     image: postgres:15
     env_file:
       - config/docker.env
-    volumes:
-      - db_data:/var/lib/postgresql/data
     ports:
       - '5435:5432'
     networks:
       - default
+    tmpfs:
+      - /var/lib/postgresql/data
 
   selenium_chrome:
     image: selenium/standalone-chrome-debug
@@ -43,9 +43,6 @@ services:
       - '5900:5900'
     networks:
       - default
-
-volumes:
-  db_data:
 
 networks:
   default:


### PR DESCRIPTION
# What it does

Moves postgres to run on a tmpfs ramdisk. This yields a modest improvements in bin/setup and test time locally, and hopefully similar speedups in CI.

# Why it is important

Faster tests means less human time waiting!

# Implementation notes

This means that the development database contents will not persist across reboots for people using Docker. The main instructions have folks installing postgres with homebrew, so it won't affect most people.