### PR TITLE
Added a missing items report

### DIFF
--- a/app/controllers/admin/reports/missing_items_controller.rb
+++ b/app/controllers/admin/reports/missing_items_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  module Reports
+    class MissingItemsController < BaseController
+      def index
+        @items = Item.missing.includes(:borrow_policy, last_active_ticket: :latest_ticket_update)
+      end
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -57,6 +57,7 @@ class Item < ApplicationRecord
   scope :without_active_holds, -> { where.missing(:active_holds) }
   scope :available_now, -> { available.without_active_holds.where(status: Item.statuses[:active]) }
   scope :holdable, -> { active }
+  scope :missing, -> { where(status: Item.statuses[:missing]) }
 
   scope :by_name, -> { order(name: :asc) }
 

--- a/app/views/admin/reports/missing_items/index.html.erb
+++ b/app/views/admin/reports/missing_items/index.html.erb
@@ -1,0 +1,37 @@
+<%= content_for :header do %>
+  <%= index_header "Missing Items" %>
+<% end %>
+
+<div class="columns">
+  <div class="column col-12">
+    <table class="table">
+      <tr>
+        <th>Item</th>
+        <th>Open Tickets</th>
+        <th>Most Recent Ticket</th>
+        <th>Most Recent Update</th>
+      </tr>
+      <% @items.each do |item| %>
+        <tr>
+          <td>
+            <%= link_to item.name, [:admin, item] %><br>
+            <%= item.complete_number %>
+          </td>
+          <td>
+            <%= link_to pluralize(item.tickets.active.count, "ticket"), admin_item_tickets_path(item) %>
+          </td>
+          <td>
+            <% if item.last_active_ticket %>
+              <%= link_to item.last_active_ticket.title, admin_item_ticket_path(item, item.last_active_ticket) %>
+            <% end %>
+          </td>
+          <td>
+            <% if item.last_active_ticket %>
+              <%= truncate(item.last_active_ticket.latest_ticket_update&.body&.to_plain_text, length: 120) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -56,8 +56,9 @@
               <li class="nav-item"><%= link_to "Volunteer Shifts", admin_reports_shifts_path %></li>
               <li class="nav-item"><%= link_to "Items with Holds", admin_reports_items_with_holds_path %></li>
               <li class="nav-item"><%= link_to "Items without Image", admin_reports_items_without_image_index_path %></li>
-              <li class="nav-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %>
-              <li class="nav-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %>
+              <li class="nav-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %></li>
+              <li class="nav-item"><%= link_to "Missing Items", admin_reports_missing_items_path %></li>
+              <li class="nav-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %></li>
             </ul>
           </li>
 
@@ -157,8 +158,9 @@
                 <li class="menu-item"><%= link_to "Volunteer Shifts", admin_reports_shifts_path %></li>
                 <li class="menu-item"><%= link_to "Items with Holds", admin_reports_items_with_holds_path %></li>
                 <li class="menu-item"><%= link_to "Items without Image", admin_reports_items_without_image_index_path %></li>
-                <li class="menu-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %>
-                <li class="menu-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %>
+                <li class="menu-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %></li>
+                <li class="menu-item"><%= link_to "Missing Items", admin_reports_missing_items_path %></li>
+                <li class="menu-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %></li>
               </ul>
             </div>
             <div class="dropdown">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     namespace :reports do
       resources :memberships, only: :index
       resources :items_in_maintenance, only: :index
