### PR TITLE
Disable the maintenance option when creating an item

### DIFF
--- a/app/controllers/admin/items/tickets_controller.rb
+++ b/app/controllers/admin/items/tickets_controller.rb
@@ -24,7 +24,7 @@ module Admin
         @ticket = @item.tickets.new(ticket_params)
 
         if @ticket.save
-          @ticket.item.update!(status: Item.statuses["retired"]) if @ticket.retired?
+          update_item_status!(@ticket)
           redirect_to admin_item_ticket_url(@item, @ticket), success: "Ticket was successfully created.", status: :see_other
         else
           render :new, status: :unprocessable_entity
@@ -46,6 +46,11 @@ module Admin
       end
 
       private
+
+      def update_item_status!(ticket)
+        status = ticket.retired? ? Item.statuses["retired"] : Item.statuses["maintenance"]
+        @ticket.item.update!(status:)
+      end
 
       def set_ticket
         @ticket = Ticket.find(params[:id])

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -14,10 +14,12 @@ module ItemsHelper
     Item::STATUS_NAMES[status]
   end
 
-  def item_status_options
+  def item_status_options(disabled_statuses: [])
     Item.statuses.map do |key, value|
       description = " (#{Item::STATUS_DESCRIPTIONS[key]})" if Item::STATUS_DESCRIPTIONS[key]
-      ["#{Item::STATUS_NAMES[key]}#{description}", key]
+      ["#{Item::STATUS_NAMES[key]}#{description}", key].tap do |option|
+        option << {disabled: true} if disabled_statuses.include?(key)
+      end
     end
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -52,6 +52,11 @@ module ItemsHelper
     end
   end
 
+  def status_hint(item)
+    status_maintenance_hint = item.persisted? ? link_to("create a ticket", new_admin_item_ticket_path(item)) : "create a ticket"
+    "Only active items can be checked out. To mark an item as in maintenance, please #{status_maintenance_hint}.".html_safe
+  end
+
   class TreeNode
     attr_accessor :children
     attr_accessor :value

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -39,9 +39,7 @@
 
   <div class="columns" data-controller="conditional-field" data-conditional-field-trigger-value="<%= BorrowPolicy.not_uniquely_numbered_ids.join(",") %>">
     <div class="column col-4 col-sm-12">
-      <% status_maintenance_hint = item.persisted? ? link_to('create a ticket', new_admin_item_ticket_path(item)) : 'create a ticket' %>
-      <% status_hint = "Only active items can be checked out. To mark an item as in maintenance, please #{status_maintenance_hint}.".html_safe %>
-      <%= form.select :status, options_for_select(item_status_options(disabled_statuses: %w[maintenance]), item.status || Item.statuses[:active]), prompt: true, hint: status_hint %>
+      <%= form.select :status, options_for_select(item_status_options(disabled_statuses: %w[maintenance]), item.status || Item.statuses[:active]), prompt: true, hint: status_hint(item) %>
     </div>
     <div class="column col-4 col-sm-12">
       <%= form.select :borrow_policy_id, options_for_select(borrow_policy_options, item.borrow_policy_id || BorrowPolicy.default&.id), {hint: "Borrowing rules used for this item"}, data: {action: "conditional-field#change", "conditional-field-target": "parent"} %>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -39,7 +39,9 @@
 
   <div class="columns" data-controller="conditional-field" data-conditional-field-trigger-value="<%= BorrowPolicy.not_uniquely_numbered_ids.join(",") %>">
     <div class="column col-4 col-sm-12">
-      <%= form.select :status, options_for_select(item_status_options, item.status || Item.statuses[:active]), prompt: true, hint: "Only active items can be checked out" %>
+      <% status_maintenance_hint = item.persisted? ? link_to('create a ticket', new_admin_item_ticket_path(item)) : 'create a ticket' %>
+      <% status_hint = "Only active items can be checked out. To mark an item as in maintenance, please #{status_maintenance_hint}.".html_safe %>
+      <%= form.select :status, options_for_select(item_status_options(disabled_statuses: %w[maintenance]), item.status || Item.statuses[:active]), prompt: true, hint: status_hint %>
     </div>
     <div class="column col-4 col-sm-12">
       <%= form.select :borrow_policy_id, options_for_select(borrow_policy_options, item.borrow_policy_id || BorrowPolicy.default&.id), {hint: "Borrowing rules used for this item"}, data: {action: "conditional-field#change", "conditional-field-target": "parent"} %>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "concurrently": "^9.1.0",
     "markdown-toc": "^1.2.0",
