### PR TITLE
Member facing reservation questions

### DIFF
--- a/app/controllers/account/reservations_controller.rb
+++ b/app/controllers/account/reservations_controller.rb
@@ -14,10 +14,12 @@ module Account
 
     def new
       @reservation = Reservation.new
+      set_required_answers
       set_reservation_slots
     end
 
     def edit
+      set_required_answers
       set_reservation_slots
     end
 
@@ -26,8 +28,9 @@ module Account
 
       if @reservation.save
         # TODO use the current user's actual organization
-        redirect_to account_reservation_url(@reservation), notice: "Reservation was successfully created."
+        redirect_to account_reservation_url(@reservation), success: "Reservation was successfully created."
       else
+        set_required_answers
         set_reservation_slots
         render :new, status: :unprocessable_entity
       end
@@ -35,8 +38,9 @@ module Account
 
     def update
       if @reservation.update(reservation_params)
-        redirect_to account_reservation_url(@reservation), notice: "Reservation was successfully updated."
+        redirect_to account_reservation_url(@reservation), success: "Reservation was successfully updated."
       else
+        set_required_answers
         set_reservation_slots
         render :edit, status: :unprocessable_entity
       end
@@ -45,7 +49,7 @@ module Account
     def destroy
       @reservation.destroy!
 
-      redirect_to account_reservations_url, notice: "Reservation was successfully destroyed."
+      redirect_to account_reservations_url, success: "Reservation was successfully destroyed."
     end
 
     private
@@ -54,8 +58,19 @@ module Account
       @reservation = Reservation.find(params[:id])
     end
 
+    def set_required_answers
+      # Using includes(:stem) on the reservation's required_answers causes ActiveRecord to clear out the values set via nested
+      # attributes, so it's skipped here.
+      @answers = @reservation.required_answers.presence || Question.all.order(:name).where(archived_at: nil).includes(:stem).map { |question| RequiredAnswer.new(reservation: @reservation, stem: question.stem) }
+    end
+
     def reservation_params
-      params.require(:reservation).permit(:name, :started_at, :ended_at, :pickup_event_id, :dropoff_event_id)
+      params.require(:reservation).permit(:name,
+        :started_at,
+        :ended_at,
+        :pickup_event_id,
+        :dropoff_event_id,
+        required_answers_attributes: [:id, :stem_id, :value])
     end
 
     def set_reservation_slots

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -25,7 +25,7 @@ class Answer < ApplicationRecord
     return if suspect.nil?
     case stem.answer_type
     when Stem::AnswerTypes::INTEGER
-      suspect.to_i
+      suspect.present? ? suspect.to_i : nil
     when Stem::AnswerTypes::TEXT
       suspect.to_s
     end

--- a/app/models/required_answer.rb
+++ b/app/models/required_answer.rb
@@ -1,0 +1,3 @@
+class RequiredAnswer < Answer
+  validates :value, presence: true
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -20,6 +20,7 @@ class Reservation < ApplicationRecord
   has_many :item_pools, through: :reservation_holds
   has_many :reservation_policies, through: :item_pools
   has_many :answers, dependent: :destroy
+  has_many :required_answers, dependent: :destroy
   belongs_to :reviewer, class_name: "User", optional: true
   belongs_to :organization
   belongs_to :submitted_by, class_name: "User", optional: false
@@ -27,6 +28,7 @@ class Reservation < ApplicationRecord
   belongs_to :dropoff_event, class_name: "Event", optional: true
 
   accepts_nested_attributes_for :answers, allow_destroy: false
+  accepts_nested_attributes_for :required_answers, allow_destroy: false
   accepts_nested_attributes_for :reservation_holds, allow_destroy: true
 
   validates :name, presence: true

--- a/app/views/account/reservations/_answers.html.erb
+++ b/app/views/account/reservations/_answers.html.erb
@@ -1,0 +1,19 @@
+<% answers.each_with_index do |answer, i| %>
+  <%= tag.div class: "form-group #{answer.errors.present? ? 'has-error' : nil}" do %>
+    <%= hidden_field_tag "reservation[required_answers_attributes][#{i}][id]", answer.id %>
+    <%= hidden_field_tag "reservation[required_answers_attributes][#{i}][stem_id]", answer.stem.id %>
+    <%= label_tag "reservation[required_answers_attributes][#{i}][value]", class: "form-label" do %>
+      <%= answer.stem.content %>
+      <span class="label label-warning label-required-field">required</span>
+    <% end %>
+    <% case answer.stem.answer_type %>
+    <% when Stem::AnswerTypes::TEXT %>
+      <%= text_area_tag "reservation[required_answers_attributes][#{i}][value]", answer.value, class: "form-input" %>
+    <% when Stem::AnswerTypes::INTEGER %>
+      <%= number_field_tag "reservation[required_answers_attributes][#{i}][value]", answer.value, class: "form-input", autocomplete: "off" %>
+    <% end %>
+    <% if answer.errors[:value].present? %>
+      <div class="form-input-hint"><%= answer.errors[:value].join(", ") %></div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/account/reservations/_answers.html.erb
+++ b/app/views/account/reservations/_answers.html.erb
@@ -1,5 +1,5 @@
 <% answers.each_with_index do |answer, i| %>
