### PR TITLE
Tweak sign up for clarity around payments

### DIFF
--- a/app/forms/membership_payment_form.rb
+++ b/app/forms/membership_payment_form.rb
@@ -4,7 +4,7 @@ class MembershipPaymentForm
   attr_accessor :amount_dollars
 
   validates_numericality_of :amount_dollars,
-    greater_than_or_equal_to: 1, less_than_or_equal_to: 500
+    greater_than_or_equal_to: 5, less_than_or_equal_to: 500
 
   def amount
     Money.new(amount_dollars.to_i * 100)

--- a/app/views/signup/payments/new.html.erb
+++ b/app/views/signup/payments/new.html.erb
@@ -31,7 +31,7 @@
         <p>
           You can save time by making one-time payment online using a credit card or Apple/Google Pay.
         </p>
-        <%= form.money_field :amount_dollars, label: "Your membership fee:", class: "input-lg" %>
+        <%= form.money_field :amount_dollars, label: "Your membership fee:", class: "input-lg", type: :number, min: 5 %>
       </fieldset>
       <%= form.actions do %>
         <%= form.submit "Pay Online Now", data: {turbo: false} %>

--- a/app/views/signup/payments/new.html.erb
+++ b/app/views/signup/payments/new.html.erb
@@ -7,10 +7,16 @@
     </div>
     <div class="signup-fee-description">
       <p>
-        Your membership fee will be your only payment to the Tool Library for one year.
+        This means you choose how much your one-year membership costs.
       </p>
       <p>
-        If everyone paid $100 for their one-year membership, we would be able to grow the organization and offer new programs. This is only a suggestion &mdash; and not a requirement &mdash; so please choose a number that makes sense for you and your budget.
+        Please choose how much you can contribute to this community service. Membership contributions are the Tool Library's main source of income to pay our staff, pay our rent, and buy and maintain our tools.
+      </p>
+      <p>
+        We recommend contributing $100 for a one-year membership, but this is only a recommendation. Many people pay more and many people pay less.
+      </p>
+      <p>
+        Please note that your membership contribution is the only payment you will make to the Tool Library this year. There are no late fees, replacement fees, or rental fees.
       </p>
     </div>
   </div>
@@ -41,14 +47,14 @@
   <div class="column col-sm-12 col-4 col-mr-auto complete-in-person">
     <%= form_with(url: skip_signup_payments_url, builder: SpectreFormBuilder) do |form| %>
       <fieldset>
-        <legend>Complete Signup at the Library</legend>
+        <legend>Pay in-person</legend>
         <p>
-          You can also complete signup in person at the library. We accept cash, credit cards, and mobile payments, and
+          You can also complete your payment in person at the library. We accept cash, credit cards, and mobile payments, and
           are happy to answer any questions you have about membership.
         </p>
       </fieldset>
 
-      <%= button_tag "Complete in Person", class: "btn btn-lg btn-block" %>
+      <%= button_tag "Pay in-person", class: "btn btn-lg btn-block" %>
     <% end %>
   </div>
 </div>

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -83,7 +83,7 @@ class UserSignupTest < ApplicationSystemTestCase
     email = complete_first_three_steps
 
     perform_enqueued_jobs do
-      click_on "Complete in Person"
+      click_on "Pay in-person"
 
       assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
     end
@@ -99,7 +99,7 @@ class UserSignupTest < ApplicationSystemTestCase
     email = complete_first_three_steps
 
     perform_enqueued_jobs do
-      click_on "Complete in Person"
+      click_on "Pay in-person"
 
       assert_selector "li.step-item.active", text: "Complete", wait: slow_op_wait_time
     end


### PR DESCRIPTION
# What it does

Changes some copy and has the form require a minimum of a $5 online donation

# Why it is important

Takes care of the requests in #1682 

# UI Change Screenshot

New copy:
![Screenshot 2024-10-07 at 7 18 53 PM](https://github.com/user-attachments/assets/4ea3416d-3930-4579-8337-94ead329189d)

Attempting to donate $4:
![Screenshot 2024-10-07 at 7 19 05 PM](https://github.com/user-attachments/assets/5b118072-7edb-43a6-aad8-ffee2e7a29e8)

# Implementation notes

Happy to tweak any formatting or anything else. 

I put a validation in the form for the $5 minimum but if someone tries to get around that I also adjusted the minimum in `MembershipPaymentForm`. This also changes the behavior for renewals which isn't in the card but seems like the kind of thing we'd want changed everywhere.
