### PR TITLE
Add the retired status to tickets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,6 +613,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/app/controllers/admin/items/tickets/ticket_updates_controller.rb
+++ b/app/controllers/admin/items/tickets/ticket_updates_controller.rb
@@ -5,12 +5,6 @@ module Admin
         before_action :set_ticket
         before_action :set_ticket_update, only: [:edit, :update, :destroy]
 
-        # def index
-        #   @maintenance_reports = @item.maintenance_reports.includes(:audit)
-
-        #   @events = @maintenance_reports.to_a.concat(@item.audits.includes(:maintenance_report)).sort_by(&:created_at)
-        # end
-
         def new
           @ticket_update_form = TicketUpdateForm.new(@ticket)
         end

--- a/app/controllers/admin/items/tickets_controller.rb
+++ b/app/controllers/admin/items/tickets_controller.rb
@@ -24,6 +24,7 @@ module Admin
         @ticket = @item.tickets.new(ticket_params)
 
         if @ticket.save
+          @ticket.item.update!(status: Item.statuses["retired"]) if @ticket.retired?
           redirect_to admin_item_ticket_url(@item, @ticket), success: "Ticket was successfully created.", status: :see_other
         else
           render :new, status: :unprocessable_entity
@@ -32,6 +33,7 @@ module Admin
 
       def update
         if @ticket.update(ticket_params)
+          @ticket.item.update!(status: Item.statuses["retired"]) if @ticket.retired?
           redirect_to admin_item_ticket_url(@item, @ticket), success: "Ticket was successfully updated.", status: :see_other
         else
           render :edit, status: :unprocessable_entity

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -3,21 +3,24 @@ class Ticket < ApplicationRecord
     "assess" => "Assess",
     "repairing" => "Repair in Progress",
     "parts" => "Parts on Order",
-    "resolved" => "Resolved"
+    "resolved" => "Resolved",
+    "retired" => "Retired"
   }
 
   STATUS_DESCRIPTIONS = {
     "assess" => "newly created; needs examination by maintenance team",
     "parts" => nil,
     "repairing" => nil,
-    "resolved" => "the problem has been fixed"
+    "resolved" => "the problem has been fixed",
+    "retired" => "removed from inventory"
   }
 
   enum :status, {
     assess: "assess",
     parts: "parts",
     repairing: "repairing",
-    resolved: "resolved"
+    resolved: "resolved",
+    retired: "retired"
   }
 
   belongs_to :item

--- a/db/migrate/20241113202700_add_retired_to_ticket_status.rb
+++ b/db/migrate/20241113202700_add_retired_to_ticket_status.rb
@@ -1,0 +1,9 @@
+class AddRetiredToTicketStatus < ActiveRecord::Migration[7.2]
+  def up
+    add_enum_value :ticket_status, "retired"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_05_021006) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_13_202700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_05_021006) do
     "parts",
     "repairing",
     "resolved",
+    "retired",
   ], force: :cascade
 
   create_enum :user_role, [


### PR DESCRIPTION
# What it does

Add the retired status to tickets, always change an item's status to be retired when a retired ticket is created or a ticket is updated to retired.

# Why it is important

#1745 

# UI Change Screenshot

Item's ticket page with no tickets:
![Screenshot 2024-11-13 at 2 51 57 PM](https://github.com/user-attachments/assets/f2019d17-abd0-42de-97a5-7715bf96e70d)

Item's ticket page after creating a "retired" ticket:
![Screenshot 2024-11-13 at 2 52 26 PM](https://github.com/user-attachments/assets/3ac0f2d2-3fd3-4652-ac7a-60736432cf60)

Item's ticket page with an "assess" ticket:
![Screenshot 2024-11-13 at 2 53 16 PM](https://github.com/user-attachments/assets/d592b21d-8d1d-4a74-80af-83ac407f2239)

Item's ticket page after updating the "assess" ticket to "retired":
![Screenshot 2024-11-13 at 2 53 33 PM](https://github.com/user-attachments/assets/df38241b-8b11-4dbe-a1db-5b4220c8c8de)

# Implementation notes

I suppose it's possible for the item update to fail (although I don't see how), but I used `update!` so it should surface if it does.
