### PR TITLE
Allow holds to be disabled for individual items

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -69,7 +69,7 @@ module Account
     end
 
     def load_holds_and_loans
-      @holds = Hold.active.includes(:item, member: {appointments: :holds}).where(member: @member, item: {status: Item.statuses[:active]})
+      @holds = Hold.active.where(member: @member).joins(:item).merge(Item.holdable).includes(:item, member: {appointments: :holds})
       @loans = @member.loans.includes(:item, member: {appointments: :loans}).checked_out
     end
 

--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -3,11 +3,17 @@ module Account
     include Pagy::Backend
 
     def index
-      @holds = current_member.active_holds.recent_first.includes(:item)
+      @holds = current_member.active_holds.recent_first.joins(:item).merge(Item.holdable)
     end
 
     def create
       @item = Item.find(params[:item_id])
+
+      unless @item.holds_enabled
+        redirect_to item_path(@item), error: "Can't be placed on hold", status: :see_other
+        return
+      end
+
       @new_hold = Hold.new(item: @item, member: current_member, creator: current_user)
 
       @new_hold.transaction do

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -92,7 +92,7 @@ module Admin
       params.require(:item).permit(
         :name, :other_names, :description, :size, :brand, :model, :serial, :number, :image, :status, :strength,
         :power_source, :borrow_policy_id, :quantity, :checkout_notice, :delete_image, :location_shelf, :location_area, :url,
-        :purchase_price, :purchase_link, :myturn_item_type, category_ids: []
+        :purchase_price, :purchase_link, :myturn_item_type, :holds_enabled, category_ids: []
       )
     end
 

--- a/app/controllers/admin/members/holds_controller.rb
+++ b/app/controllers/admin/members/holds_controller.rb
@@ -12,6 +12,12 @@ module Admin
       def create
         @item = Item.find(new_hold_params[:item_id])
 
+        unless @item.holds_enabled
+          flash[:checkout_error] = "Holds are disabled for this item"
+          redirect_to admin_member_holds_path(@member, anchor: "checkout"), status: :see_other
+          return
+        end
+
         @hold = Hold.new(item: @item, member: @member, creator: current_user)
 
         @hold.transaction do

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -56,7 +56,8 @@ class Item < ApplicationRecord
   scope :in_maintenance, -> { where(status: Item.statuses.values_at(:maintenance)) }
   scope :without_active_holds, -> { where.missing(:active_holds) }
   scope :available_now, -> { available.without_active_holds.where(status: Item.statuses[:active]) }
-  scope :holdable, -> { active }
+  scope :holdable, -> { active.and(holds_enabled) }
+  scope :holds_enabled, -> { where(holds_enabled: true) }
   scope :missing, -> { where(status: Item.statuses[:missing]) }
 
   scope :by_name, -> { order(name: :asc) }
@@ -97,7 +98,11 @@ class Item < ApplicationRecord
   end
 
   def holdable?
-    active?
+    active? && holds_enabled
+  end
+
+  def holds_enabled_status
+    holds_enabled ? "enabled" : "disabled"
   end
 
   delegate :allow_multiple_holds_per_member?, to: :borrow_policy

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -53,19 +53,21 @@
 
   <div class="columns mt-2">
     <div class="column col-4 col-sm-12">
-      <%= form.money_field :purchase_price, label: "Approximate purchase price" %>
+      <%= form.money_field :purchase_price, label: "Purchase price", hint: "What would it cost to replace?" %>
     </div>
     <div class="column col-8 col-sm-12">
       <%= form.text_field :purchase_link %>
     </div>
   </div>
 
+  <%= form.text_field :url, label: "More info URL", hint: "Link to more info, e.g. a manufacturer website" %>
+
   <%= form.rich_text_area :description,
         hint: "Any details about the tool. Could be notes about parts, usage, etc and will appear on the tool's public page" %>
 
   <%= form.text_area :checkout_notice, hint: "Shown when checking item out" %>
 
-  <%= form.text_field :url, label: "URL", hint: "Link to more info, e.g. a manufacturer website" %>
+  <%= form.check_box :holds_enabled, label: "Allow holds to be placed on this item", hint: "Unchecking will hide but not delete existing holds." %>
 
   <fieldset>
     <legend>Item Location</legend>

