### PR TITLE
Resolve pending reservation items

### DIFF
--- a/app/controllers/admin/reservations/pending_reservation_items_controller.rb
+++ b/app/controllers/admin/reservations/pending_reservation_items_controller.rb
@@ -1,11 +1,32 @@
 module Admin
   module Reservations
     class PendingReservationItemsController < BaseController
+      before_action :load_pending_reservation_item
+
+      # Merge into the reservation
+      def update
+        result = ReservationLending.add_pending_item_to_reservation(@pending_reservation_item)
+        if result.success?
+          render_turbo_response(
+            turbo_stream: turbo_stream.action(:redirect,
+              admin_reservation_pickup_path(@pending_reservation_item.reservation))
+          )
+        else
+          render_turbo_response :error
+        end
+      end
+
+      # Remove from reservation
       def destroy
-        @pending_reservation_item = @reservation.pending_reservation_items.find(params[:id])
         if @pending_reservation_item.destroy
           render_turbo_response :destroy
         end
+      end
+
+      private
+
+      def load_pending_reservation_item
+        @pending_reservation_item = @reservation.pending_reservation_items.find(params[:id])
       end
     end
   end

--- a/app/controllers/concerns/reservation_lending.rb
+++ b/app/controllers/concerns/reservation_lending.rb
@@ -1,0 +1,31 @@
+module ReservationLending
+  extend self
+
+  # Returns a Result containing either a newly created ReservationLoan or an error
+  def add_pending_item_to_reservation(pending_reservation_item)
+    reservation = pending_reservation_item.reservation
+
+    reservation.transaction do
+      item_pool = pending_reservation_item.reservable_item.item_pool
+      reservation_hold = reservation.reservation_holds.find_or_initialize_by(item_pool:)
+
+      if reservation_hold.persisted?
+        reservation_hold.quantity += 1
+      else
+        reservation_hold.quantity = 1
+      end
+
+      if reservation_hold.save
+        reservation_loan = reservation.reservation_loans.create(reservable_item: pending_reservation_item.reservable_item, reservation_hold:)
+        if reservation_loan.save
+          pending_reservation_item.destroy!
+          Result.success(reservation_loan)
+        else
+          Result.failure(reservation_loan.errors.full_messages.to_sentence)
+        end
+      else
+        Result.failure(reservation_hold.errors.full_messages.to_sentence)
+      end
+    end
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.find_random
+    order("RANDOM()").first
+  end
 end

--- a/app/models/item_pool.rb
+++ b/app/models/item_pool.rb
@@ -10,6 +10,7 @@ class ItemPool < ApplicationRecord
   validate :unnumbered_has_no_items
 
   scope :uniquely_numbered, -> { where(uniquely_numbered: true) }
+  scope :not_uniquely_numbered, -> { where(uniquely_numbered: false) }
 
   acts_as_tenant :library
 

--- a/app/views/admin/reservations/_pending_reservation_items.html.erb
+++ b/app/views/admin/reservations/_pending_reservation_items.html.erb
@@ -7,6 +7,7 @@
                     <%= pending_reservation_item.reservable_item.number %> -
                     <%= pending_reservation_item.reservable_item.name %>
                     <%= button_to "Remove", [:admin, reservation, pending_reservation_item], method: :delete %>
+                    <%= button_to "Add to Reservation", [:admin, reservation, pending_reservation_item], method: :put %>
                 </li>
             <% end %>
         </ul>

--- a/bin/setup
+++ b/bin/setup
@@ -36,8 +36,8 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Loading dev data =="
   system! 'bin/rails devdata:load'
 
-  puts "\n== Creating loans and holds =="
-  system! 'bin/rails devdata:create_loans_and_holds'
+  puts "\n== Creating loans, holds, and reservations =="
+  system! 'bin/rails devdata:create_loans_and_holds devdata:create_reservations'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,7 @@ Rails.application.routes.draw do
         scope module: "reservations" do
           resources :reservation_loans, only: [:create, :destroy]
           resources :reservation_holds
