### PR TITLE
Use category name when linking to categories.

### DIFF
--- a/app/views/admin/items/_items.html.erb
+++ b/app/views/admin/items/_items.html.erb
@@ -37,7 +37,7 @@
 
     <%= tag.div class: "items-table-categories" do %>
       <% item.categories.each do |category| %>
-        <%= link_to tag.name, admin_items_path(category: category.id) %>
+        <%= link_to category.name, admin_items_path(category: category.id) %>
       <% end %>
     <% end %>
     <div class="item-table-divider"></div>

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -188,7 +188,7 @@ class ItemsTest < ApplicationSystemTestCase
       assert_text "Viewing all 3 items"
     end
 
-    click_on "Drills"
+    click_on "Drills", match: :first # there are multiple links to this category on the page
     within(".items-summary") do
       assert_text "Viewing 2 items assigned to Drills", normalize_ws: true
     end


### PR DESCRIPTION
# What it does

Just a very small fix. This bug was preventing the display of category links in the admin items index. We were rendering a link around an empty `name` tag, which meant that the links were effectively invisible. With this fix, they show the category name again.

# UI Change Screenshot

Before: 
<img width="761" alt="Screenshot 2024-11-10 at 7 56 44 PM" src="https://github.com/user-attachments/assets/2f325294-1887-4eb8-8e04-140a13da3fd2">

After:
<img width="722" alt="Screenshot 2024-11-10 at 7 57 01 PM" src="https://github.com/user-attachments/assets/cf24c2e8-8a39-4476-af60-3b29645df8ca">