--- a/app/views/admin/items/_item_panel.html.erb
+++ b/app/views/admin/items/_item_panel.html.erb
@@ -54,6 +54,9 @@
                     <%= link_to(pluralize(count, "files"), admin_item_attachments_path(item)) %>
                 <% end %>
             <% end %>
+            <%= icon_stat "list", title: "hold list status" do %>
+                holds <%= @item.holds_enabled_status %>
+            <% end %>
         </ul>
     </div>
 </div>

--- a/app/views/admin/items/holds/index.html.erb
+++ b/app/views/admin/items/holds/index.html.erb
@@ -1,4 +1,10 @@
 <%= render "admin/items/profile" do %>
+  <% if !@item.holds_enabled %>
+    <div class="toast toast-warning">
+      <p>Holds are disabled for this item.</p>
+    </div>
+  <% end %>
+
   <div class="btn-group mt-2">
     <%= link_to_unless params[:inactive].blank?, "Current", url_for, class: "btn btn-sm" do %>
       <button class="btn btn-sm active">Current</button>

--- a/app/views/admin/members/holds/_form.html.erb
+++ b/app/views/admin/members/holds/_form.html.erb
@@ -1,20 +1,24 @@
-<%= form_with(
-      model: @member.holds.new,
-      url: admin_member_holds_path(@member),
-      builder: SpectreFormBuilder,
-      data: {turbo_frame: "_top"}
-    ) do |form| %>
+<% if @item.holds_enabled %>
+  <%= form_with(
+        model: @member.holds.new,
+        url: admin_member_holds_path(@member),
+        builder: SpectreFormBuilder,
+        data: {turbo_frame: "_top"}
+      ) do |form| %>
 
-  <% if flash.key? :checkout_error %>
-    <div class="toast toast-error"><%= flash[:checkout_error] %></div>
+    <% if flash.key? :checkout_error %>
+      <div class="toast toast-error"><%= flash[:checkout_error] %></div>
+    <% end %>
+
+    <%= form.hidden_field :member_id %>
+    <%= form.hidden_field :item_id, value: @item.id %>
+
+    <%= button_tag class: "btn" do %>
+      <%= feather_icon "clipboard" %>Hold
+    <% end %>
+
+    <%= (@item.holds.active.count + 1).ordinalize %> in line
   <% end %>
-
-  <%= form.hidden_field :member_id %>
-  <%= form.hidden_field :item_id, value: @item.id %>
-
-  <%= button_tag class: "btn" do %>
-    <%= feather_icon "clipboard" %>Hold
-  <% end %>
-
-  <%= (@item.holds.active.count + 1).ordinalize %> in line
+<% else %>
+  Holds are disabled for this item.
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -135,6 +135,8 @@
           <%= render partial: "items/place_hold_on/not_logged_in" %>
         <% end %>
 
+      <% else %>
+        <p>This item can't be placed on hold.</p>
       <% end %>
 
     </div>

--- a/db/migrate/20241105021006_add_enable_holds_to_items.rb
+++ b/db/migrate/20241105021006_add_enable_holds_to_items.rb
@@ -1,0 +1,5 @@
+class AddEnableHoldsToItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :items, :holds_enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_26_205021) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_05_021006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -575,6 +575,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_26_205021) do
     t.string "purchase_link"
     t.integer "purchase_price_cents"
     t.string "myturn_item_type"
+    t.boolean "holds_enabled", default: true
     t.index ["borrow_policy_id", "library_id"], name: "index_items_on_borrow_policy_id_and_library_id"
     t.index ["borrow_policy_id"], name: "index_items_on_borrow_policy_id"
     t.index ["library_id"], name: "index_items_on_library_id"

--- a/test/controllers/account/holds_controller_test.rb
+++ b/test/controllers/account/holds_controller_test.rb
@@ -34,5 +34,15 @@ module Account
       hold = @item.holds.last
       refute hold.started?
     end
+
+    test "doesn't create hold for item with holds disabled" do
+      @item.update!(holds_enabled: false)
+
+      assert_no_difference("@item.holds.count") do
+        post account_holds_url, params: {item_id: @item.id}
+      end
+      assert_redirected_to item_url(@item.id)
+      assert_equal "Can't be placed on hold", flash[:error]
+    end
   end
 end

