### PR TITLE
Require email confirmation before "borrowing" items

### DIFF
--- a/app/assets/stylesheets/partials/_index.scss
+++ b/app/assets/stylesheets/partials/_index.scss
@@ -1,4 +1,5 @@
 @import './users_password_new';
+@import './users_confirmations_new';
 @import './users_sign_in';
 @import './admin_members_item_holds';
 @import './admin_appointments';

--- a/app/assets/stylesheets/partials/_users_confirmations_new.scss
+++ b/app/assets/stylesheets/partials/_users_confirmations_new.scss
@@ -1,0 +1,19 @@
+.users-confirmations-new {
+  max-width: 500px;
+
+  .new_user {
+    margin-top: 20px;
+  }
+
+  .actions {
+    margin-top: 50px;
+  }
+
+  .field.text input {
+    width: 100%;
+  }
+
+  .btn {
+    width: 60%;
+  }
+}

--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -11,7 +11,7 @@ module Account
       @new_hold = Hold.new(item: @item, member: current_member, creator: current_user)
 
       @new_hold.transaction do
-        if @new_hold.save
+        if current_user.confirmed? && @new_hold.save
           ahoy.track "Placed hold", hold_id: @new_hold.id
           @new_hold.start! if @new_hold.ready_for_pickup?
           redirect_to item_path(@item), success: "Hold placed.", status: :see_other

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :rememberable,
-    :lockable, :timeoutable, :trackable, :validatable
+    :lockable, :timeoutable, :trackable, :validatable, :confirmable,
+    reconfirmable: true
 
   acts_as_tenant :library
 

--- a/app/views/account/_email_verification_message.html.erb
+++ b/app/views/account/_email_verification_message.html.erb
@@ -1,0 +1,10 @@
+<% unless current_user.confirmed? %>
+  <div class="toast toast-warning">
+    <p>
+      <strong>Your email address has not been verified.</strong>
+      To borrow tools, please confirm your email address by clicking the link in the confirmation email you received.
+      If you didn't receive an email or can't find it then you can request another one.
+    </p>
+    <%= link_to "Resend Confirmation Email", new_user_confirmation_path, class: "btn btn-lg btn-default" %>
+  </div>
+<% end %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,16 @@
-<h2>Resend confirmation instructions</h2>
+<div class="users-confirmations-new container">
+  <h2>Resend Confirmation Instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post}) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post}) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+    <div class="field text mb-2">
+      <%= f.label :email %><br>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+    <div class="actions text-center">
+      <%= f.submit "Resend Confirmation Instructions", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -37,6 +37,7 @@
         <li>If you don't have a membership with us yet, <%= link_to "sign up online", signup_path %>.</li>
       <% end %>
         <li>If you need to choose or don't remember your password, <%= link_to "reset your password", new_user_password_path %>.</li>
+        <li>If you need haven't confirmed your email address, <%= link_to "request a confirmation email", new_user_confirmation_path %>.</li>
       </ul>
   </div>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -73,13 +73,20 @@
                   You have this item checked out
                 <% elsif @current_hold %>
                   You have this item on hold
+                <% elsif !current_user.confirmed? %>
+                  Confirm your email address before placing this item on hold
                 <% else %>
                   You can place this item on hold
                 <% end %>
               </h5>
             </div>
             <div class="card-body">
-              <% if @item.available? %>
+              <% if !current_user.confirmed? %>
+                <p>
+                  Click the link in the confirmation email you received to confirm your email address.
+                  If you didn't receive an email or can't find it then you can <%= link_to "request another one", new_user_confirmation_path %>.
+                </p>
+              <% elsif @item.available? %>
                 <% if @item.active_holds.empty? %>
                   <p>
                     If you place this item on hold you will be <b>first</b> on the waiting list.
@@ -126,7 +133,7 @@
                 <%= render partial: "items/place_hold_on/item_user_checked_out", locals: {loan: @item.checked_out_exclusive_loan} %>
               <% elsif @current_hold %>
                 <%= render partial: "items/place_hold_on/item_already_with_a_hold", locals: {hold: @current_hold} %>
-              <% else %>
+              <% elsif current_user.confirmed? %>
                 <%= render partial: "items/place_hold_on/item", locals: {item: @item} %>
               <% end %>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,6 +84,7 @@
           <%= flash_message :alert, "error" %>
 
           <%= render(partial: "account/membership_renewal_message") if user_signed_in? %>
