### PR TITLE
Swap member and user relationship

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -18,7 +18,7 @@ class Member < ApplicationRecord
   has_one :pending_membership, -> { merge(Membership.pending) }, class_name: "Membership"
   has_one :last_membership, -> { order("ended_at DESC NULLS FIRST") }, class_name: "Membership"
 
-  has_one :user, dependent: :destroy
+  belongs_to :user, optional: true
   has_many :notes, as: :notable
 
   PRONOUNS = ["he/him", "she/her", "they/them"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
     super_admin: "super_admin"
   }
 
-  belongs_to :member, optional: true
+  has_one :member
 
   scope :by_creation_date, -> { order(created_at: :asc) }
 

--- a/db/migrate/20240904212517_make_members_belong_to_user.rb
+++ b/db/migrate/20240904212517_make_members_belong_to_user.rb
@@ -1,0 +1,23 @@
+class MakeMembersBelongToUser < ActiveRecord::Migration[7.2]
+  def up
+    change_table(:members) do |t|
+      t.belongs_to :user, null: true, foreign_key: true, index: true
+      t.index %i[library_id user_id], unique: true
+    end
+
+    execute("UPDATE members SET user_id = u.id from users u where members.id = u.member_id")
+
+    remove_belongs_to :users, :member, null: true, foreign_key: true
+  end
+
+  def down
+    change_table(:users) do |t|
+      t.belongs_to :member, null: true, foreign_key: true, index: true
+      t.index %i[member_id library_id], unique: false
+    end
+
+    execute("UPDATE users SET member_id = m.id from members m where users.id = m.user_id")
+
+    remove_belongs_to :members, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_04_212517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -654,8 +654,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
     t.text "pronouns", default: [], array: true
     t.string "pronunciation"
     t.integer "library_id"
+    t.bigint "user_id"
     t.index ["library_id", "number"], name: "index_members_on_library_id_and_number", unique: true
+    t.index ["library_id", "user_id"], name: "index_members_on_library_id_and_user_id", unique: true
     t.index ["library_id"], name: "index_members_on_library_id"
+    t.index ["user_id"], name: "index_members_on_user_id"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -885,7 +888,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "role", default: "member", null: false, enum_type: "user_role"
-    t.bigint "member_id"
     t.integer "library_id"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
@@ -895,8 +897,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
     t.index ["email", "library_id"], name: "index_users_on_email_and_library_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["library_id"], name: "index_users_on_library_id"
-    t.index ["member_id", "library_id"], name: "index_users_on_member_id_and_library_id"
-    t.index ["member_id"], name: "index_users_on_member_id"
     t.index ["reset_password_token", "library_id"], name: "index_users_on_reset_password_token_and_library_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token", "library_id"], name: "index_users_on_unlock_token_and_library_id"
@@ -923,6 +923,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
   add_foreign_key "loans", "items"
   add_foreign_key "loans", "loans", column: "initial_loan_id"
   add_foreign_key "loans", "members"
+  add_foreign_key "members", "users"
   add_foreign_key "memberships", "members"
   add_foreign_key "notes", "users", column: "creator_id"
   add_foreign_key "notifications", "members"
@@ -949,7 +950,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_201215) do
   add_foreign_key "ticket_updates", "users", column: "creator_id"
   add_foreign_key "tickets", "items"
   add_foreign_key "tickets", "users", column: "creator_id"
