### PR TITLE
Added a renew all button for loans

### DIFF
--- a/app/controllers/account/loans_controller.rb
+++ b/app/controllers/account/loans_controller.rb
@@ -1,11 +1,21 @@
 module Account
   class LoansController < BaseController
+    include Lending
+
     def index
       @loans = current_member.loans.checked_out.includes(:item, :renewal_requests).order(:due_at)
     end
 
     def history
       @loans = current_member.loan_summaries.returned.order(ended_at: :desc)
+    end
+
+    def renew_all
+      current_member.loans.checked_out.each do |loan|
+        renew_loan(loan) if loan.member_renewable?
+      end
+
+      redirect_to account_loans_path, status: :see_other, success: "Renewed all loaned items"
     end
   end
 end

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -6,6 +6,9 @@
         <% if @current_library.allow_appointments? %>
           <%= link_to "Schedule a Return", new_account_appointment_path, class: "btn btn-primary" %>
         <% end %>
+        <% if @loans.any?(&:member_renewable?)%>
+          <%= button_to "Renew All", renew_all_account_loans_path, method: :post, class: "btn btn-secondary" %>
+        <% end %>
         <%= link_to "View Loan History", history_account_loans_path, class: "ml-2" %>
       <% end %>
 

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -6,7 +6,7 @@
         <% if @current_library.allow_appointments? %>
           <%= link_to "Schedule a Return", new_account_appointment_path, class: "btn btn-primary" %>
         <% end %>
-        <% if @loans.any?(&:member_renewable?)%>
+        <% if @loans.any?(&:member_renewable?) %>
           <%= button_to "Renew All", renew_all_account_loans_path, method: :post, class: "btn btn-secondary" %>
         <% end %>
         <%= link_to "View Loan History", history_account_loans_path, class: "ml-2" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     end
     resources :loans, only: :index do
       get :history, to: "loans#history", on: :collection
+      post :renew_all, to: "loans#renew_all", on: :collection
     end
     resource :member, only: [:show, :edit, :update]
     resource :password, only: [:edit, :update]

--- a/test/system/account/loans_test.rb
+++ b/test/system/account/loans_test.rb
@@ -1,0 +1,44 @@
+require "application_system_test_case"
+
+module Account
+  class ReservationsTest < ApplicationSystemTestCase
+    setup do
+      @member = create(:verified_member_with_membership)
+      login_as @member.user
+    end
+
+    test "members can renew all renewable loans" do
+      borrow_policy = create(:member_renewable_borrow_policy)
+
+      ignored_item = create(:item, borrow_policy:)
+      create(:loan, item: ignored_item)
+
+      renewable_item = create(:item, borrow_policy:)
+      create(:loan, member: @member, item: renewable_item)
+
+      non_renewable_item = create(:item, borrow_policy:)
+      create(:loan, member: @member, item: non_renewable_item, renewal_count: borrow_policy.renewal_limit)
+
+      visit account_loans_path
+
+      assert_difference("Loan.count", 1) do
+        click_on "Renew All"
+        assert_text "Renewed"
+      end
+
+      renewed_loan = Loan.last
+      assert_equal renewable_item, renewed_loan.item
+    end
+
+    test "members that lack renewable loans don't see a renew all button" do
+      borrow_policy = create(:member_renewable_borrow_policy)
+
+      non_renewable_item = create(:item, borrow_policy:)
+      create(:loan, member: @member, item: non_renewable_item, renewal_count: borrow_policy.renewal_limit)
+
+      visit account_loans_path
+
+      refute_text "Renew All"
+    end
+  end
+end


### PR DESCRIPTION
# What it does

Adds a button and controller action to renew all loans.

# Why it is important

Takes care of #1311 

# UI Change Screenshot

The loans page with the button:
![Screenshot 2024-08-08 at 3 45 23 PM](https://github.com/user-attachments/assets/56c63efc-d873-4aed-be34-3c61798f13f0)

The loans page with the button and the flash message:
![Screenshot 2024-08-08 at 3 45 35 PM](https://github.com/user-attachments/assets/c80cd585-9cb7-40a5-b8f2-ba342006b7f9)

# Implementation notes

Right now the button only appears if any one of the loans can be renewed. 

It didn't seem to make sense to lump the request renewal aspect of some of the loans in with this button, but maybe that could be useful at some point.
