### PR TITLE
Update to version 4 of upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
       #   if: ${{ matrix.test == 'system' && failure() }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.test == 'system' && failure() }}
         with:
           path: |


### PR DESCRIPTION
# What it does

I got an email about v3 being deprecated and will no longer work starting in January 2025. [The docs about this are here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Our use case is pretty simple, so I think this is the only change that's needed.