-          resources :pending_reservation_items, only: [:destroy]
+          resources :pending_reservation_items, only: [:update, :destroy]
           resource :status, only: :update
           resource :review, only: [:edit, :update, :show]
           resource :pickup, only: :show

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+ActionMailer::Base.perform_deliveries = false
+
 def seed_library(library, email_suffix = "", postal_code = "60609")
   ActsAsTenant.with_tenant(library) do
     member_attrs = {

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -114,7 +114,7 @@ namespace :devdata do
             delay: 10,
             duration: 4,
             notes: "This looks good.",
-            assign_events: true,
+            assign_events: true
           ) do |reservation|
             reservation.reservation_holds.create!(item_pool: ItemPool.uniquely_numbered.find_random, quantity: 2)
             reservation.reservation_holds.create!(item_pool: ItemPool.not_uniquely_numbered.find_random, quantity: 2)
@@ -124,11 +124,11 @@ namespace :devdata do
     end
   end
 
-  def create_reservation(name:, status:, delay:0, duration: 1, notes: nil, assign_events: false)
+  def create_reservation(name:, status:, delay: 0, duration: 1, notes: nil, assign_events: false)
     started_at = Time.current.beginning_of_day + delay.days
     ended_at = started_at.end_of_day + duration.days
     pickup_event, dropoff_event = if assign_events
-      [Event.appointment_slots.where("start >= ?", started_at).first, Event.appointment_slots.where("finish <= ?", ended_at).last]
+      [Event.appointment_slots.where(start: started_at..).first, Event.appointment_slots.where(finish: ..ended_at).last]
     else
       [nil, nil]
     end

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -100,6 +100,51 @@ namespace :devdata do
     end
   end
 
+  task create_reservations: :environment do
+    ActiveRecord::Base.transaction do
+      Library.all.each_with_index do |library, index|
+        ActsAsTenant.with_tenant(library) do
+          create_reservation(name: "Pending reservation", status: Reservation.statuses[:pending], delay: 1, duration: 3) do |reservation|
+            reservation.reservation_holds.create!(item_pool: ItemPool.uniquely_numbered.find_random, quantity: 2)
+            reservation.reservation_holds.create!(item_pool: ItemPool.not_uniquely_numbered.find_random, quantity: 2)
+          end
+          create_reservation(
+            name: "Approved reservation",
+            status: Reservation.statuses[:approved],
+            delay: 10,
+            duration: 4,
+            notes: "This looks good.",
+            assign_events: true,
+          ) do |reservation|
+            reservation.reservation_holds.create!(item_pool: ItemPool.uniquely_numbered.find_random, quantity: 2)
+            reservation.reservation_holds.create!(item_pool: ItemPool.not_uniquely_numbered.find_random, quantity: 2)
+          end
+        end
+      end
+    end
+  end
+
+  def create_reservation(name:, status:, delay:0, duration: 1, notes: nil, assign_events: false)
+    started_at = Time.current.beginning_of_day + delay.days
+    ended_at = started_at.end_of_day + duration.days
+    pickup_event, dropoff_event = if assign_events
+      [Event.appointment_slots.where("start >= ?", started_at).first, Event.appointment_slots.where("finish <= ?", ended_at).last]
+    else
+      [nil, nil]
+    end
+    yield Reservation.create!(
+      name: name,
+      status: status,
+      organization: Organization.find_random,
+      started_at: started_at,
+      ended_at: ended_at,
+      submitted_by: User.find_random,
+      notes: notes,
+      pickup_event: pickup_event,
+      dropoff_event: dropoff_event
+    )
+  end
+
   def create_member(username, city:, holds: 0, waiting_holds: 0, loans: 0, appointments: 0, status: :verified, postal_code: "60609")
     email_prefix = (city == "Chicago") ? "" : "#{city.downcase}."
     email = "#{username}@#{email_prefix}example.com"

