### PR TITLE
Add flash_highlight and clean up bits of old highlighting.

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -288,68 +288,6 @@ $photo-width: 187px;
   max-width: 100%;
 }
 
-.categories-table {
-  display: grid;
-
-  grid-template-columns: 1fr 100px 200px;
-  grid-row-gap: 0.3rem;
-  grid-column-gap: 0.6rem;
-
-  .categories-table-row {
-    display: contents;
-    &:hover .categories-table-name,
-    &:hover .categories-table-count {
-      background: variables.$bg-color-dark;
-    }
-    .categories-table-name.highlight {
-      animation: highlight-fade-out 1.5s;
-    }
-  }
-
-  .categories-table-header {
-    font-weight: bold;
-  }
-
-  .categories-table-name {
-    grid-column-start: 1;
-    padding-left: 0.2rem;
-    &.nested-1 {
-      margin-left: 1rem;
-    }
-    &.nested-2 {
-      margin-left: 2rem;
-    }
-    &.nested-3 {
-      margin-left: 3rem;
-    }
-    &.nested-4 {
-      margin-left: 4rem;
-    }
-    &.nested-5 {
-      margin-left: 5rem;
-    }
-    &.nested-6 {
-      margin-left: 6rem;
-    }
-    &.nested-7 {
-      margin-left: 7rem;
-    }
-    &.nested-8 {
-      margin-left: 8rem;
-    }
-    &.nested-9 {
-      margin-left: 9rem;
-    }
-    &.nested-10 {
-      margin-left: 10rem;
-    }
-  }
-
-  .categories-table-count {
-    text-align: center;
-  }
-}
-
 .responsive-table {
   display: flex;
   flex-wrap: wrap;
@@ -825,10 +763,6 @@ form.membership-amount {
     margin-top: 0 !important;
     padding-top: 0.4rem;
   }
-
-  .highlight {
-    animation: highlight-fade-out 1.5s;
-  }
 }
 
 .admin {
@@ -850,12 +784,13 @@ form.membership-amount {
   }
 }
 
+.highlight {
+  animation: highlight-fade-out 1.5s;
+}
+
 @keyframes highlight-fade-out {
   from {
-    background-color: antiquewhite;
-  }
-  to {
-    background: transparent;
+    background-color: variables.$secondary-color-light;
   }
 }
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -39,7 +39,7 @@ module Admin
     end
 
     def flash_highlight(id_or_object)
-      identifier = if String === id_or_object
+      identifier = if id_or_object.is_a?(String)
         id_or_object
       else
         dom_id(id_or_object)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class BaseController < ApplicationController
+    include ActionView::RecordIdentifier
+
     before_action :authenticate_user!
     before_action :require_staff
     before_action :load_requested_renewal_request_count
@@ -34,6 +36,16 @@ module Admin
       if !@current_library.allow_appointments?
         render_not_found
       end
+    end
+
+    def flash_highlight(id_or_object)
+      identifier = if String === id_or_object
+        id_or_object
+      else
+        dom_id(id_or_object)
+      end
+      flash[:highlight] ||= []
+      flash[:highlight] << identifier
     end
   end
 end

--- a/app/controllers/admin/bulk_renewals_controller.rb
+++ b/app/controllers/admin/bulk_renewals_controller.rb
@@ -7,7 +7,10 @@ module Admin
 
     def update
       @member.loans.checked_out.each do |loan|
-        renew_loan(loan) if loan.within_renewal_limit?
+        if loan.within_renewal_limit?
+          renewal = renew_loan(loan)
+          flash_highlight(renewal)
+        end
       end
 
       redirect_to admin_member_url(@member.id), status: :see_other

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -19,6 +19,7 @@ module Admin
       @loan = create_loan(@item, @member)
 
       if @loan.persisted?
+        flash_highlight(@loan)
         redirect_to admin_member_path(@loan.member, anchor: dom_id(@loan)), status: :see_other
       else
         flash[:checkout_error] = @loan.errors.full_messages_for(:item_id).join

--- a/app/controllers/admin/members/hold_loans_controller.rb
+++ b/app/controllers/admin/members/hold_loans_controller.rb
@@ -5,7 +5,10 @@ module Admin
 
       def create
         @member.transaction do
-          @member.active_holds.map { |hold| create_loan_from_hold(hold) }
+          @member.active_holds.map do |hold|
+            loan = create_loan_from_hold(hold)
+            flash_highlight(loan)
+          end
         end
         redirect_to admin_member_path(@member), status: :see_other
       end

--- a/app/controllers/admin/members/holds_controller.rb
+++ b/app/controllers/admin/members/holds_controller.rb
@@ -22,6 +22,7 @@ module Admin
 
         @hold.transaction do
           if @hold.save
+            flash_highlight(@hold)
             @hold.start! if @hold.ready_for_pickup?
             redirect_to admin_member_holds_path(@member, anchor: dom_id(@hold)), status: :see_other
           else
