### PR TITLE
Only update user unconfirmed email if user exists and email was changed.

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -58,10 +58,10 @@ class Member < ApplicationRecord
   before_validation :downcase_email
 
   after_update :update_neon_crm, if: :can_update_neon_crm?
+  after_update :update_user_email
   after_save :send_welcome_text, if: -> {
     reminders_via_text? && (saved_change_to_phone_number? || saved_change_to_reminders_via_text?)
   }
-  after_save :update_user_email
 
   acts_as_tenant :library
 
@@ -148,7 +148,9 @@ class Member < ApplicationRecord
   end
 
   def update_user_email
-    user.update_column(:unconfirmed_email, email) if user&.persisted? # Skip validations
+    if user && user.email != email
+      user.update_column(:unconfirmed_email, email)
+    end
   end
 
   def update_neon_crm

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -57,8 +57,22 @@ module Admin
       assert_redirected_to admin_member_url(@member)
     end
 
-    test "should resend member verification email" do
+    test "should resend member verification email to new unconfirmed user" do
       member = create(:member, user: create(:user, :unconfirmed))
+      ActionMailer::Base.deliveries.clear
+
+      post resend_verification_email_admin_member_url(member)
+      assert_redirected_to admin_member_url(member)
+
+      mails = ActionMailer::Base.deliveries
+      assert_equal 1, mails.count
+      mail = ActionMailer::Base.deliveries.last
+      assert_equal [member.user.email], mail.to
+      assert_equal "Confirmation instructions", mail.subject
+    end
+
+    test "should resend member verification email to previously confirmed user" do
+      member = create(:member, user: create(:user, :unconfirmed, unconfirmed_email: "unconfirmed@example.com"))
       ActionMailer::Base.deliveries.clear
 
       post resend_verification_email_admin_member_url(member)


### PR DESCRIPTION
# What it does

Fixes an issue that was reported by staff. If a member updates their profile, their email is always marked as unconfirmed. This PR limits this to situations where the email has actually change.