### PR TITLE
Move reservation reviewing into a tab

### DIFF
--- a/app/views/admin/reservations/_profile.html.erb
+++ b/app/views/admin/reservations/_profile.html.erb
@@ -9,9 +9,6 @@
     <% elsif @reservation.manager.can? :build %>
       <%= button_to "Start Building", admin_reservation_status_path(@reservation), method: :patch, params: {reservation: {status: Reservation.statuses[:building]}}, remote: true, class: "btn" %>
 
-    <% elsif @reservation.manager.can? :approve %>
-      <%= link_to "Review", edit_admin_reservation_review_path(@reservation), class: "btn" %>
-
     <% elsif @reservation.manager.can? :ready %>
       <%= button_to "Ready for Pickup", admin_reservation_status_path(@reservation), method: :patch, params: {reservation: {status: Reservation.statuses[:ready]}}, remote: true, class: "btn" %>
 
@@ -49,6 +46,7 @@
       <%= tab_link "Items", admin_reservation_path(@reservation) %>
       <%= tab_link "Pickup", admin_reservation_pickup_path(@reservation) %>
       <%= tab_link "Questions", admin_reservation_questions_path(@reservation) %>
+      <%= tab_link "Review", edit_admin_reservation_review_path(@reservation) if @reservation.manager.can?(:approve) %>
       <%= tab_link("Review Notes", admin_reservation_review_path(@reservation)) if @reservation.notes? %>
     </ul>
 

--- a/app/views/admin/reservations/reviews/edit.html.erb
+++ b/app/views/admin/reservations/reviews/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>Editing reservation review</h1>
-
-<%= render "form", reservation: @reservation %>
+<%= render "admin/reservations/profile" do %>
+  <%= render "form", reservation: @reservation %>
+<% end %>

--- a/test/factories/reservations.rb
+++ b/test/factories/reservations.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
     library { Library.first || association(:library) }
     organization
 
+    trait :pending do
+      status { "pending" }
+      notes { nil }
+    end
+
     trait :requested do
       status { "requested" }
       notes { nil }

--- a/test/system/admin/reservations/reviews_test.rb
+++ b/test/system/admin/reservations/reviews_test.rb
@@ -59,4 +59,11 @@ class AdminReservationsReviewsTest < ApplicationSystemTestCase
 
     assert_text "Can't review a reservation with status approved"
   end
+
+  test "does not have a review button/tab for non-requested reservations" do
+    reservation = create(:reservation, :pending)
+    visit admin_reservation_path(reservation)
+
+    refute_text(/\Areview\z/i)
+  end
 end


### PR DESCRIPTION
# What it does

Instead of reviewing a reservation on its own page, now it can be reviewed in a "Review" tab

# Why it is important

Takes care of #1634 

# UI Change Screenshot

Pending reservation:
![Screenshot 2024-08-19 at 4 44 04 PM](https://github.com/user-attachments/assets/6c615736-ff03-4168-a82f-9de278c17f3b)

Requested reservation on the items tab:
![Screenshot_2024-08-19_at_4_44_16 PM](https://github.com/user-attachments/assets/885e8277-22dd-4a0b-a554-9037464c154e)

Requested reservation on the review tab:
![Screenshot 2024-08-19 at 4 44 29 PM](https://github.com/user-attachments/assets/93097ced-44d2-473a-afc9-3376c8f5d3fa)

Immediately after approving a requested reservation:
![Screenshot 2024-08-19 at 4 44 47 PM](https://github.com/user-attachments/assets/1fd1dd16-dc3a-4a67-8a86-a2f4b40bd0f9)

The review notes tab of an approved reservation:
![Screenshot 2024-08-19 at 4 44 57 PM](https://github.com/user-attachments/assets/9d207a42-cba4-4f7d-9121-c1dac17b5835)

# Implementation notes

This is implemented the way the other tabs on the reservation show page are. I think from an accessibility perspective these tabs are probably more like a subnav rather than capital-T "Tabs" but that might be a more general thing to investigate.
