### PR TITLE
Swapped the yarn add playwright command with a generic yarn install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,9 +16,8 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
-  puts "== Installing playwright yarn package =="
-  playwright_version=`bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION'`.strip
-  system!("yarn add -D 'playwright@#{playwright_version}'")
+  puts "== Installing yarn packages =="
+  system!("yarn install")
 
   if ENV["USING_NIX"] == "1"
     # Nix cannot execute misc downloaded binaries so it brings its own browser


### PR DESCRIPTION
# What it does

Instead of running `yarn add` for playwright, this just runs `yarn install` in the `bin/setup` script. This way the version of playwright that's listed in the package.json is ultimately installed.

# Why it is important

I was running into an issue where running `bin/setup` would change the playwright version from 1.46.0 to 1.45.0 in the package.json. If I cleared those changes it would trip up the capybara/playwright immigration and tell me playwright wasn't actually installed.

# Implementation notes

I think there's a case to be made to lock playwright to what the ruby implementation considers a compatible version (via `bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION'`). Maybe a general dependency update changed the package.json and these got out of sync and we just need to figure out a better way to keep them in sync? 