### PR TITLE
Put the item's name ahead of its number on the member view of the items index

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -182,6 +182,10 @@ $photo-width: 187px;
     border-bottom: 1px solid #dadee4;
     width: 100%;
   }
+
+  .items-table-name .item-name {
+    font-size: 1rem;
+  }
 }
 
 @media all and (min-width: 841px) {

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -84,14 +84,13 @@
           <% end %>
 
           <%= tag.div class: "items-table-name" do %>
-            <strong><%= full_item_number(item) %></strong>
+            <strong><%= link_to item.name, item_path(item, search_result_index: index), class: "item-name" %></strong>
             <%= item_status_label(item) %>
             <% if item.active_holds.any? %>
               <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
             <% end %>
             <br>
-            <%= link_to item.name, item_path(item, search_result_index: index) %>
-            <%#= item.added %>
+            <strong><%= full_item_number(item) %></strong>
             <% if item.size.present? %>
               <span class="label"><%= item.size %></span>
             <% end %>


### PR DESCRIPTION
# What it does

Rearranges some markup and bumps up the item name's font size.

# Why it is important

[People were suggesting this change in the recent survey](https://chicagotoollibrary.slack.com/archives/C05RB4B5M1N/p1725532818050629)

# UI Change Screenshot

![Screenshot 2024-09-05 at 4 32 49 PM](https://github.com/user-attachments/assets/9c55724a-974d-4cba-89d6-db58da023c7e)

# Implementation notes

This doesn't impact the admin items index since the style changes use a class name that's only on the member view.
