### PR TITLE
Send reservation requested emails to all admin users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,6 +615,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux
 

--- a/app/controllers/account/reservations/submissions_controller.rb
+++ b/app/controllers/account/reservations/submissions_controller.rb
@@ -12,6 +12,7 @@ module Account
         @reservation.manager.request
         if @reservation.save
           ReservationMailer.with(reservation: @reservation).reservation_requested.deliver_later
+          ReservationMailer.with(reservation: @reservation).review_requested.deliver_later
           redirect_to account_reservation_url(@reservation), success: "The reservation was submitted."
         else
           redirect_to account_reservation_url(@reservation), error: "This reservation couldn't be submitted."

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -2,8 +2,9 @@ class ReservationMailer < ApplicationMailer
   def reservation_requested
     @reservation = params[:reservation]
     @library = @reservation.library
+    @to_emails = User.select { |user| user.has_role?("admin") && user.library_id === @library.id }.pluck(:email)
     @subject = "Reservation submitted for #{@reservation.started_at.to_fs(:short_date)}"
-    mail(to: @reservation.submitted_by.email, subject: @subject)
+    mail(to: @reservation.submitted_by.email, subject: @subject, bcc: @to_emails)
   end
 
   def reviewed

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -9,7 +9,7 @@ class ReservationMailer < ApplicationMailer
   def review_requested
     @reservation = params[:reservation]
     @library = @reservation.library
-    @admins = User.where(library_id: @library.id).where(role: ["admin", "super_admin"]).pluck(:email)
+    @admins = User.where(library_id: @library.id).where(role: ["admin"]).pluck(:email)
     @subject = "Reservation ready for review"
     mail(to: @admins, subject: @subject)
   end

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -2,9 +2,16 @@ class ReservationMailer < ApplicationMailer
   def reservation_requested
     @reservation = params[:reservation]
     @library = @reservation.library
-    @to_emails = User.select { |user| user.has_role?("admin") && user.library_id === @library.id }.pluck(:email)
     @subject = "Reservation submitted for #{@reservation.started_at.to_fs(:short_date)}"
-    mail(to: @reservation.submitted_by.email, subject: @subject, bcc: @to_emails)
+    mail(to: @reservation.submitted_by.email, subject: @subject)
+  end
+
+  def review_requested
+    @reservation = params[:reservation]
+    @library = @reservation.library
+    @admins = User.where(library_id: @library.id).where(role: ["admin", "super_admin"]).pluck(:email)
+    @subject = "Reservation ready for review"
+    mail(to: @admins, subject: @subject)
   end
 
   def reviewed

--- a/app/views/reservation_mailer/review_requested.mjml
+++ b/app/views/reservation_mailer/review_requested.mjml
@@ -1,0 +1,22 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="28px" font-weight="bold" align="center">
+      <p><%= @subject %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p><%= @reservation.name %> ready for review.</p>
+      <p>
+        <a href="<%= admin_reservation_url(@reservation) %>">Review reservation request</a> in the Circulate app.
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/reservation_mailer/review_requested.text.erb
+++ b/app/views/reservation_mailer/review_requested.text.erb
@@ -1,0 +1,5 @@
+<%= @subject %>
+
+<%= @reservation.name %>
+
+<%= admin_reservation_url(@reservation) %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -59,8 +59,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     find(:rich_text_area, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
   end
 
-  def assert_delivered_email(to:, &block)
-    delivered_mail = ActionMailer::Base.deliveries.last
+  def assert_delivered_email(to:, second_to_last: false, &block)
+    delivered_mail = second_to_last ? ActionMailer::Base.deliveries[-2] : ActionMailer::Base.deliveries.last
     assert_equal [to], delivered_mail.to
 
     assert delivered_mail.body.parts.size == 2, "non multipart email was sent!"

--- a/test/mailers/reservation_mailer_test.rb
+++ b/test/mailers/reservation_mailer_test.rb
@@ -19,6 +19,21 @@ class ReservationMailerTest < ApplicationSystemTestCase
     end
   end
 
+  test "#review_requested includes HTML and text parts when a reservation is submitted" do
+    reservation = create(:reservation)
+    admin_user = create(:user, role: "admin", library: reservation.library)
+
+    ReservationMailer.with(reservation:).review_requested.deliver_now
+
+    expected_subject = "Reservation ready for review"
+
+    assert_delivered_email(to: admin_user.email) do |html, text, _, subject|
+      assert_equal expected_subject, subject
+      assert_includes html, expected_subject, "mail should include subject in html part"
+      assert_includes text, expected_subject, "mail should include subject in text part"
+    end
+  end
+
   test "#reviewed includes html and text parts containing the notes when approved" do
     reservation = create(:reservation, :approved)
 

--- a/test/system/account/reservations_test.rb
+++ b/test/system/account/reservations_test.rb
@@ -6,6 +6,7 @@ module Account
       ActionMailer::Base.deliveries.clear
 
       @member = create(:verified_member_with_membership)
+      @admin_user = create(:user, role: "admin", library: @member.library)
       @organization = create(:organization)
       @attributes = attributes_for(:reservation, started_at: 3.days.from_now.at_noon, ended_at: 10.days.from_now.at_noon).slice(:name, :started_at, :ended_at)
 
@@ -119,9 +120,14 @@ module Account
         assert_text "The reservation was submitted."
       end
 
-      assert_emails 1
-      assert_delivered_email(to: @member.email) do |html, text|
+      assert_emails 2
+
+      assert_delivered_email(to: @member.email, second_to_last: true) do |html, text|
         assert_includes html, "Reservation submitted"
+      end
+
+      assert_delivered_email(to: @admin_user.email) do |html, text|
+        assert_includes html, "Reservation ready for review"
       end
     end
   end


### PR DESCRIPTION
# What it does

Sends email to admins when a member submits a reservation

# Why it is important

Closes #1531 

# UI Change Screenshot
<img width="1111" alt="Screenshot 2024-08-17 at 10 49 22 PM" src="https://github.com/user-attachments/assets/3faf007e-1893-444f-81aa-d033001b1a8a">

# Implementation notes
This doesn't send the mailer when an admin requests a reservation through `ReservationsController`, since it doesn't seemed like review is required when a reservation is created this way.
