### PR TITLE
Disable form submit buttons once again

### DIFF
--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -173,7 +173,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def submit(label = nil, options = {}, &)
-    parent_button(label, options.deep_merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {disable: true}), &)
+    parent_button(label, options.deep_merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {turbo_disable: true}), &)
   end
 
   def errors(debug = false)


### PR DESCRIPTION
# What it does

When we switched to the newer version of Turbo, we missed updating how we were disabling form submit buttons in `SpectreFormBuilder`. This might explain some of the issues we've seen with duplicate items.