-  <%= tag.div class: "form-group #{answer.errors.present? ? 'has-error' : nil}" do %>
+  <%= tag.div class: "form-group #{answer.errors.present? ? "has-error" : nil}" do %>
     <%= hidden_field_tag "reservation[required_answers_attributes][#{i}][id]", answer.id %>
     <%= hidden_field_tag "reservation[required_answers_attributes][#{i}][stem_id]", answer.stem.id %>
     <%= label_tag "reservation[required_answers_attributes][#{i}][value]", class: "form-label" do %>

--- a/app/views/account/reservations/_form.html.erb
+++ b/app/views/account/reservations/_form.html.erb
@@ -7,6 +7,8 @@
   <%= form.select(:pickup_event_id, grouped_options_for_select(@reservation_slots, reservation.pickup_event_id), {include_blank: "Select a Date"}, class: "form-select") %>
   <%= form.select(:dropoff_event_id, grouped_options_for_select(@reservation_slots, reservation.dropoff_event_id), {include_blank: "Select a Date"}, class: "form-select") %>
 
+  <%= render "answers", answers: @answers %>
+
   <%= form.actions do %>
     <%= form.submit %>
   <% end %>

--- a/app/views/account/reservations/show.html.erb
+++ b/app/views/account/reservations/show.html.erb
@@ -32,6 +32,12 @@
           Dropoff: <%= format_reservation_event(@reservation.dropoff_event) %>
         </p>
       <% end %>
+      <dl>
+        <% @reservation.answers.includes(:stem).each do |answer| %>
+          <dt><%= answer.stem.content %></dt>
+          <dd><%= answer.value %></dd>
+        <% end %>
+      </dl>
     </div>
     <div class="column col-8 col-md-12">
       <table class="table">

--- a/test/factories/required_answers.rb
+++ b/test/factories/required_answers.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :required_answer, parent: :answer
+end

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -49,11 +49,20 @@ class AnswerTest < ActiveSupport::TestCase
 
     answer.value = nil
     assert_nil answer.value
+    assert_equal ({"text" => nil}), answer.result
 
     answer.stem = integer_stem
     answer.value = 5
     assert_equal 5, answer.value
     assert_equal ({"integer" => 5}), answer.result
+
+    answer.value = nil
+    assert_nil answer.value
+    assert_equal ({"integer" => nil}), answer.result
+
+    answer.value = ""
+    assert_nil answer.value
+    assert_equal ({"integer" => nil}), answer.result
 
     answer.value = nil
     assert_nil answer.value

--- a/test/models/required_answer_test.rb
+++ b/test/models/required_answer_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class RequiredAnswerTest < ActiveSupport::TestCase
+  test "validations" do
+    required_answer = build(:required_answer)
+    required_answer.valid?
+    assert_equal({}, required_answer.errors.messages)
+
+    required_answer = RequiredAnswer.new
+
+    assert required_answer.invalid?
+    assert_equal ["can't be blank"], required_answer.errors[:result]
+    assert_equal ["can't be blank"], required_answer.errors[:value]
+  end
+end

--- a/test/system/account/reservations/questions_test.rb
+++ b/test/system/account/reservations/questions_test.rb
@@ -1,0 +1,73 @@
+require "application_system_test_case"
+
+class AccountReservationsQuestionsTest < ApplicationSystemTestCase
+  setup do
+    ActionMailer::Base.deliveries.clear
+
+    @organization = create(:organization)
+    @member = create(:verified_member_with_membership)
+    @attributes = attributes_for(:reservation, started_at: 3.days.from_now.at_noon, ended_at: 10.days.from_now.at_noon).slice(:name, :started_at, :ended_at)
+
+    login_as @member.user
+  end
+
+  def date_input_format(datetime)
+    datetime.strftime("%Y-%m-%d")
+  end
+
+  test "viewing a reservation's questions and answers" do
+    reservation = create(:reservation)
+    create(:answer) # ignored
+    answers = create_list(:answer, 2, reservation:)
+
+    visit account_reservation_url(reservation)
+
+    answers.each do |answer|
+      assert_text answer.stem.content
+      assert_text answer.value
+    end
+  end
+
+  test "creating a reservation with questions and answers" do
+    text_stem = create(:stem, :text)
+    integer_stem = create(:stem, :integer)
+    create(:stem, :archived) # ignored
+
+    visit new_account_reservation_path
+    fill_in "Name", with: @attributes[:name]
+    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
+    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
+    fill_in text_stem.content, with: "text answer"
+    fill_in integer_stem.content, with: "150"
+
+    assert_equal 0, Answer.count
+    assert_difference("Answer.count", 2) do
+      click_on "Create Reservation"
+      assert_text "Reservation was successfully created"
+    end
+
+    assert_equal 1, text_stem.answers.count
+    assert_equal 1, integer_stem.answers.count
+    assert_equal "text answer", text_stem.answers.first.value
+    assert_equal 150, integer_stem.answers.first.value
+  end
+
+  test "creating a reservation with questions and answers with errors" do
+    text_stem = create(:stem, :text)
+
+    visit new_account_reservation_path
+    fill_in "Name", with: @attributes[:name]
+    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
+    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
+    fill_in text_stem.content, with: ""
+
+    assert_equal 0, Answer.count
+    assert_difference("Answer.count", 0) do
+      click_on "Create Reservation"
+      assert_text "Please correct the errors below"
+    end
+
+    assert_equal 0, text_stem.answers.count
+    assert_text "can't be blank"
+  end
+end