+          <%= render(partial: "account/email_verification_message") if user_signed_in? %>
 
           <%= yield %>
         </div>

--- a/app/views/signup/confirmations/_instructions.html.erb
+++ b/app/views/signup/confirmations/_instructions.html.erb
@@ -4,7 +4,11 @@
 <% if @amount %>
   <p><strong>Your payment of <%= @amount.format %> has been processed and applied to your account.</strong></p>
 <% end %>
-<p>To activate your membership, please bring the following with you to the library the first time you visit:</p>
+<p>To activate your membership please:</p>
+<ul>
+  <li><strong>Confirm your email address</strong><br>You'll receive an email with a confirmation link that you need to click or paste into your browser.</li>
+</ul>
+<p>And please bring the following with you to the library the first time you visit:</p>
 <ul>
   <li><strong>Proof of your address</strong><br>This needs to include your name and current address in <%= library.city %>. Utility bills, leases, and other official mail work well for this.</li>
   <li><strong>A photo ID</strong><br>This needs to show your name and a photo and can be from the state, your job, school, etc.</li>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -134,7 +134,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 2.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/db/migrate/20240806214629_add_devise_confirmable_to_users.rb
+++ b/db/migrate/20240806214629_add_devise_confirmable_to_users.rb
@@ -1,0 +1,15 @@
+class AddDeviseConfirmableToUsers < ActiveRecord::Migration[7.1]
+  def change
+    change_table(:users) do |t|
+      t.string :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string :unconfirmed_email
+      t.index :confirmation_token, unique: true
+    end
+
+    reversible do |direction|
+      direction.up { execute "UPDATE users SET confirmation_sent_at=now(), confirmed_at=now()" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_221811) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_06_214629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -879,6 +879,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_221811) do
     t.enum "role", default: "member", null: false, enum_type: "user_role"
     t.bigint "member_id"
     t.integer "library_id"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email", "library_id"], name: "index_users_on_email_and_library_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["library_id"], name: "index_users_on_library_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,39 +6,46 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
       reminders_via_email: true, reminders_via_text: false, receive_newsletter: true, volunteer_interest: true
     }
 
+    confirmed_email_attrs = { confirmation_sent_at: Time.current, confirmed_at: Time.current }
+
     admin_member = Member.create!(member_attrs.merge(
       email: "admin#{email_suffix}@example.com", full_name: "Admin Member", preferred_name: "Admin"
     ))
-    User.create!(email: admin_member.email, password: "password", member: admin_member, role: "admin")
+    User.create!(email: admin_member.email, password: "password", member: admin_member, role: "admin", **confirmed_email_attrs)
+
+    unconfirmed_email_member = Member.create!(member_attrs.merge(
+      email: "member_with_unconfirmed_email#{email_suffix}@example.com", full_name: "Unconfirmed Email", preferred_name: "Unconfirmed Email"
+    ))
+    User.create!(email: unconfirmed_email_member.email, password: "password", member: unconfirmed_email_member)
 
     verified_member = Member.create!(member_attrs.merge(
       email: "verified_member#{email_suffix}@example.com", full_name: "Firstname Lastname", preferred_name: "Verified", status: 1, address_verified: true
     ))
-    User.create!(email: verified_member.email, password: "password", member: verified_member)
+    User.create!(email: verified_member.email, password: "password", member: verified_member, **confirmed_email_attrs)
     verified_member.memberships.create!(started_at: Time.current, ended_at: 1.year.since)
 
     unverified_member = Member.create!(member_attrs.merge(
       email: "new_member#{email_suffix}@example.com", full_name: "Firstname Lastname", preferred_name: "New"
     ))
-    User.create!(email: unverified_member.email, password: "password", member: unverified_member)
+    User.create!(email: unverified_member.email, password: "password", member: unverified_member, **confirmed_email_attrs)
 
     member_for_18_months = Member.create!(member_attrs.merge(
       email: "member_for_18_months#{email_suffix}@example.com", full_name: "Member for Eighteen Months", preferred_name: "18mo", status: 1, address_verified: true
     ))
