### PR TITLE
Improve UI of reservation items screen

### DIFF
--- a/app/controllers/admin/reservations/reviews_controller.rb
+++ b/app/controllers/admin/reservations/reviews_controller.rb
@@ -3,7 +3,7 @@ module Admin
     class ReviewsController < BaseController
       def edit
         unless @reservation.manager.can?(:approve)
-          redirect_to admin_reservation_path(@reservation), error: "Can't review a reservation with status #{@reservation.manager.state}"
+          redirect_to default_reservation_tab_path(@reservation), error: "Can't review a reservation with status #{@reservation.manager.state}"
         end
       end
 
@@ -12,14 +12,14 @@ module Admin
 
         event = review_params[:event].to_sym
         unless @reservation.manager.can?(event)
-          redirect_to admin_reservation_path(@reservation), error: "Can't #{event} a reservation with status #{@reservation.manager.state}"
+          redirect_to default_reservation_tab_path(@reservation), error: "Can't #{event} a reservation with status #{@reservation.manager.state}"
           return
         end
 
         @reservation.transaction do
           if @reservation.manager.trigger(event) && @reservation.update(reservation_params)
             ReservationMailer.with(reservation: @reservation).reviewed.deliver_later
-            redirect_to admin_reservation_url(@reservation), success: "Reservation was successfully updated."
+            redirect_to default_reservation_tab_path(@reservation), success: "Reservation was successfully updated."
           else
             render :edit, status: :unprocessable_entity
           end

--- a/app/controllers/admin/reservations/statuses_controller.rb
+++ b/app/controllers/admin/reservations/statuses_controller.rb
@@ -3,9 +3,9 @@ module Admin
     class StatusesController < BaseController
       def update
         if @reservation.update(reservation_params)
-          redirect_to admin_reservation_url(@reservation), notice: "Reservation was successfully updated."
+          redirect_to default_reservation_tab_path(@reservation), notice: "Reservation was successfully updated."
         else
-          redirect_to admin_reservation_url(@reservation), error: "Reservation could not updated: #{@reservation.errors.full_messages.join(", ")}"
+          redirect_to default_reservation_tab_path(@reservation), error: "Reservation could not updated: #{@reservation.errors.full_messages.join(", ")}"
         end
       end
 

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -46,7 +46,7 @@ module Admin
 
     def update
       if @reservation.update(reservation_params)
-        redirect_to admin_reservation_url(@reservation), success: "Reservation was successfully updated."
+        redirect_to default_reservation_tab_path(@reservation), success: "Reservation was successfully updated."
       else
         @item_pools = ItemPool.all
         set_organization_options

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -46,7 +46,15 @@ module AdminHelper
   end
 
   def tab_link(label, path, badge: nil)
-    opts = (badge.present? && badge != 0) ? {class: "badge", data: {badge: badge}} : {}
+    opts = {}
+    if badge.present?
+      if badge == true
+        opts[:class] = "badge"
+      elsif badge != 0
+        opts[:class] = "badge"
+        opts[:data] = {badge: badge}
+      end
+    end
     tag.li(class: "tab-item #{"active" if current_page?(path)}") do
       link_to label, path, **opts
     end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -13,6 +13,15 @@ module ReservationsHelper
     [event.start, event.finish].map { |time| format_event_time(time) }.join(" - ")
   end
 
+  def default_reservation_tab_path(reservation)
+    manager = reservation.manager
+    if manager.requested? || manager.pending?
+      admin_reservation_path(reservation)
+    else
+      admin_reservation_pickup_path(reservation)
+    end
+  end
+
   private
 
   def format_event_time(time)

--- a/app/models/reservation_hold.rb
+++ b/app/models/reservation_hold.rb
@@ -28,6 +28,11 @@ class ReservationHold < ApplicationRecord
     loaned_quantity == quantity
   end
 
+  # How many more items are needed to satisfy this hold?
+  def remaining_quantity
+    quantity - loaned_quantity
+  end
+
   private
 
   def ensure_quantity_is_available

--- a/app/views/admin/reservations/_profile.html.erb
+++ b/app/views/admin/reservations/_profile.html.erb
@@ -51,10 +51,10 @@
     <% end %>
 
     <ul class="tab">