--- a/test/system/account/reservations_test.rb
+++ b/test/system/account/reservations_test.rb
@@ -114,7 +114,7 @@ module Account
       end
     end
 
-    test "creating a reservation, adding items, and submitting it " do
+    test "creating a reservation, adding items, and submitting it" do
       create_events
       hammer_pool = create(:item_pool, name: "Hammer")
       create(:reservable_item, item_pool: hammer_pool)

--- a/test/system/admin/reservations/questions_test.rb
+++ b/test/system/admin/reservations/questions_test.rb
@@ -1,0 +1,86 @@
+require "application_system_test_case"
+
+class AdminReservationsQuestionsTest < ApplicationSystemTestCase
+  setup do
+    sign_in_as_admin
+    @organization = create(:organization)
+    @attributes = attributes_for(:reservation, started_at: 3.days.from_now.at_noon, ended_at: 10.days.from_now.at_noon).slice(:name, :started_at, :ended_at)
+  end
+
+  def date_input_format(datetime)
+    datetime.strftime("%Y-%m-%d")
+  end
+
+  test "viewing a reservation's questions and answers" do
+    reservation = create(:reservation)
+    create(:answer) # ignored
+    answers = create_list(:answer, 2, reservation:)
+
+    visit admin_reservation_url(reservation)
+    # TODO: This is a somewhat ambiguous selector that I'm dropping in to fix
+    # tests in a sweep. Consider rearranging the view to make it easier to
+    # select between the tab and the global nav.
+    within(".tab") do
+      click_on "Questions"
+    end
+
+    answers.each do |answer|
+      assert_text answer.stem.content
+      assert_text answer.value
+    end
+  end
+
+  test "creating a reservation with questions and answers" do
+    text_stem = create(:stem, :text)
+    integer_stem = create(:stem, :integer)
+    create(:stem, :archived) # ignored
+
+    visit new_admin_reservation_path
+    fill_in "Name", with: @attributes[:name]
+    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
+    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
+    select(@organization.name, from: "Organization")
+    fill_in text_stem.content, with: "text answer"
+    fill_in integer_stem.content, with: "150"
+
+    assert_equal 0, Answer.count
+    assert_difference("Answer.count", 2) do
+      click_on "Create Reservation"
+      assert_text "Reservation was successfully created"
+    end
+
+    assert_equal 1, text_stem.answers.count
+    assert_equal 1, integer_stem.answers.count
+    assert_equal "text answer", text_stem.answers.first.value
+    assert_equal 150, integer_stem.answers.first.value
+  end
+
+  test "updating a reservation with questions and answers" do
+    reservation = create(:reservation)
+    text_stem = create(:stem, :text)
+    integer_stem = create(:stem, :integer)
+    create(:stem, :archived) # ignored
+    text_answer = create(:answer, reservation:, stem: text_stem)
+    integer_answer = create(:answer, reservation:, stem: integer_stem, value: 3)
+
+    visit admin_reservation_path(reservation)
+    click_on "Edit"
+
+    fill_in "Name", with: @attributes[:name]
+    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
+    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
+    fill_in text_stem.content, with: "text answer"
+    fill_in integer_stem.content, with: "150"
+
+    assert_difference("Answer.count", 0) do
+      click_on "Update Reservation"
+      assert_text "Reservation was successfully updated"
+    end
+
+    text_answer.reload
+    integer_answer.reload
+
+    assert_equal "text answer", text_answer.value
+    assert_equal 150, integer_answer.value
+  end
+end

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -72,25 +72,6 @@ class AdminReservationsTest < ApplicationSystemTestCase
     end
   end
 
