### PR TITLE
Move color overrides into the main spectre variables file.

### DIFF
--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -2,35 +2,10 @@
 
 @use "mixins";
 
-$primary-color: #2f7890;
-$primary-color-light: color.adjust(#2f7890, $lightness: 20%, $space: hsl);
-$secondary-color: color.adjust(#cdabbe, $lightness: -10%, $space: hsl);
-$error-color: #df6c54;
-$warning-color: #fbcf33;
-$success-color: #aebe39;
-$dark-color: #423730;
-$gray-color-dark: #605045;
-$gray-color: #ae9c90;
-$gray-color-light: #d9d0cb;
-$light-color: white;
+@use 'spectre-css/_variables';
 
 $max-mobile-width: 600px;
 $min-desktop-width: $max-mobile-width + 1px;
-$light-gray: #e4ddda;
-
-$secondary-color-light: color.adjust(
-  $secondary-color,
-  $lightness: 20%,
-  $space: hsl
-);
-
-$background-color: #f9f6f2;
-
-$background-color-dark: color.adjust(
-  $background-color,
-  $lightness: -5%,
-  $space: hsl
-);
 
 @mixin mobile {
   @media only screen and (max-width: $max-mobile-width) {
@@ -45,41 +20,41 @@ $background-color-dark: color.adjust(
 }
 
 @mixin default-button {
-  border-color: color.adjust($gray-color-light, $lightness: 5%, $space: hsl);
+  border-color: color.adjust(variables.$gray-color-light, $lightness: 5%, $space: hsl);
   transition: none;
   &,
   &:visited {
-    color: $gray-color-dark;
+    color: variables.$gray-color-dark;
   }
   &:hover {
-    background-color: $secondary-color-light;
-    border-color: color.adjust($secondary-color, $lightness: 10%, $space: hsl);
-    color: $dark-color;
+    background-color: variables.$secondary-color-light;
+    border-color: color.adjust(variables.$secondary-color, $lightness: 10%, $space: hsl);
+    color: variables.$dark-color;
   }
   &:active,
   &.active {
-    background-color: $secondary-color;
-    border-color: color.adjust($secondary-color, $lightness: -10%, $space: hsl);
+    background-color: variables.$secondary-color;
+    border-color: color.adjust(variables.$secondary-color, $lightness: -10%, $space: hsl);
     color: white;
   }
 }
 
 @mixin title {
-  border-color: color.adjust($gray-color-light, $lightness: 5%, $space: hsl);
+  border-color: color.adjust(variables.$gray-color-light, $lightness: 5%, $space: hsl);
   transition: none;
   &,
   &:visited {
-    color: $gray-color-dark;
+    color: variables.$gray-color-dark;
   }
   &:hover {
-    background-color: $secondary-color-light;
-    border-color: color.adjust($secondary-color, $lightness: 10%, $space: hsl);
-    color: $dark-color;
+    background-color: variables.$secondary-color-light;
+    border-color: color.adjust(variables.$secondary-color, $lightness: 10%, $space: hsl);
+    color: variables.$dark-color;
   }
   &:active,
   &.active {
-    background-color: $secondary-color;
-    border-color: color.adjust($secondary-color, $lightness: -10%, $space: hsl);
+    background-color: variables.$secondary-color;
+    border-color: color.adjust(variables.$secondary-color, $lightness: -10%, $space: hsl);
     color: white;
   }
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -2,7 +2,7 @@
 @use "spectre-css/variables";
 
 @mixin subtle-box-shadow {
-  box-shadow: globals.$light-gray 1px 1px 4px 0px;
+  box-shadow: variables.$light-gray 1px 1px 4px 0px;
 }
 
 header.header {
@@ -52,7 +52,7 @@ header.header {
   }
 
   .icon-container {
-    border-color: globals.$light-gray;
+    border-color: variables.$light-gray;
 
     .icon {
       color: variables.$dark-color;
@@ -169,7 +169,7 @@ header.header {
 
       &:hover,
       &:focus {
-        background-color: globals.$light-gray;
+        background-color: variables.$light-gray;
       }
 
       &.extra-space {

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 
 @use 'globals';
-
+@use 'spectre-css/_variables';
 @use 'spectre-css/mixins/_shadow';
 
 .selectize-input {
@@ -10,8 +10,8 @@
   border-radius: 0.1rem;
   &.focus {
     box-shadow: none;
-    @include shadow.control-shadow(globals.$primary-color);
-    border-color: globals.$primary-color;
+    @include shadow.control-shadow(variables.$primary-color);
+    border-color: variables.$primary-color;
   }
 }
 
@@ -22,7 +22,7 @@
 .selectize-control.multi .selectize-input [data-value] {
   background-image: none;
   background-repeat: no-repeat;
-  background-color: globals.$secondary-color;
+  background-color: variables.$secondary-color;
   text-shadow: none;
   box-shadow: none;
   filter: none;
@@ -31,30 +31,30 @@
 .selectize-control.multi .selectize-input [data-value].active {
   background-image: none;
   background-repeat: no-repeat;
-  background-color: color.adjust(globals.$secondary-color, $lightness: -10%, $space: hsl);
+  background-color: color.adjust(variables.$secondary-color, $lightness: -10%, $space: hsl);
   filter: none;
 }
 
 .selectize-control.multi .selectize-input > div.active,
 .selectize-control.plugin-remove_button [data-value].active .remove {
-  border-color: color.adjust(globals.$secondary-color, $lightness: -20%, $space: hsl);
+  border-color: color.adjust(variables.$secondary-color, $lightness: -20%, $space: hsl);
 }
 
 .selectize-control.multi .selectize-input > div,
 .selectize-control.plugin-remove_button [data-value] .remove {
-  border-color: color.adjust(globals.$secondary-color, $lightness: -10%, $space: hsl);
+  border-color: color.adjust(variables.$secondary-color, $lightness: -10%, $space: hsl);
 }
 
 
 .selectize-dropdown [data-selectable].option {
-  color: globals.$gray-color-dark;
+  color: variables.$gray-color-dark;
 }
 .selectize-dropdown [data-selectable].option.active {
-  background: globals.$secondary-color-light;
+  background: variables.$secondary-color-light;
 }
 .selectize-dropdown [data-selectable].option:hover {
   cursor: pointer;
-  color: globals.$dark-color;
+  color: variables.$dark-color;
 }
 
 trix-editor {
@@ -63,8 +63,8 @@ trix-editor {
   border-radius: 0.1rem;
   color: #51433b;
   &:focus {
-    @include shadow.control-shadow(globals.$primary-color);
-    border-color: globals.$primary-color;
+    @include shadow.control-shadow(variables.$primary-color);
+    border-color: variables.$primary-color;
   }
 }
 trix-toolbar {
@@ -84,7 +84,7 @@ trix-toolbar {
 }
 
 .step .step-item a::before {
-  border-color: globals.$background-color;
+  border-color: variables.$bg-color;
 }
 
 .form-checkbox,
@@ -93,17 +93,17 @@ trix-toolbar {
   input {
     &:focus + .form-icon {
       @include shadow.control-shadow();
-      border-color: globals.$secondary-color;
+      border-color: variables.$secondary-color;
     }
     &:checked + .form-icon {
-      background: globals.$secondary-color;
-      border-color: globals.$secondary-color;
+      background: variables.$secondary-color;
+      border-color: variables.$secondary-color;
     }
   }
 }
 
 .divider[data-content]::after, .divider-vert[data-content]::after {
-  background: globals.$background-color;
+  background: variables.$bg-color;
 }
 
 // Fix issue where the tag input is being drawn above the name autocomplete
@@ -122,7 +122,7 @@ trix-toolbar {
     margin-top: 0.5rem;
     @include globals.default-button();
     .icon {
-      color: globals.$dark-color;
+      color: variables.$dark-color;
     }
   }
 }
@@ -143,27 +143,27 @@ form {
 
 // Improve contrast on labels
 .label {
-  background-color: color.adjust(globals.$gray-color-light, $lightness: 1%, $space: hsl);
+  background-color: color.adjust(variables.$gray-color-light, $lightness: 1%, $space: hsl);
   &, &.label-success, &.label-warning, &.label-error, &.label-primary, &.label-secondary {
     color: inherit;
   }
 
-  &.label-primary { background-color: color.adjust(globals.$primary-color, $lightness: 40%, $space: hsl); }
-  &.label-secondary { background-color: globals.$secondary-color-light; }
-  &.label-success { background-color: color.adjust(globals.$success-color, $lightness: 20%, $space: hsl); }
-  &.label-warning { background-color: color.adjust(globals.$warning-color, $lightness: 20%, $space: hsl); }
-  &.label-error { background-color: color.adjust(globals.$error-color, $lightness: 20%, $space: hsl); }
+  &.label-primary { background-color: color.adjust(variables.$primary-color, $lightness: 40%, $space: hsl); }
+  &.label-secondary { background-color: variables.$secondary-color-light; }
+  &.label-success { background-color: color.adjust(variables.$success-color, $lightness: 20%, $space: hsl); }
+  &.label-warning { background-color: color.adjust(variables.$warning-color, $lightness: 20%, $space: hsl); }
+  &.label-error { background-color: color.adjust(variables.$error-color, $lightness: 20%, $space: hsl); }
 }
 
 .toast {
   color: inherit;
-  background-color: color.adjust(globals.$gray-color-light, $lightness: 1%, $space: hsl);
+  background-color: color.adjust(variables.$gray-color-light, $lightness: 1%, $space: hsl);
 
-  &.toast-primary { background-color: color.adjust(globals.$primary-color, $lightness: 30%, $space: hsl); }
-  &.toast-secondary { background-color: globals.$secondary-color-light; }
-  &.toast-success { background-color: color.adjust(globals.$success-color, $lightness: 20%, $space: hsl); }
-  &.toast-warning { background-color: color.adjust(globals.$warning-color, $lightness: 20%, $space: hsl); }
-  &.toast-error { background-color: color.adjust(globals.$error-color, $lightness: 20%, $space: hsl); }
+  &.toast-primary { background-color: color.adjust(variables.$primary-color, $lightness: 30%, $space: hsl); }
+  &.toast-secondary { background-color: variables.$secondary-color-light; }
+  &.toast-success { background-color: color.adjust(variables.$success-color, $lightness: 20%, $space: hsl); }
+  &.toast-warning { background-color: color.adjust(variables.$warning-color, $lightness: 20%, $space: hsl); }
+  &.toast-error { background-color: color.adjust(variables.$error-color, $lightness: 20%, $space: hsl); }
 
   a {
     text-decoration: none;
@@ -177,19 +177,19 @@ form {
   .dropdown-toggle {
     color: white;
     &:focus {
-      background: globals.$secondary-color;
+      background: variables.$secondary-color;
       color: white;
-      outline-color: globals.$secondary-color-light;
-      @include shadow.control-shadow(globals.$secondary-color);
+      outline-color: variables.$secondary-color-light;
+      @include shadow.control-shadow(variables.$secondary-color);
     }
   }
   .menu {
     max-height: 100vh;
   }
   .menu .menu-item > a {
-    color: globals.$dark-color;
+    color: variables.$dark-color;
     &:hover {
-      background: globals.$secondary-color-light;
+      background: variables.$secondary-color-light;
     }
   }
 }

--- a/app/assets/stylesheets/partials/_admin_appointments.scss
+++ b/app/assets/stylesheets/partials/_admin_appointments.scss
@@ -1,8 +1,8 @@
-@use "../globals";
+@use '../spectre-css/_variables';
 
 .admin-appointments {
   div.card.completed {
-    background-color: globals.$background-color-dark;
+    background-color: variables.$bg-color-dark;
     opacity: 0.7;
   }
 
@@ -43,7 +43,7 @@
   }
 
   tr.completed {
-    background-color: globals.$background-color-dark;
+    background-color: variables.$bg-color-dark;
     td {
       opacity: 0.7;
     }
@@ -109,7 +109,7 @@ p.appointment-comment {
   }
 
   tr.completed {
-    background-color: globals.$background-color-dark;
+    background-color: variables.$bg-color-dark;
     td {
       opacity: 0.7;
     }

--- a/app/assets/stylesheets/spectre-css/_variables.scss
+++ b/app/assets/stylesheets/spectre-css/_variables.scss
@@ -7,31 +7,53 @@ $version: "0.5.9";
 $rtl: false !default;
 
 // Core colors
-$primary-color: #5755d9 !default;
+// $primary-color: #5755d9 !default;
+$primary-color: #2f7890;
 $primary-color-dark: color.adjust($primary-color, $lightness: -3%, $space: hsl) !default;
-$primary-color-light: color.adjust($primary-color, $lightness: 3%, $space: hsl) !default;
-$secondary-color: color.adjust($primary-color, $lightness: 37.5%, $space: hsl) !default;
+// $primary-color-light: color.adjust($primary-color, $lightness: 3%, $space: hsl) !default;
+$primary-color-light: color.adjust(#2f7890, $lightness: 20%, $space: hsl);
+// $secondary-color: color.adjust($primary-color, $lightness: 37.5%, $space: hsl) !default;
+$secondary-color: color.adjust(#cdabbe, $lightness: -10%, $space: hsl);
 $secondary-color-dark: color.adjust($secondary-color, $lightness: -3%, $space: hsl) !default;
-$secondary-color-light: color.adjust($secondary-color, $lightness: 3%, $space: hsl) !default;
+// $secondary-color-light: color.adjust($secondary-color, $lightness: 3%, $space: hsl) !default;
+$secondary-color-light: color.adjust(
+  $secondary-color,
+  $lightness: 20%,
+  $space: hsl
+);
 
 // Gray colors
-$dark-color: #303742 !default;
+// $dark-color: #303742 !default;
+$dark-color: #423730;
 $light-color: #fff !default;
-$gray-color: color.adjust($dark-color, $lightness: 55%, $space: hsl) !default;
-$gray-color-dark: color.adjust($gray-color, $lightness: -30%, $space: hsl) !default;
-$gray-color-light: color.adjust($gray-color, $lightness: 20%, $space: hsl) !default;
+$light-color: white;
+// $gray-color: color.adjust($dark-color, $lightness: 55%, $space: hsl) !default;
+$gray-color: #ae9c90;
+// $gray-color-dark: color.adjust($gray-color, $lightness: -30%, $space: hsl) !default;
+$gray-color-dark: #605045;
+// $gray-color-light: color.adjust($gray-color, $lightness: 20%, $space: hsl) !default;
+$gray-color-light: #d9d0cb;
 
 $border-color: color.adjust($dark-color, $lightness: 65%, $space: hsl) !default;
 $border-color-dark: color.adjust($border-color, $lightness: -10%, $space: hsl) !default;
 $border-color-light: color.adjust($border-color, $lightness: 8%, $space: hsl) !default;
-$bg-color: color.adjust($dark-color, $lightness: 75%, $space: hsl) !default;
-$bg-color-dark: color.adjust($bg-color, $lightness: -3%, $space: hsl) !default;
+// $bg-color: color.adjust($dark-color, $lightness: 75%, $space: hsl) !default;
+$bg-color: #f9f6f2;
+// $bg-color-dark: color.adjust($bg-color, $lightness: -3%, $space: hsl) !default;
+$bg-color-dark: color.adjust(
+  $bg-color,
+  $lightness: -5%,
+  $space: hsl
+);
 $bg-color-light: $light-color !default;
 
 // Control colors
-$success-color: #32b643 !default;
-$warning-color: #ffb700 !default;
-$error-color: #e85600 !default;
+// $success-color: #32b643 !default;
+$success-color: #aebe39;
+// $warning-color: #ffb700 !default;
+$warning-color: #fbcf33;
+// $error-color: #e85600 !default;
+$error-color: #df6c54;
 
 // Other colors
 $code-color: #d73e48 !default;
@@ -41,6 +63,7 @@ $body-font-color: color.adjust($dark-color, $lightness: 5%, $space: hsl) !defaul
 $link-color: $primary-color !default;
 $link-color-dark: color.adjust($link-color, $lightness: -10%, $space: hsl) !default;
 $link-color-light: color.adjust($link-color, $lightness: 10%, $space: hsl) !default;
+$light-gray: #e4ddda;
 
 // Fonts
 // Credit: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/

--- a/app/assets/stylesheets/spectre-css/mixins/_shadow.scss
+++ b/app/assets/stylesheets/spectre-css/mixins/_shadow.scss
@@ -1,11 +1,11 @@
-@use "../../globals";
+@use "../variables";
 
 // Component focus shadow
-@mixin control-shadow($color: globals.$primary-color) {
+@mixin control-shadow($color: variables.$primary-color) {
   box-shadow: 0 0 0 .1rem rgba($color, .2);
 }
 
 // Shadow mixin
 @mixin shadow-variant($offset) {
-  box-shadow: 0 $offset ($offset + .05rem) * 2 rgba(globals.$dark-color, .3);
+  box-shadow: 0 $offset ($offset + .05rem) * 2 rgba(variables.$dark-color, .3);
 }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -21,7 +21,7 @@
 @use "spectre-css/variables";
 
 body {
-  background-color: globals.$background-color;
+  background-color: variables.$bg-color;
 }
 
 .feather-icon {
@@ -299,7 +299,7 @@ $photo-width: 187px;
     display: contents;
     &:hover .categories-table-name,
     &:hover .categories-table-count {
-      background: globals.$background-color-dark;
+      background: variables.$bg-color-dark;
     }
     .categories-table-name.highlight {
       animation: highlight-fade-out 1.5s;
@@ -1060,7 +1060,7 @@ table.monthly-adjustments {
 
 .note-form {
   padding: 0.5rem 1rem 1.2rem;
-  background: globals.$background-color-dark;
+  background: variables.$bg-color-dark;
   margin-bottom: 1rem;
   label {
     font-weight: 500;
@@ -1307,7 +1307,7 @@ footer.page-footer {
   font-size: 0.8rem;
   padding: 1rem 0 0;
   flex-shrink: 0;
-  background: globals.$background-color-dark;
+  background: variables.$bg-color-dark;
   text-align: center;
   position: relative;
 }


### PR DESCRIPTION
# What it does

When we updated the Sass to use `@use` instead of `@import` in #1716, some of the built-in framework colors stopped being overridden properly. We were using `@import` to just replace global variables for `$primary-color`, etc, but with `@use` everything is namespaced so that no longer works.

I couldn't figure out a nicer way to do this, so I just moved our customization into the main `spectre-css/_variables` file and commented out what was there originally.

Here are a couple places I noticed odd colors:
<img width="690" alt="Screenshot 2024-10-30 at 9 53 44 PM" src="https://github.com/user-attachments/assets/56490731-dd3e-4b02-aed7-f50804b9e235">
<img width="647" alt="Screenshot 2024-10-30 at 9 53 50 PM" src="https://github.com/user-attachments/assets/74527552-3023-49aa-a217-4c7a4f28e9c0">

And after this PR, things are back to normal:
<img width="640" alt="Screenshot 2024-10-30 at 9 54 05 PM" src="https://github.com/user-attachments/assets/cc0ea374-ed50-4d50-8093-7b86fc7faa39">
<img width="641" alt="Screenshot 2024-10-30 at 9 54 10 PM" src="https://github.com/user-attachments/assets/953abea6-2d68-4195-9bbb-ad6609ca4438">


