### PR TITLE
Remove unnecessary spacing resulting from specter upgrade

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -62,6 +62,7 @@ body.admin {
     background: $error-color;
     p {
       margin-bottom: 0.7rem;
+      margin-top: 0;
     }
     a {
       color: white;

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -130,6 +130,15 @@ form.button_to {
   display: inline;
 }
 
+form {
+  fieldset {
+    padding: 0;
+  }
+  legend + p {
+    margin-top: 0;
+  }
+}
+
 // Improve contrast on labels
 .label {
   background-color: lighten($gray-color-light, 1%);
@@ -157,6 +166,9 @@ form.button_to {
   a {
     text-decoration: none;
   }
+  p {
+    margin-top: 0;
+  }
 }
 
 .dropdown {
@@ -168,6 +180,9 @@ form.button_to {
       outline-color: $secondary-color-light;
       @include control-shadow($secondary-color);
     }
+  }
+  .menu {
+    max-height: 100vh;
   }
   .menu .menu-item > a {
     color: $dark-color;

--- a/app/assets/stylesheets/partials/_admin_memberships.scss
+++ b/app/assets/stylesheets/partials/_admin_memberships.scss
@@ -1,3 +1,6 @@
 .fieldset-radio-inputs {
   margin-left: 1.2rem;
+  p {
+    margin-top: 0;
+  }
 }

--- a/app/assets/stylesheets/partials/_items_index.scss
+++ b/app/assets/stylesheets/partials/_items_index.scss
@@ -48,6 +48,9 @@
   }
 
   .category-nav {
+    li {
+      margin-left: 0;
+    }
     button.toggle-categories {
       margin-bottom: .3rem;
       @media all and (min-width: 641px)  {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -518,7 +518,10 @@ legend {
 }
 
 .signup-steps {
-  margin: 1rem 0 2rem;
+  margin: 1rem 0 1rem;
+  .step-item {
+    margin-left: 0;
+  }
 }
 
 .signup-logo {
@@ -606,6 +609,9 @@ form.membership-amount {
     margin-bottom: 2rem;
   }
   .verification-instructions {
+  }
+  h1 {
+    margin-bottom: 0;
   }
 }
 
@@ -877,13 +883,14 @@ table.monthly-adjustments {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      margin-left: 0;
     }
     .feather-icon {
       margin-right: 0.2rem;
     }
-    // .feather-icon + a {
-    //   margin-left: -0.3em;
-    // }
+    &:last-child {
+      margin-bottom: 0.6rem;
+    }
   }
 }
 
@@ -967,10 +974,13 @@ table.monthly-adjustments {
   .btn.btn-link {
     color: white;
   }
-  .menu .menu-item > a {
-    color: $dark-color;
-    &:hover {
-      background: $secondary-color-light;
+  .menu .menu-item {
+    margin-left: 0;
+    & > a {
+      color: $dark-color;
+      &:hover {
+        background: $secondary-color-light;
+      }
     }
   }
   input:focus {


### PR DESCRIPTION
# What it does

The spectre.css upgrade in #1686 ended up messing up a bunch of spacing in the app, mostly due to changes to the default styles of `p`, `ul`, and `li` elements. I clicked around and fixed the most glaring visual issues, but I wouldn't be surprised if there are more.

I also ended up fixing #893 in the process.