### PR TITLE
Show the raw value of each item's status in addition to the member facing version in the admin interface

### DIFF
--- a/app/views/admin/items/_item_panel.html.erb
+++ b/app/views/admin/items/_item_panel.html.erb
@@ -11,6 +11,7 @@
         <h6>
             <strong><%= item.complete_number %></strong>
             <%= item_status_label(item) %>
+            <span class="label item-checkout-status"><%= item.status.capitalize %></span>
         </h6>
     </div>
 

--- a/app/views/admin/items/_items.html.erb
+++ b/app/views/admin/items/_items.html.erb
@@ -13,6 +13,7 @@
     <%= tag.div class: "items-table-name" do %>
       <strong><%= full_item_number(item) %></strong>
       <%= item_status_label(item) %>
+      <span class="label item-checkout-status"><%= item.status.capitalize %></span>
       <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
       <br>
       <%= link_to item.name, admin_item_path(item) %>

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -190,6 +190,11 @@ class ItemsTest < ApplicationSystemTestCase
     @hold = create(:hold, member: @member, item: @item3, creator: @user)
 
     visit admin_items_url
+
+    assert_text "Available"
+    assert_text "On Hold"
+    assert_text "Active"
+
     within(".items-summary") do
       assert_text "Viewing all 3 items"
     end
@@ -203,5 +208,15 @@ class ItemsTest < ApplicationSystemTestCase
     within(".items-summary") do
       assert_text "Viewing 1 item assigned to Drills", normalize_ws: true
     end
+  end
+
+  test "viewing an item's status" do
+    item = create(:item, :active)
+    create(:overdue_loan, item:)
+
+    visit admin_item_url(item)
+
+    assert_text "Overdue"
+    assert_text "Active"
   end
 end


### PR DESCRIPTION
# What it does

Displays `item.status` on the admin item's index and show pages in addition to the `item_status_label` version.

# Why it is important

#1742 

# UI Change Screenshot

Admin items  index page:
![Screenshot 2024-12-17 at 4 33 21 PM](https://github.com/user-attachments/assets/9ee6750f-15e2-4927-bacc-31a46d572d22)

Admin item show page:
![Screenshot 2024-12-17 at 4 33 44 PM](https://github.com/user-attachments/assets/e3efb652-a48d-4067-823b-7068309e7a4c)

# Implementation notes

Just added the capitalized version of the status to both pages. Right now it's background is always gray, but we could add some colors to make it a little nicer if it's not too noisy.