+      resources :missing_items, only: :index
       resources :monthly_activities, only: :index
       resources :member_requests, only: :index
       resources :notifications, only: :index

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,41 +10,41 @@ def seed_library(library, email_suffix = "", postal_code = "60609")
 
     admin_user = User.create!(email: "admin#{email_suffix}@example.com", password: "password", role: "admin", **confirmed_email_attrs)
     Member.create!(member_attrs.merge(
-      email: admin_user.email, full_name: "Admin Member", preferred_name: "Admin"
+      email: admin_user.email, full_name: "Admin Member", preferred_name: "Admin", user: admin_user
     ))
 
     unconfirmed_email_user = User.create!(email: "member_with_unconfirmed_email#{email_suffix}@example.com", password: "password", unconfirmed_email: "member_with_unconfirmed_email#{email_suffix}@example.com")
     Member.create!(member_attrs.merge(
-      email: unconfirmed_email_user.email, full_name: "Unconfirmed Email", preferred_name: "Unconfirmed Email"
+      email: unconfirmed_email_user.email, full_name: "Unconfirmed Email", preferred_name: "Unconfirmed Email", user: unconfirmed_email_user
     ))
 
     verified_user = User.create!(email: "verified_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     verified_member = Member.create!(member_attrs.merge(
-      email: verified_user.email, full_name: "Firstname Lastname", preferred_name: "Verified", status: 1, address_verified: true
+      email: verified_user.email, full_name: "Firstname Lastname", preferred_name: "Verified", status: 1, address_verified: true, user: verified_user
     ))
     verified_member.memberships.create!(started_at: Time.current, ended_at: 1.year.since)
 
     unverified_user = User.create!(email: "new_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     Member.create!(member_attrs.merge(
-      email: unverified_user.email, full_name: "Firstname Lastname", preferred_name: "New"
+      email: unverified_user.email, full_name: "Firstname Lastname", preferred_name: "New", user: unverified_user
     ))
 
     member_for_18_months_user = User.create!(email: "member_for_18_months#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     member_for_18_months = Member.create!(member_attrs.merge(
-      email: member_for_18_months_user.email, full_name: "Member for Eighteen Months", preferred_name: "18mo", status: 1, address_verified: true
+      email: member_for_18_months_user.email, full_name: "Member for Eighteen Months", preferred_name: "18mo", status: 1, address_verified: true, user: member_for_18_months_user
     ))
     Membership.create!(member: member_for_18_months, started_at: 18.months.ago, ended_at: 6.months.ago)
     Membership.create!(member: member_for_18_months, started_at: 6.months.ago + 1.day, ended_at: 6.months.since - 1.day)
 
     expired_user = User.create!(email: "expired_member#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     expired_member = Member.create!(member_attrs.merge(
-      email: expired_user.email, full_name: "Expired Member", preferred_name: "Expired", status: 1, address_verified: true
+      email: expired_user.email, full_name: "Expired Member", preferred_name: "Expired", status: 1, address_verified: true, user: expired_user
     ))
     Membership.create!(member: expired_member, started_at: 18.months.ago, ended_at: 6.months.ago)
 
     expires_in_one_week_user = User.create!(email: "expires_soon#{email_suffix}@example.com", password: "password", **confirmed_email_attrs)
     expires_in_one_week_member = Member.create!(member_attrs.merge(
-      email: expires_in_one_week_user.email, full_name: "Expires Soon Member", preferred_name: "Soon", status: 1, address_verified: true
+      email: expires_in_one_week_user.email, full_name: "Expires Soon Member", preferred_name: "Soon", status: 1, address_verified: true, user: expires_in_one_week_user
     ))
     Membership.create!(member: expires_in_one_week_member, started_at: 351.days.ago, ended_at: 14.days.since)
 

--- a/test/factories/ticket_updates.rb
+++ b/test/factories/ticket_updates.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ticket_update do
+    ticket { association(:ticket) }
+    sequence(:body) { |n| "This ticket update ##{n}" }
+    creator { association(:user) }
+  end
+end

--- a/test/models/ticket_update_test.rb
+++ b/test/models/ticket_update_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class TicketUpdateTest < ActiveSupport::TestCase
+  test "has a valid factory/trait" do
+    ticket_update = build(:ticket_update)
+    ticket_update.valid?
+    assert_equal({}, ticket_update.errors.messages)
+  end
+end

--- a/test/system/admin/reports/missing_items_test.rb
+++ b/test/system/admin/reports/missing_items_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class AdminMissingItemsTest < ApplicationSystemTestCase
+  setup do
+    sign_in_as_admin
+  end
+
+  test "shows all of the missing items in the system" do
+    first_active_item = create(:item, :active)
+    missing_items = create_list(:item, 3, :missing)
+    last_active_item = create(:item, :active)
+
+    ticket = create(:ticket, item: missing_items.first)
+
+    create(:ticket_update, ticket:)
+    last_ticket_update = create(:ticket_update, ticket:)
+
+    visit admin_reports_missing_items_url
+
+    missing_items.each do |item|
+      assert_text item.name
+      assert_text item.complete_number
+    end
+
+    assert_text "1 ticket"
+    assert_text ticket.title
+    assert_text last_ticket_update.body.to_plain_text
+
+    [first_active_item, last_active_item].each do |item|
+      refute_text item.name
+    end
+  end
+end


### PR DESCRIPTION
# What it does

Adds a report that lists all of the items with a status of "missing"

# Why it is important

Takes care of [#1640](https://github.com/chicago-tool-library/circulate/issues/1640)

# UI Change Screenshot

![Screenshot 2024-09-06 at 3 58 36 PM](https://github.com/user-attachments/assets/7b002f5a-619b-4c10-bad2-64284fc39e17)

# Implementation notes

More or less a version of the items in maintenance report, so the ticket stuff might not be relevant in the long run (It's my understanding that before the "missing" status was added missing items were marked with tickets labelled "missing", so the ticket stuff might help surface those tickets so they can be closed out).

Also, I corrected a mistake I made with the seeds in another PR where the members weren't actually associated with their users. I can pull that out into a separate PR if we need to (my bad).
