### PR TITLE
Sort tickets  on maintenance ticket list on the admin item's page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,6 +613,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/app/controllers/admin/items/tickets_controller.rb
+++ b/app/controllers/admin/items/tickets_controller.rb
@@ -4,7 +4,7 @@ module Admin
       before_action :set_ticket, only: %i[show edit update destroy]
 
       def index
-        @tickets = @item.tickets.all
+        @tickets = @item.tickets.all.order(:status, updated_at: :desc)
       end
 
       def show


### PR DESCRIPTION
# What it does

Sorts the maintenance tickets by `status` (ascending) and `updated_at` (descending).

# Why it is important

#1744 

# UI Change Screenshot

![Screenshot 2024-11-13 at 2 17 02 PM](https://github.com/user-attachments/assets/756300c6-5fab-44d6-a3a6-87b2d7bc3dd7)

# Implementation notes

Order up!