@@ -33,7 +34,8 @@ module Admin
 
       def lend
         @hold = @member.active_holds.find(params[:id])
-        if create_loan_from_hold(@hold)
+        if (loan = create_loan_from_hold(@hold))
+          flash_highlight(loan)
           redirect_to admin_member_holds_path(@hold.member), status: :see_other
         else
           redirect_to admin_member_holds_path(@hold.member), error: "That hold could not be loaned", status: :see_other

--- a/app/controllers/admin/renewals_controller.rb
+++ b/app/controllers/admin/renewals_controller.rb
@@ -21,7 +21,7 @@ module Admin
       if @loan.renewal?
         @previous_loan = undo_loan_renewal(@loan)
         flash_highlight(@previous_loan)
-        redirect_to admin_member_path(@loan.member, anchor: dom_id(@previous_loan)), status: :see_other
+        redirect_to admin_member_path(@loan.member), status: :see_other
       else
         redirect_to admin_member_path(@loan.member, anchor: "current-loans"), error: "Renewal could not be destroyed!", status: :see_other
       end

--- a/app/controllers/admin/renewals_controller.rb
+++ b/app/controllers/admin/renewals_controller.rb
@@ -8,7 +8,8 @@ module Admin
       @renewal = renew_loan(@loan)
 
       if @renewal
-        redirect_to admin_member_url(@loan.member_id, anchor: dom_id(@renewal)), status: :see_other
+        flash_highlight(@renewal)
+        redirect_to admin_member_url(@loan.member_id), status: :see_other
       else
         redirect_to admin_member_url(@loan.member_id), error: "That item couldn't be renewed.", status: :see_other
       end
@@ -19,6 +20,7 @@ module Admin
 
       if @loan.renewal?
         @previous_loan = undo_loan_renewal(@loan)
+        flash_highlight(@previous_loan)
         redirect_to admin_member_path(@loan.member, anchor: dom_id(@previous_loan)), status: :see_other
       else
         redirect_to admin_member_path(@loan.member, anchor: "current-loans"), error: "Renewal could not be destroyed!", status: :see_other

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,7 @@ import '@rails/actiontext'
 import './controllers'
 import { setupFeatherIcons } from './lib/feather'
 import { arrangeAppointment } from './lib/appointments'
+import { highlightElement } from './lib/highlight'
 
 ActiveStorage.start()
 