-    User.create!(email: member_for_18_months.email, password: "password", member: member_for_18_months)
+    User.create!(email: member_for_18_months.email, password: "password", member: member_for_18_months, **confirmed_email_attrs)
     Membership.create!(member: member_for_18_months, started_at: 18.months.ago, ended_at: 6.months.ago)
     Membership.create!(member: member_for_18_months, started_at: 6.months.ago + 1.day, ended_at: 6.months.since - 1.day)
 
     expired_member = Member.create!(member_attrs.merge(
       email: "expired_member#{email_suffix}@example.com", full_name: "Expired Member", preferred_name: "Expired", status: 1, address_verified: true
     ))
-    User.create!(email: expired_member.email, password: "password", member: expired_member)
+    User.create!(email: expired_member.email, password: "password", member: expired_member, **confirmed_email_attrs)
     Membership.create!(member: expired_member, started_at: 18.months.ago, ended_at: 6.months.ago)
 
     expires_in_one_week_member = Member.create!(member_attrs.merge(
       email: "expires_soon#{email_suffix}@example.com", full_name: "Expires Soon Member", preferred_name: "Soon", status: 1, address_verified: true
     ))
-    User.create!(email: expires_in_one_week_member.email, password: "password", member: expires_in_one_week_member)
+    User.create!(email: expires_in_one_week_member.email, password: "password", member: expires_in_one_week_member, **confirmed_email_attrs)
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 
     # Hardcoding this value (the value of which is "password") means that user sessions aren't invalidated when running
@@ -100,5 +107,7 @@ User.create!(
   email: "super.admin@example.com",
   password: "password",
   library: Library.first,
-  role: "super_admin"
+  role: "super_admin",
+  confirmation_sent_at: Time.current,
+  confirmed_at: Time.current
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
       reminders_via_email: true, reminders_via_text: false, receive_newsletter: true, volunteer_interest: true
     }
 