-      <%= tab_link "Items", admin_reservation_path(@reservation) %>
-      <%= tab_link "Pickup", admin_reservation_pickup_path(@reservation) %>
+      <%= tab_link "Reservation", admin_reservation_path(@reservation) %>
+      <%= tab_link "Items", admin_reservation_pickup_path(@reservation) %>
       <%= tab_link "Questions", admin_reservation_questions_path(@reservation) %>
-      <%= tab_link "Review", edit_admin_reservation_review_path(@reservation) if @reservation.manager.can?(:approve) %>
+      <%= tab_link("Review", edit_admin_reservation_review_path(@reservation), badge: true) if @reservation.manager.can?(:approve) %>
       <%= tab_link("Review Notes", admin_reservation_review_path(@reservation)) if @reservation.notes? %>
     </ul>
 

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -20,7 +20,7 @@
           <%= link_to reservation.organization.name, admin_organization_path(reservation.organization) %>
         </td>
         <td>
-          <%= link_to reservation.name, admin_reservation_path(reservation) %>
+          <%= link_to reservation.name, default_reservation_tab_path(reservation) %>
         </td>
 
         <td>

--- a/app/views/admin/reservations/pickups/_reservation_hold.erb
+++ b/app/views/admin/reservations/pickups/_reservation_hold.erb
@@ -1,30 +1,43 @@
-<div id="<%= dom_id(reservation_hold) %>">
-    <h3 id="item-pool-<%= reservation_hold.item_pool_id %>">
-        <%= reservation_hold.item_pool.name %>
-        (<%= reservation_hold.loaned_quantity %>/<%= reservation_hold.quantity %>)
-
-        <% if reservation.status == Reservation.statuses[:building] && !reservation_hold.item_pool.uniquely_numbered? && !reservation_hold.satisfied? %>
-        <%= button_to "Add all",
-              admin_reservation_reservation_loans_path(reservation),
-              method: :post,
-              params: {reservation_loan: {reservation_hold_id: reservation_hold.id}},
-              class: "btn btn-sm" %>
+<tbody id="<%= dom_id(reservation_hold) %>">
+  <tr>
+    <th colspan="2" scope="rowgroup" id="item-pool-<%= reservation_hold.item_pool_id %>">
+      <%= reservation_hold.item_pool.name %>
+    </th>
+    <th>
+      <%= reservation_hold.loaned_quantity %>/<%= reservation_hold.quantity %>
+    </th>
+  </tr>
+  <% reservation_hold.reservation_loans.each do |reservation_loan| %>
+    <tr>
+      <% if reservation_loan.quantity %>
+        <td><%= reservation_hold.item_pool.name %></td>
+        <td><%= reservation_loan.quantity %></td>
+      <% else %>
+        <td><%= reservation_loan.reservable_item.id %></td>
+        <td><%= reservation_loan.reservable_item.name %></td>
+      <% end %>
+      <td>
+        <% if reservation.manager.state == :building %>
+            <%= button_to "Remove", admin_reservation_reservation_loan_path(reservation, reservation_loan), method: :delete, class: "btn btn-sm" %>
         <% end %>
-    </h3>
-    <ul>
-        <% reservation_hold.reservation_loans.each do |reservation_loan| %>
-        <li>
-            <% if reservation_loan.quantity %>
-            <%= reservation_hold.item_pool.name %> -
-            <%= reservation_loan.quantity %>
-            <% else %>
-            <%= reservation_loan.reservable_item.id %> -
-            <%= reservation_loan.reservable_item.name %>
-            <% end %>
-            <% if reservation.manager.state == :building %>
-                <%= button_to "Remove", admin_reservation_reservation_loan_path(reservation, reservation_loan), method: :delete, class: "btn btn-sm" %>
-            <% end %>
-        </li>
+      </td>
+    <tr>
+  <% end %>
+  <% if reservation.status == Reservation.statuses[:building] &&  !reservation_hold.satisfied? %>
+    <tr class="text-italic">
+      <td colspan="2">
+        <%= pluralize reservation_hold.remaining_quantity, "more item" %> needed
+        <%= link_to "View available", admin_item_pool_path(reservation_hold.item_pool), target: "_blank" %>
+      </td>
+      <td>
+        <% if !reservation_hold.item_pool.uniquely_numbered? %>
+          <%= button_to "Add all",
+                admin_reservation_reservation_loans_path(reservation),
+                method: :post,
+                params: {reservation_loan: {reservation_hold_id: reservation_hold.id}},
+                class: "btn btn-sm" %>
         <% end %>