@@ -21,3 +22,32 @@ Turbo.StreamActions.arrangeAppointment = function () {
 
 document.documentElement.addEventListener('turbo:load', setupFeatherIcons)
 document.documentElement.addEventListener('turbo:frame-render', setupFeatherIcons)
+document.documentElement.addEventListener('turbo:load', highlightElement)
+document.documentElement.addEventListener('turbo:frame-render', highlightElement)
+
+// Uncomment for trubo debugging sessions :-/
+// const events = [
+//   "turbo:fetch-request-error",
+//   "turbo:frame-missing",
+//   "turbo:frame-load",
+//   "turbo:frame-render",
+//   "turbo:before-frame-render",
+//   "turbo:load",
+//   "turbo:render",
+//   "turbo:before-stream-render",
+//   "turbo:before-render",
+//   "turbo:before-cache",
+//   "turbo:submit-end",
+//   "turbo:before-fetch-response",
+//   "turbo:before-fetch-request",
+//   "turbo:submit-start",
+//   "turbo:visit",
+//   "turbo:before-visit",
+//   "turbo:click"
+// ]
+
+// events.forEach(e => {
+//   addEventListener(e, (event) => {
+//     console.log(e, event);
+//   });
+// });

--- a/app/javascript/lib/highlight.js
+++ b/app/javascript/lib/highlight.js
@@ -1,0 +1,18 @@
+// If an element to highlight is declared in the document head, add a CSS class
+// to highlight it. Remove the class when the highlight animation completes
+// so it can be triggered on the same element again if needed.
+export function highlightElement () {
+  const metaTag = document.querySelector("meta[name='highlight-element']")
+  if (metaTag) {
+    const elementIDs = metaTag.getAttribute('content').split(',')
+    elementIDs.forEach(elementID => {
+      const element = document.getElementById(elementID)
+      if (element) {
+        element.addEventListener('animationend', function (event) {
+          element.classList.remove('highlight')
+        }, { once: true })
+        element.classList.add('highlight')
+      }
+    })
+  }
+}

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
   <% appointment_return_items.each do |return_item| %>
-    <div class="columns mt-2 mb-2 highlightable">
+    <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
           <% if return_item.item.image.attached? %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <% appointment_pickup_items.each do |pickup_item| %>
-    <div class="columns mt-2 mb-2 highlightable">
+    <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
           <% if pickup_item.item.image.attached? %>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -10,7 +10,7 @@
 
   <% @categories.each do |category| %>
     <%= tag.div class: "categories-table-row" do %>
-      <%= tag.div class: "categories-table-name nested-#{category.path_ids.size - 1} highlightable", id: dom_id(category) do %>
+      <%= tag.div class: "categories-table-name nested-#{category.path_ids.size - 1}", id: dom_id(category) do %>
         <% if category.parent_id.present? %>&rdsh;<% end %>
         <%= category.name %>
       <% end %>

--- a/app/views/admin/members/holds/history.html.erb
+++ b/app/views/admin/members/holds/history.html.erb
@@ -2,7 +2,7 @@
   <% if @holds.any? %>
     <div id="current-holds" class="member-holds">
       <% @holds.each do |hold| %>
-        <div id="<%= dom_id hold %>" class="columns mt-2 mb-2 highlightable">
+        <div id="<%= dom_id hold %>" class="columns mt-2 mb-2">
           <div class="column col-sm-6 col-4">
             <%= tag.div class: "item-image" do %>
               <% if hold.item.image.attached? %>

--- a/app/views/admin/members/holds/index.html.erb
+++ b/app/views/admin/members/holds/index.html.erb
@@ -2,7 +2,7 @@
   <% if @holds.any? %>
     <div id="current-holds" class="member-holds">
       <% @holds.each do |hold| %>
-        <div id="<%= dom_id hold %>" class="columns mt-2 mb-2 highlightable">
+        <div id="<%= dom_id hold %>" class="columns mt-2 mb-2">
           <div class="column col-sm-6 col-4">
             <%= tag.div class: "item-image" do %>
               <% if hold.item.image.attached? %>
@@ -43,5 +43,5 @@
     </div>
   <% end %>
 
-  <%= render partial: "admin/members/lookup", locals: {member: @member} %>
+  <%= render partial: "admin/members/lookup", locals: {member: @member, lookup: @lookup} %>
 <% end %>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -14,7 +14,7 @@
         </div>
       </div>
       <% @returned_loan_summaries.each do |summary| %>
-        <div id="<%= dom_id summary.latest_loan %>" class="columns mt-2 mb-2 highlightable">
+        <div id="<%= dom_id summary.latest_loan %>" class="columns mt-2 mb-2">
           <div class="column col-sm-6 col-4">
             <%= tag.div class: "item-image" do %>
               <% if summary.item.image.attached? %>
@@ -60,7 +60,7 @@
           </div>
         </div>
         <% summaries.sort_by { |s| s.latest_loan.updated_at }.each do |summary| %>
-          <div id="<%= dom_id summary.latest_loan %>" class="columns mt-2 mb-2 highlightable">
+          <div id="<%= dom_id summary.latest_loan %>" class="columns mt-2 mb-2">
             <div class="column col-sm-6 col-4">
               <%= tag.div class: "item-image" do %>
                 <% if summary.item.image.attached? %>
@@ -115,7 +115,7 @@
     <p class="mt-2">No current loans or recently returned items.</p>
   <% end %>
 
-  <%= render partial: "admin/members/lookup", locals: {member: @member} %>
+  <%= render partial: "admin/members/lookup", locals: {member: @member, lookup: @lookup} %>
 </div>
 
 <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -9,6 +9,11 @@
     <% unless request.get? && !form_request? # prevent turbo for caching form redisplays, which will often contain validation messages %>
       <meta name="turbo-cache-control" content="no-preview">
     <% end %>
+    <%= turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+    <%= yield :head %>
+    <% if flash.key? :highlight %>
+      <meta name="highlight-element" content="<%= flash[:highlight].join(",") %>">
+    <% end %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   </head>

--- a/test/controllers/admin/renewals_controller_test.rb
+++ b/test/controllers/admin/renewals_controller_test.rb
@@ -17,7 +17,7 @@ module Admin
         post admin_renewals_url(loan_id: @loan)
       end
 
-      assert_redirected_to admin_member_url(@loan.member, anchor: "loan_#{Loan.last.id}")
+      assert_redirected_to admin_member_url(@loan.member)
 
       @loan.reload
 
@@ -41,7 +41,7 @@ module Admin
         delete admin_renewal_url(@renewal)
       end
 
-      assert_redirected_to admin_member_url(@loan.member, anchor: "loan_#{@loan.id}")
+      assert_redirected_to admin_member_url(@loan.member)
 
       @loan.reload
 


### PR DESCRIPTION
# What it does

* Adds a new/better way to highlight areas of the page that are updated. This is mostly useful on screens where there are long lists of items, as they sometimes move around as changes are made. I added a `flash_highlight` helper function to manage this- it's easy to just call it in a controller with an `ActiveRecord` object.
* Enables [morphing for page refreshes](https://jonsully.net/blog/turbo-8-page-refreshes-morphing-explained-at-length/#stay-on-the-rails), which should make some interactions where a user is redirected back to the same page they're already on nicer.
* Cleans up some old styles that weren't being used.

# UI Change Screenshot

![2024-11-08 09 11 50](https://github.com/user-attachments/assets/e735b11d-45ed-4ec1-abf8-a43c81cf5a2e)
