### PR TITLE
Sort the members with overdue items report by most overdue and add borrow policy filters

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -733,6 +733,13 @@ form.membership-amount {
   }
 }
 
+.filters {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 2em;
+  gap: 1ch;
+}
+
 .instructions {
   .main {
     color: variables.$primary-color;

--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -7,13 +7,7 @@ module Admin
       include ActionView::Helpers::DateHelper
 
       def index
-        overdue_loan_min = Loan.arel_table[:due_at].minimum.as("overdue_loan_min")
-        query = Member.all
-          .joins(:overdue_loans)
-          .group(:id)
-          .includes(:user, overdue_loans: :item)
-          .select(:id, :user_id, :preferred_name, :full_name, :phone_number, overdue_loan_min)
-          .order(overdue_loan_min: :asc)
+        query = build_query
 
         respond_to do |format|
           format.html do
@@ -27,6 +21,24 @@ module Admin
       end
 
       private
+
+      def build_query
+        overdue_loan_min = Loan.arel_table[:due_at].minimum.as("overdue_loan_min")
+
+        loans_query = Loan.overdue
+
+        if params[:borrow_policy_id]
+          loans_query = loans_query.joins(:item).where(item: { borrow_policy_id: params[:borrow_policy_id]})
+        end
+
+        Member.all
+          .where(id: loans_query.select(:member_id))
+          .joins(:overdue_loans)
+          .group(:id)
+          .includes(:user, overdue_loans: :item)
+          .select(:id, :user_id, :preferred_name, :full_name, :phone_number, overdue_loan_min)
+          .order(overdue_loan_min: :asc)
+      end
 
       def build_csv(members)
         CSV.generate(headers: true) do |csv|

--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -7,7 +7,13 @@ module Admin
       include ActionView::Helpers::DateHelper
 
       def index
-        query = Member.all.joins(:overdue_loans).distinct.includes(:user, overdue_loans: :item).order(email: :asc)
+        overdue_loan_min = Loan.arel_table[:due_at].minimum.as("overdue_loan_min")
+        query = Member.all
+          .joins(:overdue_loans)
+          .group(:id)
+          .includes(:user, overdue_loans: :item)
+          .select(:id, :user_id, :preferred_name, :full_name, :phone_number, overdue_loan_min)
+          .order(overdue_loan_min: :asc)
 
         respond_to do |format|
           format.html do

--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -28,7 +28,7 @@ module Admin
         loans_query = Loan.overdue
 
         if params[:borrow_policy_id]
-          loans_query = loans_query.joins(:item).where(item: { borrow_policy_id: params[:borrow_policy_id]})
+          loans_query = loans_query.joins(:item).where(item: {borrow_policy_id: params[:borrow_policy_id]})
         end
 
         Member.all

--- a/app/views/admin/reports/members_with_overdue_loans/index.html.erb
+++ b/app/views/admin/reports/members_with_overdue_loans/index.html.erb
@@ -6,6 +6,20 @@
 
 <div class="columns">
   <div class="column col-12">
+     <div class="filters">
+      Filter by borrow policy:
+      <div class="btn-group">
+        <%= link_to_unless params[:borrow_policy_id].blank?, "All", {}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">All</button>
+        <% end %>
+
+        <% BorrowPolicy.all.order(:name).each do |borrow_policy| %>
+          <%= link_to_unless_current borrow_policy.name, {borrow_policy_id: borrow_policy.id}, class: "btn btn-sm" do %>
+            <button class="btn btn-sm active"><%= borrow_policy.name %></button>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
 
     <table class="table">
       <tr>

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -56,7 +56,6 @@ class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
     end
     BorrowPolicy.where.not(id: [borrow_policy_1, borrow_policy_2].map(&:id)).delete_all
 
-
     visit admin_reports_members_with_overdue_loans_url
 
     assert_text @member_with_one_overdue_loan.user.email

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -15,18 +15,18 @@ class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
     create(:loan, member: @member_with_non_overdue_loans)
     create(:ended_loan, member: @member_with_non_overdue_loans)
 
-    member_with_one_overdue_loan = create(:member, :with_user, preferred_name: "(Over)Drew")
-    create(:overdue_loan, member: member_with_one_overdue_loan, due_at: 3.weeks.ago)
-    create(:loan, member: member_with_one_overdue_loan)
+    @member_with_one_overdue_loan = create(:member, :with_user, preferred_name: "(Over)Drew")
+    create(:overdue_loan, member: @member_with_one_overdue_loan, due_at: 3.weeks.ago)
+    create(:loan, member: @member_with_one_overdue_loan)
 
-    member_with_multiple_overdue_loans = create(:member, :with_user, preferred_name: "(Mul)Timothy")
+    @member_with_multiple_overdue_loans = create(:member, :with_user, preferred_name: "(Mul)Timothy")
     1.upto(3).each do |n|
-      create(:overdue_loan, member: member_with_multiple_overdue_loans, due_at: n.weeks.ago)
+      create(:overdue_loan, member: @member_with_multiple_overdue_loans, due_at: n.weeks.ago)
     end
-    create(:loan, member: member_with_multiple_overdue_loans)
-    create(:ended_loan, member: member_with_multiple_overdue_loans)
+    create(:loan, member: @member_with_multiple_overdue_loans)
+    create(:ended_loan, member: @member_with_multiple_overdue_loans)
 
-    @overdue_loan_members = [member_with_one_overdue_loan, member_with_multiple_overdue_loans]
+    @overdue_loan_members = [@member_with_one_overdue_loan, @member_with_multiple_overdue_loans]
   end
 
   test "the table lists the member's name, contact information, and overdue tools" do
@@ -46,5 +46,33 @@ class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
       end
     end
     assert_equal 3, all("tr").size # 2 for members, 1 for the header
+  end
+
+  test "the table can be filtered by borrow policy" do
+    borrow_policy_1, borrow_policy_2 = BorrowPolicy.first(2)
+    Item.update_all(borrow_policy_id: borrow_policy_1.id)
+    @member_with_one_overdue_loan.overdue_loans.each do |loan|
+      loan.item.update!(borrow_policy: borrow_policy_2)
+    end
+    BorrowPolicy.where.not(id: [borrow_policy_1, borrow_policy_2].map(&:id)).delete_all
+
+
+    visit admin_reports_members_with_overdue_loans_url
+
+    assert_text @member_with_one_overdue_loan.user.email
+    assert_text @member_with_multiple_overdue_loans.user.email
+
+    assert_text borrow_policy_1.name
+    assert_text borrow_policy_2.name
+
+    click_on borrow_policy_2.name
+
+    assert_text @member_with_one_overdue_loan.user.email
+    refute_text @member_with_multiple_overdue_loans.user.email
+
+    click_on "All"
+
+    assert_text @member_with_one_overdue_loan.user.email
+    assert_text @member_with_multiple_overdue_loans.user.email
   end
 end


### PR DESCRIPTION
# What it does

This changes the members with overdue items report to:

- always show members with the longest overdue items first 
- have filters by borrow policy

# Why it is important

#1635 and #1636

# UI Change Screenshot

The report with no filters active ("All"):
![Screenshot_2024-10-26_at_5_59_48 PM](https://github.com/user-attachments/assets/3f1b26e5-253e-4e7b-a9c3-087a64d95612)

The report with an active filter:
![Screenshot_2024-10-26_at_6_00_02 PM](https://github.com/user-attachments/assets/453e798b-77b2-4d37-bdf0-d14ce731ac1e)

# Implementation notes

Maybe there's a better way to get everything out in a single activerecord query (ie without `in`) so I'm open to suggestions but this works pretty well. 