-    </ul>
-</div>
+      </td>
+    </tr>
+  <% end %>
+</tbody>

--- a/app/views/admin/reservations/pickups/show.html.erb
+++ b/app/views/admin/reservations/pickups/show.html.erb
@@ -11,10 +11,18 @@
 
   <%= render partial: "admin/reservations/pending_reservation_items", locals: {reservation: @reservation} %>
 
-  <div id="date-holds">
+  <table class="table" id="reservation_holds">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th></th>
+      </tr>
+    </thead>
+
     <% @reservation.reservation_holds.each do |reservation_hold| %>
       <%= render partial: "reservation_hold", locals: {reservation: @reservation, reservation_hold: reservation_hold} %>
     <% end %>
-  </div>
+  </table>
 
 <% end %>

--- a/test/system/admin/reservations_test.rb
+++ b/test/system/admin/reservations_test.rb
@@ -37,6 +37,12 @@ class AdminReservationsTest < ApplicationSystemTestCase
     ]
   end
 
+  def assert_hold_quantity(item_pool, quantity)
+    within "tr", text: item_pool.name do
+      assert_text quantity
+    end
+  end
+
   test "visiting the index" do
     Time.use_zone("America/Chicago") do
       reservations = [
@@ -212,7 +218,7 @@ class AdminReservationsTest < ApplicationSystemTestCase
       click_on "Add"
     end
 
-    assert_active_tab "Items"
+    assert_active_tab "Reservation"
     assert_text "Hammer"
 
     reservation.reload
@@ -252,16 +258,16 @@ class AdminReservationsTest < ApplicationSystemTestCase
     create(:reservation_hold, reservation: reservation, item_pool: hammer_pool)
     visit admin_reservation_pickup_path(reservation)
 
-    assert_active_tab "Pickup"
+    assert_active_tab "Items"
     fill_in "Item ID", with: hammer.id
     click_on "Add Item"
 
-    assert_text "#{hammer_pool.name} (1/1)"
+    assert_hold_quantity hammer_pool, "1/1"
     assert_text "All requirements satisfied"
     assert_text hammer.name
 
     click_on "Remove"
-    assert_text "#{hammer_pool.name} (0/1)"
+    assert_hold_quantity hammer_pool, "0/1"
     refute_text "All requirements satisfied"
     refute_text hammer.name
   end
@@ -275,7 +281,7 @@ class AdminReservationsTest < ApplicationSystemTestCase
 
     assert_no_difference "PendingReservationItem.count" do
       assert_difference "PendingReservationItem.count", 1 do
-        assert_active_tab "Pickup"
+        assert_active_tab "Items"
         fill_in "Item ID", with: hammer.id
         click_on "Add Item"
 
@@ -296,7 +302,7 @@ class AdminReservationsTest < ApplicationSystemTestCase
 
     assert_difference -> { reservation.reservation_holds.count } => 1,
       -> { reservation.pending_reservation_items.count } => 0 do
-      assert_active_tab "Pickup"
+      assert_active_tab "Items"
       fill_in "Item ID", with: hammer.id
       click_on "Add Item"
 
@@ -305,7 +311,7 @@ class AdminReservationsTest < ApplicationSystemTestCase
       click_on "Add to Reservation"
 
       refute_text "1 item scanned that did not match the reservation"
-      assert_text "Hammer (1/1)"
+      assert_hold_quantity hammer_pool, "1/1"
     end
   end
 end


### PR DESCRIPTION
# What it does

* Renames two reservation tabs: `items` becomes `reservation` and `pickup` becomes `items`. I think this will make more sense to staff (it already does to me).
* Rebuilds the Items tab to use a table and be more information-dense. This will help the UI scale, be more scannable, and provide a space for other controls as needed.
* Adds the concept of a "default tab" when viewing reservations in the admin. This is so we can have the more relevant tab already selected when folks go to visit a reservation. Which tab this is will vary over the lifecycle of a reservation. The code here is a start but will need adjustment as we continue to build out functionality.

# UI Change Screenshot
<img width="662" alt="Screenshot 2024-10-17 at 10 21 34 AM" src="https://github.com/user-attachments/assets/350f69d3-a15c-4ad3-ba25-e223e1dd1de7">
<img width="670" alt="Screenshot 2024-10-17 at 10 21 23 AM" src="https://github.com/user-attachments/assets/59bbb373-fc73-4336-b5ad-a4c9f237ccb3">