-  add_foreign_key "users", "members"
 
   create_view "category_nodes", materialized: true, sql_definition: <<-SQL
       WITH RECURSIVE search_tree(id, library_id, name, slug, parent_id, path_names, path_ids) AS (

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,44 +8,44 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
 
     confirmed_email_attrs = {confirmation_sent_at: Time.current, confirmed_at: Time.current}
 
-    admin_member = Member.create!(member_attrs.merge(
-      email: "admin#{email_suffix}@example.com", full_name: "Admin Member", preferred_name: "Admin"
+    admin_user = User.create!(email: "admin#{email_suffix}@example.com", password: "password", role: "admin", **confirmed_email_attrs)
+    Member.create!(member_attrs.merge(
+      email: admin_user.email, full_name: "Admin Member", preferred_name: "Admin"
     ))
-    User.create!(email: admin_member.email, password: "password", member: admin_member, role: "admin", **confirmed_email_attrs)
 
-    unconfirmed_email_member = Member.create!(member_attrs.merge(
-      email: "member_with_unconfirmed_email#{email_suffix}@example.com", full_name: "Unconfirmed Email", preferred_name: "Unconfirmed Email"
+    unconfirmed_email_user = User.create!(email: "member_with_unconfirmed_email#{email_suffix}@example.com", password: "password", unconfirmed_email: "member_with_unconfirmed_email#{email_suffix}@example.com")
+    Member.create!(member_attrs.merge(
+      email: unconfirmed_email_user.email, full_name: "Unconfirmed Email", preferred_name: "Unconfirmed Email"
     ))
-    User.create!(email: unconfirmed_email_member.email, password: "password", member: unconfirmed_email_member)
 
+    verified_user = User.create!(email: "verified_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     verified_member = Member.create!(member_attrs.merge(
-      email: "verified_member#{email_suffix}@example.com", full_name: "Firstname Lastname", preferred_name: "Verified", status: 1, address_verified: true
+      email: verified_user.email, full_name: "Firstname Lastname", preferred_name: "Verified", status: 1, address_verified: true
     ))
-    User.create!(email: verified_member.email, password: "password", member: verified_member, **confirmed_email_attrs)
     verified_member.memberships.create!(started_at: Time.current, ended_at: 1.year.since)
 
-    unverified_member = Member.create!(member_attrs.merge(
-      email: "new_member#{email_suffix}@example.com", full_name: "Firstname Lastname", preferred_name: "New"
+    unverified_user = User.create!(email: "new_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
+    Member.create!(member_attrs.merge(
+      email: unverified_user.email, full_name: "Firstname Lastname", preferred_name: "New"
     ))
-    User.create!(email: unverified_member.email, password: "password", member: unverified_member, **confirmed_email_attrs)
 
+    member_for_18_months_user = User.create!(email: "member_for_18_months#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     member_for_18_months = Member.create!(member_attrs.merge(
-      email: "member_for_18_months#{email_suffix}@example.com", full_name: "Member for Eighteen Months", preferred_name: "18mo", status: 1, address_verified: true
+      email: member_for_18_months_user.email, full_name: "Member for Eighteen Months", preferred_name: "18mo", status: 1, address_verified: true
     ))
-    User.create!(email: member_for_18_months.email, password: "password", member: member_for_18_months, **confirmed_email_attrs)
     Membership.create!(member: member_for_18_months, started_at: 18.months.ago, ended_at: 6.months.ago)
     Membership.create!(member: member_for_18_months, started_at: 6.months.ago + 1.day, ended_at: 6.months.since - 1.day)
 
+    expired_user = User.create!(email: "expired_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     expired_member = Member.create!(member_attrs.merge(
-      email: "expired_member#{email_suffix}@example.com", full_name: "Expired Member", preferred_name: "Expired", status: 1, address_verified: true
+      email: expired_user.email, full_name: "Expired Member", preferred_name: "Expired", status: 1, address_verified: true
     ))
-    User.create!(email: expired_member.email, password: "password", member: expired_member, **confirmed_email_attrs)
     Membership.create!(member: expired_member, started_at: 18.months.ago, ended_at: 6.months.ago)
 
+    expires_in_one_week_user = User.create!(email: "expires_soon#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     expires_in_one_week_member = Member.create!(member_attrs.merge(
-      email: "expires_soon#{email_suffix}@example.com", full_name: "Expires Soon Member", preferred_name: "Soon", status: 1, address_verified: true
+      email: expires_in_one_week_user.email, full_name: "Expires Soon Member", preferred_name: "Soon", status: 1, address_verified: true
     ))
-    User.create!(email: expires_in_one_week_member.email, password: "password", member: expires_in_one_week_member, **confirmed_email_attrs)
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 
     # Hardcoding this value (the value of which is "password") means that user sessions aren't invalidated when running

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -109,10 +109,11 @@ namespace :devdata do
     @member_count ||= 100
     number = @member_count += 1
 
+    user = User.create!(email: email, password: "password", confirmed_at: Time.current, confirmation_sent_at: Time.current)
     member = Member.create!(
       status: status,
       email: email,
-      user: User.create!(email: email, password: "password", confirmed_at: Time.current, confirmation_sent_at: Time.current),
+      user: user,
       phone_number: "5005550006",
       full_name: full_name,
       preferred_name: preferred_name,
@@ -169,6 +170,6 @@ namespace :devdata do
   end
 
   def random_member
-    random_model(Member.where.not(email: "member_with_unconfirmed_email@example.com"))
+    random_model(Member.where.not(email: "member_with_unconfirmed_email@example.com").joins(:user))
   end
 end

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @member = create(:member)
+      @member = create(:member, :with_user)
       @user = create(:admin_user)
       sign_in @user
     end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -15,7 +15,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "shows item page for signed in user" do
-    member = create(:member)
+    member = create(:member, :with_user)
     sign_in(member.user)
     item = create(:item)
 

--- a/test/factories/appointments.rb
+++ b/test/factories/appointments.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     starts_at { "2020-09-23 11:14:27" }
     ends_at { "2020-09-23 12:14:27" }
     comment { "My Comment" }
-    member
+    member { association(:member, :with_user) }
 
     factory :appointment_with_holds do
       holds { [association(:hold, creator: member.user)] }

--- a/test/factories/members.rb
+++ b/test/factories/members.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     phone_number { "5005550006" }
     postal_code { "60609" }
     address1 { "1 N. Michigan Ave" }
-    user { association(:user, email:) }
     reminders_via_email { true }
     reminders_via_text { false }
 

--- a/test/factories/members.rb
+++ b/test/factories/members.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     library { Library.first || create(:library) }
 
     full_name { "Ida B. Wells" }
-    email
+    email { generate(:email) }
     phone_number { "5005550006" }
     postal_code { "60609" }
     address1 { "1 N. Michigan Ave" }
@@ -18,6 +18,10 @@ FactoryBot.define do
       bio { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." }
     end
 
+    trait :with_user do
+      user { association(:user, email:) }
+    end
+
     trait :with_pronunciation do
       pronunciation { "ˈaɪdə welz" }
     end
@@ -26,6 +30,7 @@ FactoryBot.define do
       preferred_name { "Ida" }
       pronouns { ["she/her"] }
       address1 { "apt 3" }
+      user { association(:user, email:) }
 
       factory :verified_member do
         sequence :number

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :membership do
     library { Library.first || create(:library) }
-    member
+    member { association(:member, :with_user) }
     started_at { 1.month.ago }
     after(:build) { |m| m.ended_at = m.started_at + 364.days if m.started_at }
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -2,10 +2,13 @@ FactoryBot.define do
   factory :user do
     library { Library.first || association(:library) }
 
-    email
+    sequence(:email) do |n|
+      "person#{n}@example.com"
+    end
     password { "password" }
     confirmation_sent_at { Time.current }
     confirmed_at { Time.current }
+    member { association(:member, email:) }
 
     trait :unconfirmed do
       confirmation_sent_at { nil }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -2,13 +2,10 @@ FactoryBot.define do
   factory :user do
     library { Library.first || association(:library) }
 
-    sequence(:email) do |n|
-      "person#{n}@example.com"
-    end
+    email { generate(:email) }
     password { "password" }
     confirmation_sent_at { Time.current }
     confirmed_at { Time.current }
-    member { association(:member, email:) }
 
     trait :unconfirmed do
       confirmation_sent_at { nil }

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -3,6 +3,20 @@ require "test_helper"
 class MemberTest < ActiveSupport::TestCase
   include Lending
 
+  [
+    :member,
+    [:member, :with_bio],
+    :complete_member,
+    :verified_member,
+    :verified_member_with_membership
+  ].each do |factory_name|
+    test "#{Array(factory_name).join(", ")} is a valid factory/trait" do
+      member = build(*factory_name)
+      member.valid?
+      assert_equal({}, member.errors.messages)
+    end
+  end
+
   test "strips no digits from phone number" do
     member = Member.new(phone_number: "(123) 456-7890")
     member.valid?
@@ -122,16 +136,16 @@ class MemberTest < ActiveSupport::TestCase
   test "updates user email when member email is updated" do
     original_email = "original@example.com"
     user = create(:user, email: original_email)
-    member = create(:member, user:, email: original_email)
+    member = user.member
 
     assert_equal original_email, member.email
-    assert_equal original_email, member.user.email
+    assert_equal original_email, user.email
 
     assert member.update(email: "revised@different.biz")
 
-    member.user.reload
-    assert_equal original_email, member.user.email
-    assert_equal "revised@different.biz", member.user.unconfirmed_email
+    user.reload
+    assert_equal original_email, user.email
+    assert_equal "revised@different.biz", user.unconfirmed_email
   end
 
   test "doesn't allow multiple users with the same email address" do

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -6,6 +6,7 @@ class MemberTest < ActiveSupport::TestCase
   [
     :member,
     [:member, :with_bio],
+    [:member, :with_user],
     :complete_member,
     :verified_member,
     :verified_member_with_membership
@@ -136,7 +137,7 @@ class MemberTest < ActiveSupport::TestCase
   test "updates user email when member email is updated" do
     original_email = "original@example.com"
     user = create(:user, email: original_email)
-    member = user.member
+    member = create(:member, user:, email: original_email)
 
     assert_equal original_email, member.email
     assert_equal original_email, user.email

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,18 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  [
+    :user,
+    [:user, :unconfirmed],
+    :member_user,
+    :staff_user,
+    :admin_user,
+    :super_admin_user
+  ].each do |factory_name|
+    test "#{Array(factory_name).join(", ")} is a valid factory/trait" do
+      user = build(*factory_name)
+      user.valid?
+      assert_equal({}, user.errors.messages)
+    end
+  end
 end

--- a/test/system/admin/check_in_check_out_test.rb
+++ b/test/system/admin/check_in_check_out_test.rb
@@ -6,7 +6,7 @@ class CheckInCheckOutTest < ApplicationSystemTestCase
   end
 
   test "pending member can't checkout items" do
-    @member = create(:member)
+    @member = create(:member, :with_user)
     @item = create(:item)
 
     visit admin_member_url(@member)

--- a/test/system/admin/holds_test.rb
+++ b/test/system/admin/holds_test.rb
@@ -6,7 +6,7 @@ class HoldsTest < ApplicationSystemTestCase
   end
 
   test "pending member can reserve items" do
-    @member = create(:member)
+    @member = create(:member, :with_user)
     @item = create(:item)
 
     visit admin_member_holds_url(@member)

--- a/test/system/admin/member_verification_test.rb
+++ b/test/system/admin/member_verification_test.rb
@@ -6,7 +6,7 @@ class MemberVerificationTest < ApplicationSystemTestCase
   end
 
   test "verify pending member without membership" do
-    @member = create(:member)
+    @member = create(:member, :with_user)
 
     visit admin_member_url(@member)
 
@@ -41,7 +41,7 @@ class MemberVerificationTest < ApplicationSystemTestCase
   end
 
   test "verify pending member without membership using square" do
-    @member = create(:member)
+    @member = create(:member, :with_user)
 
     visit admin_member_url(@member)
 
@@ -68,7 +68,7 @@ class MemberVerificationTest < ApplicationSystemTestCase
   end
 
   test "verify pending member with a membership" do
-    @member = create(:member)
+    @member = create(:member, :with_user)
     create(:membership, member: @member)
 
     visit admin_member_url(@member)

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -9,17 +9,17 @@ class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
   setup do
     sign_in_as_admin
 
-    @member_without_loans = create(:member, preferred_name: "Loanless Lane")
+    @member_without_loans = create(:member, :with_user, preferred_name: "Loanless Lane")
 
-    @member_with_non_overdue_loans = create(:member, preferred_name: "Mr. Ontime")
+    @member_with_non_overdue_loans = create(:member, :with_user, preferred_name: "Mr. Ontime")
     create(:loan, member: @member_with_non_overdue_loans)
     create(:ended_loan, member: @member_with_non_overdue_loans)
 
-    member_with_one_overdue_loan = create(:member, preferred_name: "(Over)Drew")
+    member_with_one_overdue_loan = create(:member, :with_user, preferred_name: "(Over)Drew")
     create(:overdue_loan, member: member_with_one_overdue_loan, due_at: 3.weeks.ago)
     create(:loan, member: member_with_one_overdue_loan)
 
-    member_with_multiple_overdue_loans = create(:member, preferred_name: "(Mul)Timothy")
+    member_with_multiple_overdue_loans = create(:member, :with_user, preferred_name: "(Mul)Timothy")
     1.upto(3).each do |n|
       create(:overdue_loan, member: member_with_multiple_overdue_loans, due_at: n.weeks.ago)
     end

--- a/test/system/member_checked_out_items_test.rb
+++ b/test/system/member_checked_out_items_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class MemberCheckedOutItemsTest < ApplicationSystemTestCase
   setup do
-    @member = create(:member)
+    @member = create(:member, :with_user)
 
     login_as(@member.user)
   end


### PR DESCRIPTION
# What it does

With these changes members will belong to users instead of users belonging to members.

# Why it is important

Having users belong to members is more of a historical artifact than a real design choice. This keeps things to be more like what people would expect.

# Implementation notes

I added some SQL to the migration to make sure the current member/user relationships are transferred over. There are probably some other improvements that could be made (like the columns could be non-null if we're sure there's a user for every member or pulling some of the overlap between members and users into a profile, etc), but I focused mainly on inverting the relationship.