--- a/test/controllers/concerns/reservation_lending_test.rb
+++ b/test/controllers/concerns/reservation_lending_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ReservationLendingTest < ActiveSupport::TestCase
+  test "adds a new pending item to a reservation" do
+    reservation = create(:reservation, :building)
+    pending_reservation_item = create(:pending_reservation_item, reservation: reservation)
+
+    assert_equal 0, reservation.reservation_holds.count
+
+    result = ReservationLending.add_pending_item_to_reservation(pending_reservation_item)
+
+    assert result.success?
+    assert_equal 1, reservation.reservation_holds.count
+
+    reservation_loan = result.value
+    assert_equal pending_reservation_item.reservable_item, reservation_loan.reservable_item
+
+    assert pending_reservation_item.destroyed?
+  end
+
+  test "adds a pending item that already exists to a reservation" do
+    item_pool = create(:item_pool)
+    reservable_items = 3.times.map { create(:reservable_item, item_pool:) }
+
+    reservation = create(:reservation, :building)
+    existing_reservation_hold = create(:reservation_hold, item_pool:, reservation:, quantity: 2)
+    pending_reservation_item = create(:pending_reservation_item,
+      reservable_item: reservable_items.first,
+      reservation:)
+
+    assert_equal 1, reservation.reservation_holds.count
+    assert_equal 2, existing_reservation_hold.quantity
+
+    result = ReservationLending.add_pending_item_to_reservation(pending_reservation_item)
+
+    assert result.success?
+    assert_equal 1, reservation.reservation_holds.count
+
+    reservation_loan = result.value
+    assert_equal pending_reservation_item.reservable_item, reservation_loan.reservable_item
+    assert_equal existing_reservation_hold, reservation_loan.reservation_hold
+
+    existing_reservation_hold.reload
+    assert_equal 3, existing_reservation_hold.quantity
+
+    assert pending_reservation_item.destroyed?
+  end
+end

--- a/test/factories/pending_reservation_items.rb
+++ b/test/factories/pending_reservation_items.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :pending_reservation_item do
-    reservable_item { nil }
-    reservation { nil }
+    association :reservable_item
+    association :reservation
+    association :created_by, factory: :user
   end
 end

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -339,20 +339,46 @@ class AdminReservationsTest < ApplicationSystemTestCase
     refute_text hammer.name
   end
 
-  test "adding unreserved items to a pickup" do
+  test "adding unreserved items to a pickup and then removing them" do
     hammer_pool = create(:item_pool, name: "Hammer")
     hammer = create(:reservable_item, item_pool: hammer_pool)
 
     reservation = create(:reservation, :building)
     visit admin_reservation_pickup_path(reservation)
 
-    assert_active_tab "Pickup"
-    fill_in "Item ID", with: hammer.id
-    click_on "Add Item"
+    assert_no_difference "PendingReservationItem.count" do
+      assert_difference "PendingReservationItem.count", 1 do
+        assert_active_tab "Pickup"
+        fill_in "Item ID", with: hammer.id
+        click_on "Add Item"
 
-    assert_text "1 item scanned that did not match the reservation"
-    click_on "Remove"
+        assert_text "1 item scanned that did not match the reservation"
+      end
 
-    refute_text "1 item scanned that did not match the reservation"
+      click_on "Remove"
+      refute_text "1 item scanned that did not match the reservation"
+    end
+  end
+
+  test "adding unreserved items to a pickup and merging a new item into the reservation" do
+    hammer_pool = create(:item_pool, name: "Hammer")
+    hammer = create(:reservable_item, item_pool: hammer_pool)
+
+    reservation = create(:reservation, :building)
+    visit admin_reservation_pickup_path(reservation)
+
+    assert_difference -> { reservation.reservation_holds.count } => 1,
+      -> { reservation.pending_reservation_items.count } => 0 do
+      assert_active_tab "Pickup"
+      fill_in "Item ID", with: hammer.id
+      click_on "Add Item"
+
+      assert_text "1 item scanned that did not match the reservation"
+
+      click_on "Add to Reservation"
+
+      refute_text "1 item scanned that did not match the reservation"
+      assert_text "Hammer (1/1)"
+    end
   end
 end


### PR DESCRIPTION
# What it does

* This adds the start of "resolving" `PendingReservationItems`, which means we either delete them or expand the reservations to include them.
* I added some reservations to `bin/setup` to make development easier.
* I also fixed #1676 in the process of the last task.