### PR TITLE
Tweak lograge config

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,12 +1,12 @@
 Rails.application.configure do
-  config.lograge.enabled = true
+  config.lograge.enabled = Rails.env.production?
 
   # Set a few custom parameters on log lines
   config.lograge.custom_payload do |controller|
-    {
-      user_id: controller.current_user.try(:id) || controller.try(:member).try(:user).try(:id),
-      request_id: controller.request.request_id
-    }
+    {request_id: controller.request.request_id}.tap do |payload|
+      user_id = controller.current_user.try(:id) || controller.try(:member).try(:user).try(:id)
+      payload[:user_id] = user_id if user_id
+    end
   end
 
   # Heroku environments will set this env var and expect logs on stdout


### PR DESCRIPTION
Update our [lograge](https://github.com/roidrage/lograge) configuration in two ways:

1. Disable lograge in development and test environments. I think the default Rails log format is easier to read for a human, and we mostly use log rage in production to be compatible with AppSignal's log parsing.
2. Adjusts the way we add additional properties to the logs so that we only add a `user_id` when there is a value. I think this will fix #1568.