### PR TITLE
Don't allow items that aren't active to be added to appointments.

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -69,7 +69,7 @@ module Account
     end
 
     def load_holds_and_loans
-      @holds = Hold.active.includes(member: {appointments: :holds}).where(member: @member)
+      @holds = Hold.active.includes(:item, member: {appointments: :holds}).where(member: @member, item: {status: Item.statuses[:active]})
       @loans = @member.loans.includes(:item, member: {appointments: :loans}).checked_out
     end
 

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -89,6 +89,8 @@ class Hold < ApplicationRecord
   end
 
   def ready_for_pickup?(now = Time.current)
+    return false unless item.active?
+
     # Holds for uncounted items are always ready to be picked up
     unless item.borrow_policy.uniquely_numbered?
       return true

--- a/app/views/account/appointments/_form.html.erb
+++ b/app/views/account/appointments/_form.html.erb
@@ -111,7 +111,10 @@
     <% end %>
   <% else %>
     <div class="toast toast-warning">
-      <p>You can only schedule an appointment if you have a tool on hold or that can be returned.</p>
+      <p>You can only schedule an appointment if you have at least one item that is:</p>
+      <ul>
+        <li>on hold and ready for pickup ready, or</li>
+        <li>on loan that can be returned</p>
       <%= link_to "View Inventory", items_path, class: "btn btn-lg btn-default" %>
     </div>
   <% end %>

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -137,6 +137,17 @@ class HoldTest < ActiveSupport::TestCase
     assert hold.ready_for_pickup?
   end
 
+  # Only active items can be picked up
+  Item.statuses.keys.without("active").each do |status|
+    test "#ready_for_pickup? is false when an item's status is #{status}" do
+      hold = create(:hold)
+      hold.item.update(status: Item.statuses[status])
+
+      hold.reload
+      refute hold.ready_for_pickup?
+    end
+  end
+
   test "start_waiting_holds starts a hold" do
     create(:hold)
 


### PR DESCRIPTION
# What it does

Fixes a long-standing issue where members can add items that are in maintenance to their appointments. This resulted from some gaps in logic in the appointment and hold code.

# Why it is important

Items in maintenance can't be checked out, and it's a bad experience to allow someone to think they can pick something up when they can't. It also created more work for staff, who have to sort it all out when a member is confused by this.

# Implementation notes

* Only items that have a `status` of `active` are shown on the appointment editing page.
* The logic on the holds page has been fixed so that it says "you are # 1 in line" instead of "ready for pickup" for items in maintenance.

We don't actually let members place new holds on items in maintenance, and at once point we deleted all holds for items when they entered this state. We stopped doing that because it confused members to have their holds disappear, but didn't fix this gap in logic that resulted from that change.