-    "playwright": "1.46.0",
+    "playwright": "1.45.0",
     "standard": "^17.1.2"
   },
   "scripts": {

--- a/test/controllers/admin/items/tickets_controller_test.rb
+++ b/test/controllers/admin/items/tickets_controller_test.rb
@@ -45,6 +45,20 @@ module Admin
         assert_equal body, ticket.body.to_plain_text
       end
 
+      test "creating a ticket with any status besides 'retired' updates the ticket's status to 'maintenance'" do
+        status = %w[assess repairing parts resolved].sample
+
+        refute_equal "maintenance", @item.status
+
+        assert_difference("Ticket.count") do
+          post admin_item_tickets_url(@item), params: {ticket: {status:, title: "foo", body: ""}}
+        end
+
+        ticket = Ticket.first!
+        assert_equal status, ticket.status
+        assert_equal "maintenance", @item.reload.status
+      end
+
       test "creating a retired ticket updates the item's status to retired too" do
         retired = Item.statuses["retired"]
 

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -156,4 +156,23 @@ class ItemsHelperTest < ActionView::TestCase
       end
     end
   end
+
+  class ItemStatusOptionsTest < ItemsHelperTest
+    test "it is all item statuses and descriptions" do
+      assert_includes item_status_options, ["Pending (just acquired; not ready to loan)", "pending"]
+      assert_includes item_status_options, ["Active (available to loan)", "active"]
+      assert_includes item_status_options, ["Maintenance (undergoing maintenance; do not loan)", "maintenance"]
+      assert_includes item_status_options, ["Missing (misplaced; unable to loan)", "missing"]
+      assert_includes item_status_options, ["Retired (no longer part of our inventory)", "retired"]
+    end
+
+    test "it is all item statuses and descriptions except for those that are marked as disabled" do
+      result = item_status_options(disabled_statuses: %w[maintenance retired])
+      assert_includes result, ["Maintenance (undergoing maintenance; do not loan)", "maintenance", {disabled: true}]
+      assert_includes result, ["Retired (no longer part of our inventory)", "retired", {disabled: true}]
+      assert_includes result, ["Pending (just acquired; not ready to loan)", "pending"]
+      assert_includes result, ["Active (available to loan)", "active"]
+      assert_includes result, ["Missing (misplaced; unable to loan)", "missing"]
+    end
+  end
 end

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -6,12 +6,17 @@ class ItemsTest < ApplicationSystemTestCase
     create(:default_borrow_policy)
   end
 
+  def assert_maintenance_option_is_disabled
+    assert_selector "option[value='maintenance'][disabled='disabled']"
+  end
+
   test "creating an item" do
     @item = build(:item)
 
     visit admin_items_url
     click_on "New Item"
 
+    assert_maintenance_option_is_disabled
     fill_in "Name", with: @item.name
     fill_in_rich_text_area "item_description", with: @item.description
     fill_in "Size", with: @item.size
@@ -33,6 +38,7 @@ class ItemsTest < ApplicationSystemTestCase
     visit admin_item_url(@item)
     click_on "Edit"
 
+    assert_maintenance_option_is_disabled
     fill_in "Name", with: "Modified Name"
     fill_in "Brand", with: "Modified Brand"
     fill_in_rich_text_area "item_description", with: @item.description

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,17 +3010,17 @@ pkg-conf@^3.1.0:
     find-up "^3.0.0"
     load-json-file "^5.2.0"
 
-playwright-core@1.46.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.46.0.tgz#2336ac453a943abf0dc95a76c117f9d3ebd390eb"
-  integrity sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==
+playwright-core@1.45.0:
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.0.tgz#5741a670b7c9060ce06852c0051d84736fb94edc"
+  integrity sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==
 
-playwright@1.46.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.46.0.tgz#c7ff490deae41fc1e814bf2cb62109dd9351164d"
-  integrity sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==
+playwright@1.45.0:
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.45.0.tgz#400c709c64438690f13705cb9c88ef93089c5c27"
+  integrity sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==
   dependencies:
-    playwright-core "1.46.0"
+    playwright-core "1.45.0"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -3389,7 +3389,7 @@ standard@^17.1.2:
     standard-engine "^15.1.0"
     version-guard "^1.1.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3406,6 +3406,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -3477,7 +3486,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3490,6 +3499,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -3794,7 +3810,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# What it does

Disables the maintenance option on the admin item form and marks items as in maintenance after creating a ticket.

# Why it is important

#1743 

# UI Change Screenshot

Select dropdown for a new item:
![Screenshot 2024-11-14 at 2 18 26 PM](https://github.com/user-attachments/assets/f0150005-480b-4768-956e-3b2603b7834a)

Select dropdown when editing an item:
![Screenshot 2024-11-14 at 2 17 56 PM](https://github.com/user-attachments/assets/8023b101-a810-42a6-9e50-78af687f3703)

Expanded select dropdown when editing an item:
![Screenshot 2024-11-14 at 2 18 08 PM](https://github.com/user-attachments/assets/800245e6-4fcc-4625-aeac-78ab4a30b20b)

An item just before creating a ticket:
![Screenshot 2024-11-16 at 11 36 48 AM](https://github.com/user-attachments/assets/10242d1d-47d4-48cd-9cf3-d44fac8671f9)

An item right after creating a ticket:
![Screenshot 2024-11-16 at 11 36 59 AM](https://github.com/user-attachments/assets/bafbbda9-7a76-4fbe-91cc-aa69cbc0b502)

# Implementation notes

For now I've set it up to only put items into maintenance when creating a ticket. I could see a case for marking items as available once the ticket is resolved, but I can also imagine reasons we might not want that to happen (maybe another ticket was created afterwards or that issue is resolved because it's lost now or something). 