-    confirmed_email_attrs = { confirmation_sent_at: Time.current, confirmed_at: Time.current }
+    confirmed_email_attrs = {confirmation_sent_at: Time.current, confirmed_at: Time.current}
 
     admin_member = Member.create!(member_attrs.merge(
       email: "admin#{email_suffix}@example.com", full_name: "Admin Member", preferred_name: "Admin"

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -153,7 +153,7 @@ namespace :devdata do
     # holds where this person is in line behind someone else
     waiting_holds.times do
       item = random_model(Item.active.available.without_active_holds)
-      member_in_front = random_model(Member)
+      member_in_front = random_member
       Hold.create!(member: member_in_front, item: item, creator: member_in_front.user)
       Hold.create!(member: member, item: item, creator: member.user)
     end
@@ -166,5 +166,9 @@ namespace :devdata do
 
   def random_model(scope)
     scope.order("RANDOM()").first
+  end
+
+  def random_member
+    random_model(Member.where.not(email: "member_with_unconfirmed_email@example.com"))
   end
 end

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -112,7 +112,7 @@ namespace :devdata do
     member = Member.create!(
       status: status,
       email: email,
-      user: User.create!(email: email, password: "password"),
+      user: User.create!(email: email, password: "password", confirmed_at: Time.current, confirmation_sent_at: Time.current),
       phone_number: "5005550006",
       full_name: full_name,
       preferred_name: preferred_name,

--- a/test/controllers/account/holds_controller_test.rb
+++ b/test/controllers/account/holds_controller_test.rb
@@ -8,10 +8,11 @@ module Account
       @item = create(:item)
       @member = create(:verified_member_with_membership)
       @user = create(:user, member: @member)
-      sign_in @user
     end
 
     test "creates hold for an item and starts hold" do
+      sign_in @user
+
       assert_difference("@item.holds.count") do
         post account_holds_url, params: {item_id: @item.id}
       end
@@ -23,6 +24,8 @@ module Account
     end
 
     test "creates hold for an item and doesn't start hold" do
+      sign_in @user
+
       create(:hold, item: @item)
 
       assert_difference("@item.holds.count") do
@@ -33,6 +36,15 @@ module Account
 
       hold = @item.holds.last
       refute hold.started?
+    end
+
+    test "does not create holds for users that have unconfirmed email addresses" do
+      member = create(:member, user: create(:user, :unconfirmed))
+      sign_in member.user
+
+      assert_difference("@item.holds.count", 0) do
+        post account_holds_url, params: {item_id: @item.id}
+      end
     end
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -55,7 +55,7 @@ module Admin
 
       user.reload
 
-      assert_equal "modified@example.com", user.email
+      assert_equal "modified@example.com", user.unconfirmed_email
       assert_equal "admin", user.role
     end
 
@@ -67,7 +67,7 @@ module Admin
 
       user.reload
 
-      assert_equal "modified@example.com", user.email
+      assert_equal "modified@example.com", user.unconfirmed_email
       assert_equal "member", user.role
     end
 
@@ -82,7 +82,7 @@ module Admin
 
       user.reload
 
-      assert_equal "modified@example.com", user.email
+      assert_equal "modified@example.com", user.unconfirmed_email
       assert_equal "super_admin", user.role
     end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,9 +1,16 @@
 FactoryBot.define do
   factory :user do
-    library { Library.first || create(:library) }
+    library { Library.first || association(:library) }
 
     email
     password { "password" }
+    confirmation_sent_at { Time.current }
+    confirmed_at { Time.current }
+
+    trait :unconfirmed do
+      confirmation_sent_at { nil }
+      confirmed_at { nil }
+    end
 
     factory :member_user do
       role { "member" }

--- a/test/system/holds_test.rb
+++ b/test/system/holds_test.rb
@@ -32,6 +32,17 @@ class HoldsTest < ApplicationSystemTestCase
     refute_selector 'input[value="Place a hold"]'
   end
 
+  test "member with an unconfirmed email can't place a hold on an item" do
+    member = create(:member, user: create(:user, :unconfirmed))
+    login_as member.user
+
+    item = create(:item)
+
+    visit item_url(item)
+
+    assert_text "Confirm your email address before placing this item on hold"
+  end
+
   test "member can place a hold multiple times when the borrow policy allows it" do
     login_as @member.user
 

--- a/test/system/user_email_verification_test.rb
+++ b/test/system/user_email_verification_test.rb
@@ -1,0 +1,28 @@
+require "application_system_test_case"
+
+class UserEmailVerificationTest < ApplicationSystemTestCase
+  test "unconfirmed users see a message asking them to verify their email address" do
+    member = create(:member, user: create(:user, :unconfirmed))
+    login_as member.user
+
+    visit root_path
+
+    assert_selector ".toast-warning"
+    assert_text "email address has not been verified"
+  end
+
+  test "confirmed users do not see a message asking them to verify their email address" do
+    member = create(:member, user: create(:user))
+    login_as member.user
+
+    visit root_path
+
+    refute_selector ".toast-warning"
+  end
+
+  test "users that are not signed in do not see a message asking them to verify their email address" do
+    visit root_path
+
+    refute_selector ".toast-warning"
+  end
+end


### PR DESCRIPTION
# What it does

This adds a check to prevent users from placing holds on items before confirming their email address (via devise). It also adds some warning toast messages to encourage users to confirm.

# Why it is important

Handles #1370 

# UI Change Screenshot

Verify email message on the search page:
![Screenshot 2024-08-07 at 3 21 06 PM](https://github.com/user-attachments/assets/c678d9d1-b93f-47e2-901d-7e68831753bb)

Verify email message on the item page:
![Screenshot 2024-08-07 at 3 20 58 PM](https://github.com/user-attachments/assets/d57a5354-d413-464e-a950-bc969b47ea14)

Message where a user would normally see the "Place Hold" button:
![Screenshot 2024-08-07 at 3 21 51 PM](https://github.com/user-attachments/assets/caab7e82-cb99-4d28-bb9d-cb8abe61395c)

Member login page:
![Screenshot_2024-08-07_at_3_22_07 PM](https://github.com/user-attachments/assets/455ae56c-9b07-4e0f-9524-934014c70feb)

Resend confirmation instructions page:
![Screenshot 2024-08-07 at 3 22 18 PM](https://github.com/user-attachments/assets/468ccde4-9599-4930-9f41-5073e30b2a1b)

# Implementation notes

It doesn't look like members can create loans directly, so I prevented members with unconfirmed email addresses from being able to make holds. Admins could still create loans for these members, so maybe we want to add a message on the admin side that warns them about creating loans for these members?

Right now the migration will mark all existing users as verified so these changes should only impact new members. I'm not sure if there's a heuristic we could use to make this smarter.

Take a look and let me know what you think!
