### PR TITLE
Added renewal count to the renewal requests index page

### DIFF
--- a/app/views/admin/renewal_requests/index.html.erb
+++ b/app/views/admin/renewal_requests/index.html.erb
@@ -24,11 +24,9 @@
       <table class="table table-scroll">
         <thead>
           <tr>
-            <th>
-              <span>Item</span><br>
-              <span>Holds</span>
-            </th>
-            <th>Item Number</th>
+            <th>Item</th>
+            <th>Holds</th>
+            <th>Renewals</th>
             <th>Member</th>
             <th>Requested On</th>
             <th>Status</th>
@@ -40,9 +38,10 @@
             <tr>
               <td>
                 <span><%= link_to request.loan.item.name, [:admin, request.loan.item] %></span><br>
-                <span><%= request.loan.item.active_holds.size %> <%= "hold".pluralize(request.loan.item.active_holds.size) %></span>
+                <span><%= full_item_number(request.loan.item) %></span>
               </td>
-              <td><%= full_item_number(request.loan.item) %></td>
+              <td><%= request.loan.item.active_holds.size %></td>
+              <td><%= request.loan.renewal_count %></td>
               <td><%= link_to preferred_or_default_name(request.loan.member), [:admin, request.loan.member] %></td>
               <td><%= date_with_time_title request.created_at %></td>
               <td>


### PR DESCRIPTION
# What it does

Added the renewal count to the renewal requests index page and rearranged a few of the columns.

# Why it is important

#1654 

# UI Change Screenshot

The renewal requests index page on a iPad mini
![Screenshot 2024-11-08 at 3 28 23 PM](https://github.com/user-attachments/assets/59fdb146-8fdf-45dd-a7a0-bb4e1ce1f5ba)

# Implementation notes

If this page needs to support a narrower screen size we can combine some of the columns but the iPad mini (768px wide in portrait mode) seems like it would cover most devices. Let me know if not!
