### PR TITLE
Add some utilities for pulling repo data

### DIFF
--- a/repo_analysis/.gitignore
+++ b/repo_analysis/.gitignore
@@ -1,0 +1,1 @@
+github.db

--- a/repo_analysis/Gemfile
+++ b/repo_analysis/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby "3.1.6"
+
+gem "sqlite3"

--- a/repo_analysis/Gemfile.lock
+++ b/repo_analysis/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sqlite3 (2.0.3-arm64-darwin)
+
+PLATFORMS
+  arm64-darwin-23
+
+DEPENDENCIES
+  sqlite3
+
+RUBY VERSION
+   ruby 3.1.6p260
+
+BUNDLED WITH
+   2.4.15

--- a/repo_analysis/README.md
+++ b/repo_analysis/README.md
@@ -1,0 +1,15 @@
+# Repo Analysis
+
+This directory holds some scripts used to fetch repository data from Github
+and extract it in various forms. It's useful for generating a list of PRs
+recently merges, or a list of who has contributed, etc.
+
+Fetching the data requires Python and some Python libraries.
+
+To use:
+
+1. Install the dependencies using `pip3 install -r requirements.in'.
+2. Setup a github access token [and configure github-to-sqlite to use it](https://github.com/dogsheep/github-to-sqlite?tab=readme-ov-file#authentication).
+3. Run `sync.sh` to fetch the data.
+4. Run `datasette github.db` to investigate the data in a nice web-based UI (optional but sometimes handy).
+5. Edit/run `rake` to extract the data in a specific format.

--- a/repo_analysis/Rakefile
+++ b/repo_analysis/Rakefile
@@ -1,0 +1,29 @@
+require "csv"
+require "sqlite3"
+
+db = SQLite3::Database.new("github.db")
+
+desc "Print a CSV list of PRs (either still open or closed in the last two months)"
+task :recent_prs do
+  query = <<~SQL
+    SELECT pull_requests.*, users.name
+    FROM pull_requests
+    LEFT JOIN users on users.id == pull_requests.user
+    WHERE (closed_at IS NULL OR closed_at >= "2024-06-01") AND user != 49699333
+    ORDER BY closed_at DESC NULLS FIRST
+  SQL
+
+  # pull_requests schema
+  # id, node_id, number, state, locked, title, user, body, created_at, updated_at, closed_at, merged_at, merge_commit_sha, assignee, milestone, draft, head, base, author_association, auto_merge, repo, url, merged_by
+
+  csv = CSV.new(STDOUT, col_sep: "\t")
+  csv << %w{pr author merged_at link}
+  db.execute(query) do |row|
+    csv << [
+      row[5], # title
+      row[23], # author
+      row[11], # state
+      "https://github.com/chicago-tool-library/circulate/pull/#{row[2]}"
+    ]
+  end
+end

--- a/repo_analysis/requirements.in
+++ b/repo_analysis/requirements.in
@@ -1,0 +1,2 @@
+github-to-sqlite
+datasette

--- a/repo_analysis/sync.sh
+++ b/repo_analysis/sync.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+github-to-sqlite pull-requests github.db chicago-tool-library/circulate
+github-to-sqlite contributors github.db chicago-tool-library/circulate


### PR DESCRIPTION
The README says it best:

> This directory holds some scripts used to fetch repository data from Github
and extract it in various forms. It's useful for generating a list of PRs
recently merged, or a list of who has contributed, etc.
> 
> Fetching the data requires Python and some Python libraries.