--- a/test/controllers/admin/members/holds_controller_test.rb
+++ b/test/controllers/admin/members/holds_controller_test.rb
@@ -57,6 +57,18 @@ module Admin
         hold = member.holds.last
         refute hold.started?
       end
+
+      test "does not place a hold when an item has holds disabled" do
+        member = create(:verified_member)
+        item = create(:item, holds_enabled: false)
+
+        assert_no_difference("member.holds.active.count") do
+          post admin_member_holds_url(member), params: {hold: {item_id: item.id}}
+        end
+
+        assert_redirected_to admin_member_holds_url(member, anchor: "checkout")
+        assert_equal "Holds are disabled for this item", flash[:checkout_error]
+      end
     end
   end
 end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -133,6 +133,16 @@ class ItemTest < ActiveSupport::TestCase
     assert item.destroy
   end
 
+  test "is holdable when active and has holds enabled" do
+    item = create(:item, status: Item.statuses[:active], holds_enabled: true)
+    assert item.holdable?
+  end
+
+  test "is not holdable when holds are disabled" do
+    item = create(:item, status: Item.statuses[:active], holds_enabled: false)
+    refute item.holdable?
+  end
+
   test "has a next_hold" do
     item = create(:item)
     hold = create(:hold, item: item, created_at: 2.days.ago)

--- a/test/system/appointments_test.rb
+++ b/test/system/appointments_test.rb
@@ -99,11 +99,13 @@ class AppointmentsTest < ApplicationSystemTestCase
 
     @active_item = create(:item)
     @maintenance_item = create(:item)
+    @unholdable_item = create(:item) # an item that was put on hold before it was set to not allow holds
 
     create(:started_hold, item: @active_item, member: @member)
     create(:hold, item: @maintenance_item, member: @member)
 
     @maintenance_item.update(status: Item.statuses[:maintenance])
+    @unholdable_item.update(holds_enabled: false)
 
     visit account_holds_url
 
@@ -111,9 +113,8 @@ class AppointmentsTest < ApplicationSystemTestCase
       assert_text "Ready for pickup"
     end
 
-    within list_item_containing(@maintenance_item.complete_number) do
-      assert_text "#1 on wait list"
-    end
+    refute_text @maintenance_item.complete_number
+    refute_text @unholdable_item.complete_number
 
     click_on "Schedule a Pick Up"
 
@@ -124,6 +125,7 @@ class AppointmentsTest < ApplicationSystemTestCase
     end
 
     refute_text @maintenance_item.complete_number
+    refute_text @unholdable_item.complete_number
   end
 
   test "multiple members can make an appointment for an uncounted tool" do

--- a/test/system/holds_test.rb
+++ b/test/system/holds_test.rb
@@ -32,6 +32,16 @@ class HoldsTest < ApplicationSystemTestCase
     refute_selector 'input[value="Place a hold"]'
   end
 
+  test "member can't place a hold on an item with holds disabled" do
+    login_as @member.user
+
+    @item = create(:item, holds_enabled: false)
+
+    visit item_url(@item)
+
+    refute_selector 'input[value="Place a hold"]'
+  end
+
   test "member can place a hold multiple times when the borrow policy allows it" do
     login_as @member.user
 


### PR DESCRIPTION
# What it does

Adds a new field to items that allows staff to disable holds as requested in #1714.

# Why it is important

There are cases where having an item be placed on hold created more trouble than it's worth.

# UI Change Screenshot

Toggle in the item edit form:
<img width="369" alt="image" src="https://github.com/user-attachments/assets/2e4ae583-5323-4384-89d2-2d22303558ce">

Showing whether holds are enabled in the item sidebar for staff:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/cc3957e1-b415-46bd-ab20-e33c2f68de4e">

Indicating that holds are disabled on public item pages:

<img width="974" alt="Screenshot 2024-11-06 at 12 20 57 AM" src="https://github.com/user-attachments/assets/2ab9a98d-e92f-42a1-9fb2-1aead672bca2">

# Implementation notes

* Holds that already exist when this setting is disabled for an item are hidden in the member-facing UI but remain in the database.