### PR TITLE
Try to use magick command and fallback to convert.

### DIFF
--- a/app/lib/certificate/generator.rb
+++ b/app/lib/certificate/generator.rb
@@ -5,9 +5,16 @@ module Certificate
     end
 
     def generate
+      # see if magick command exists, if not, fall back to convert
+      command = command_exists?("magick") ? "magick" : "convert"
       @tempfile = Tempfile.new
-      `convert #{File.dirname(__FILE__)}/template.jpg -fill black -pointsize 58 -draw "text 1190,970 '#{@code}'" #{@tempfile.path}`
+      `#{command} #{File.dirname(__FILE__)}/template.jpg -fill black -pointsize 58 -draw "text 1190,970 '#{@code}'" #{@tempfile.path}`
       @tempfile.path
+    end
+
+    def command_exists?(name)
+      `which #{name}`
+      $?.success?
     end
   end
 end


### PR DESCRIPTION
# What it does

Resolves #1689 by attempting to use the `magick` command instead of `convert`, which will be deprecated in Imagemagick 7. This deprecation warning has started showing up on developer machines, and it's annoying.

For bonus fun, Heroku has an older version of imagemagick from before there was a `magic` command. So I added a fallback for environments where we only have the older command.