-  test "viewing a reservation's questions and answers" do
-    reservation = create(:reservation)
-    create(:answer) # ignored
-    answers = create_list(:answer, 2, reservation:)
-
-    visit admin_reservation_url(reservation)
-    # TODO: This is a somewhat ambiguous selector that I'm dropping in to fix
-    # tests in a sweep. Consider rearranging the view to make it easier to
-    # select between the tab and the global nav.
-    within(".tab") do
-      click_on "Questions"
-    end
-
-    answers.each do |answer|
-      assert_text answer.stem.content
-      assert_text answer.value
-    end
-  end
-
   test "viewing a reservation's review notes after review" do
     reservation = create(:reservation, :approved)
 
@@ -144,31 +125,6 @@ class AdminReservationsTest < ApplicationSystemTestCase
     end
   end
 
-  test "creating a reservation with questions and answers" do
-    text_stem = create(:stem, :text)
-    integer_stem = create(:stem, :integer)
-    create(:stem, :archived) # ignored
-
-    visit new_admin_reservation_path
-    fill_in "Name", with: @attributes[:name]
-    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
-    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
-    select(@organization.name, from: "Organization")
-    fill_in text_stem.content, with: "text answer"
-    fill_in integer_stem.content, with: "150"
-
-    assert_equal 0, Answer.count
-    assert_difference("Answer.count", 2) do
-      click_on "Create Reservation"
-      assert_text "Reservation was successfully created"
-    end
-
-    assert_equal 1, text_stem.answers.count
-    assert_equal 1, integer_stem.answers.count
-    assert_equal "text answer", text_stem.answers.first.value
-    assert_equal 150, integer_stem.answers.first.value
-  end
-
   test "updating a reservation successfully" do
     reservation = create(:reservation)
     first_event, last_event = create_events
@@ -212,35 +168,6 @@ class AdminReservationsTest < ApplicationSystemTestCase
     reservation.reload
 
     refute_equal @attributes[:name], reservation.name
-  end
-
-  test "updating a reservation with questions and answers" do
-    reservation = create(:reservation)
-    text_stem = create(:stem, :text)
-    integer_stem = create(:stem, :integer)
-    create(:stem, :archived) # ignored
-    text_answer = create(:answer, reservation:, stem: text_stem)
-    integer_answer = create(:answer, reservation:, stem: integer_stem, value: 3)
-
-    visit admin_reservation_path(reservation)
-    click_on "Edit"
-
-    fill_in "Name", with: @attributes[:name]
-    find("#start-date-field").set(date_input_format(@attributes[:started_at]))
-    find("#end-date-field").set(date_input_format(@attributes[:ended_at]))
-    fill_in text_stem.content, with: "text answer"
-    fill_in integer_stem.content, with: "150"
-
-    assert_difference("Answer.count", 0) do
-      click_on "Update Reservation"
-      assert_text "Reservation was successfully updated"
-    end
-
-    text_answer.reload
-    integer_answer.reload
-
-    assert_equal "text answer", text_answer.value
-    assert_equal 150, integer_answer.value
   end
 
   test "the dropdown for pickup/dropoff events includes old events if already associated" do


### PR DESCRIPTION
# What it does

Members now have to answer any questions in the system when making a reservation.

# Why it is important

#1520 

# UI Change Screenshot

The new reservation form with a text and number question:
![Screenshot 2024-09-16 at 2 57 21 PM](https://github.com/user-attachments/assets/0e7f3c64-df8b-49c7-92bc-c76a64a51cd6)

The new reservation form with errors:
![Screenshot 2024-09-16 at 2 57 32 PM](https://github.com/user-attachments/assets/8ce45126-3b45-4780-91ed-9daa6b8e9cf5)

The show reservation page with answered questions
![Screenshot 2024-09-16 at 2 58 07 PM](https://github.com/user-attachments/assets/a0a2b553-d683-47af-b239-cdc69ba414ea)

# Implementation notes

Right now a `nil` value for a `number` field is coerced to a `0` so `number` questions/answers can never really be `blank?`. Not sure if this is nice or annoying but I'm happy to change it up if that's what folks prefer.

I didn't get into editing/updating since we're not likely going to have that as a flow in this part of the app. I thought about removing those actions/routes/views but I figured that'd likely end up happening once other ways of interacting with the reservation are worked out.

In order to make the questions optional for admins but required for members, I tried something a little weird but I think it works well enough: I subclassed `Answer` into a `RequiredAnswer` that has an additional validation (same table and everything else though). The risks for this are if we forget to use `RequiredAnswer` and instead use `Answer` in member-facing context. I don't think that's particularly more risky than other implementations of this kind of conditional validation logic that I've seen, but I'm always open to learning new approaches!
