### PR TITLE
Added a column for renewals count to the activity report

### DIFF
--- a/app/controllers/admin/reports/monthly_activities_controller.rb
+++ b/app/controllers/admin/reports/monthly_activities_controller.rb
@@ -12,10 +12,12 @@ module Admin
         appointments = MonthlyAppointment.all
         loans = MonthlyLoan.all
         members = MonthlyMember.all
+        renewals = MonthlyRenewal.all
 
         assign_monthlies(appointments, %i[appointments_count completed_appointments_count])
         assign_monthlies(loans, %i[loans_count active_members_count])
         assign_monthlies(members, %i[new_members_count pending_members_count])
+        assign_monthlies(renewals, %i[renewals_count])
 
         @monthly_activities = @monthly_activities.sort.to_h
       end

--- a/app/controllers/admin/reports/monthly_activities_controller.rb
+++ b/app/controllers/admin/reports/monthly_activities_controller.rb
@@ -30,7 +30,7 @@ module Admin
         when MonthlyRenewal
           %i[renewals_count]
         else
-          raise "Unknow record type: #{record}"
+          raise "Unknown record type: #{record}"
         end
       end
 

--- a/app/controllers/admin/reports/monthly_activities_controller.rb
+++ b/app/controllers/admin/reports/monthly_activities_controller.rb
@@ -2,32 +2,43 @@ module Admin
   module Reports
     class MonthlyActivitiesController < BaseController
       def index
-        fetch_monthly_activities
+        @monthly_activities = fetch_activities
       end
 
-      def fetch_monthly_activities
-        @monthly_activities = {}
+      private
 
-        # TODO: load_async in Rails 7
-        appointments = MonthlyAppointment.all
-        loans = MonthlyLoan.all
-        members = MonthlyMember.all
-        renewals = MonthlyRenewal.all
+      def fetch_activities
+        records = [*MonthlyAppointment.all, *MonthlyLoan.all, *MonthlyMember.all, *MonthlyRenewal.all]
 
-        assign_monthlies(appointments, %i[appointments_count completed_appointments_count])
-        assign_monthlies(loans, %i[loans_count active_members_count])
-        assign_monthlies(members, %i[new_members_count pending_members_count])
-        assign_monthlies(renewals, %i[renewals_count])
+        records.group_by(&:year).each_with_object([]) do |(year, records_for_year), grouped_year|
+          monthly_values = records_for_year.group_by(&:month).each_with_object([]) do |(month, records_for_month), grouped_month|
+            grouped_month << [month, records_to_amount_hash(records_for_month)]
+          end
 
-        @monthly_activities = @monthly_activities.sort.to_h
+          grouped_year << [year, monthly_values.sort_by(&:first)]
+        end.sort_by(&:first)
       end
 
-      def assign_monthlies(records, columns)
-        records.each do |record|
-          key = "#{record.year}-#{record.month.to_s.rjust(2, "0")}"
-          monthly = @monthly_activities[key] ||= Hash.new(0)
+      def columns_for_record(record)
+        case record
+        when MonthlyAppointment
+          %i[appointments_count completed_appointments_count]
+        when MonthlyLoan
+          %i[loans_count active_members_count]
+        when MonthlyMember
+          %i[new_members_count pending_members_count]
+        when MonthlyRenewal
+          %i[renewals_count]
+        else
+          raise "Unknow record type: #{record}"
+        end
+      end
 
-          columns.each { |column| monthly[column] = record[column] }
+      def records_to_amount_hash(records)
+        records.each_with_object(Hash.new(0)) do |record, hash|
+          columns_for_record(record).each do |column|
+            hash[column] = record[column]
+          end
         end
       end
     end

--- a/app/models/monthly_appointment.rb
+++ b/app/models/monthly_appointment.rb
@@ -1,2 +1,3 @@
+# View from the Scenic gem
 class MonthlyAppointment < ApplicationRecord
 end

--- a/app/models/monthly_loan.rb
+++ b/app/models/monthly_loan.rb
@@ -1,2 +1,3 @@
+# View from the Scenic gem
 class MonthlyLoan < ApplicationRecord
 end

--- a/app/models/monthly_member.rb
+++ b/app/models/monthly_member.rb
@@ -1,2 +1,3 @@
+# View from the Scenic gem
 class MonthlyMember < ApplicationRecord
 end

--- a/app/models/monthly_renewal.rb
+++ b/app/models/monthly_renewal.rb
@@ -1,0 +1,3 @@
+# View from the Scenic gem
+class MonthlyRenewal < ApplicationRecord
+end

--- a/app/views/admin/reports/monthly_activities/index.html.erb
+++ b/app/views/admin/reports/monthly_activities/index.html.erb
@@ -2,49 +2,83 @@
   <%= index_header "Activity" %>
 <% end %>
 
-<table class="table monthly-adjustments">
-  <thead>
-    <tr>
-      <th></th>
-      <th class="left-lined" colspan="2">Activity</th>
-      <th class="left-lined" colspan="2">Members</th>
-      <th class="left-lined" colspan="2">Appointments</th>
-    </tr>
-    <tr>
-      <th>Month</th>
-      <th class="left-lined">Loans</th>
-      <th class="left-lined">Renewals</th>
-      <th>Members</th>
-      <th class="left-lined">New</th>
-      <th>Pending</th>
-      <th class="left-lined">Scheduled</th>
-      <th>Completed</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @monthly_activities.each do |date, activities| %>
-      <tr>
-        <% year, month = date.split("-") %>
-        <td><%= Date::MONTHNAMES[month.to_i] %> <%= year %></td>
-        <td class="left-lined"><%= activities[:loans_count] %></td>
-        <td class="left-lined"><%= activities[:renewals_count] %></td>
-        <td class="left-lined"><%= activities[:active_members_count] %></td>
-        <td class="left-lined"><%= activities[:new_members_count] %></td>
-        <td class="left-lined"><%= activities[:pending_members_count] %></td>
-        <td class="left-lined"><%= activities[:appointments_count] %></td>
-        <td class="left-lined"><%= activities[:completed_appointments_count] %></td>
-      </tr>
-    <% end %>
-  <tfoot>
-    <tr>
-      <td>Total</td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:loans_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:renewals_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:active_members_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:new_members_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:pending_members_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:appointments_count] } %></td>
-      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:completed_appointments_count] } %></td>
-    </tr>
-  </tfoot>
-</table>
+<% @monthly_activities.each do |(year, activities_by_month)| %>
+  <div id="year-<%= year %>">
+    <h2><%= year -%></h2>
+    <table class="table monthly-adjustments">
+      <thead>
+        <tr>
+          <th></th>
+          <th class="left-lined" colspan="2">Activity</th>
+          <th class="left-lined" colspan="2">Members</th>
+          <th class="left-lined" colspan="2">Appointments</th>
+        </tr>
+        <tr>
+          <th>Month</th>
+          <th class="left-lined">Loans</th>
+          <th class="left-lined">Renewals</th>
+          <th>Members</th>
+          <th class="left-lined">New</th>
+          <th>Pending</th>
+          <th class="left-lined">Scheduled</th>
+          <th>Completed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% activities_by_month.each do |month, activities| %>
+          <tr>
+            <td class="month"><%= Date::MONTHNAMES[month.to_i] %></td>
+            <td class="left-lined <%= "loans_count-#{year}-#{month}" %>">
+              <%= activities[:loans_count] %>
+            </td>
+            <td class="left-lined <%= "renewals_count-#{year}-#{month}" %>">
+              <%= activities[:renewals_count] %>
+            </td>
+            <td class="left-lined <%= "active_members_count-#{year}-#{month}" %>">
+              <%= activities[:active_members_count] %>
+            </td>
+            <td class="left-lined <%= "new_members_count-#{year}-#{month}" %>">
+              <%= activities[:new_members_count] %>
+            </td>
+            <td class="left-lined <%= "pending_members_count-#{year}-#{month}" %>">
+              <%= activities[:pending_members_count] %>
+            </td>
+            <td class="left-lined <%= "appointments_count-#{year}-#{month}" %>">
+              <%= activities[:appointments_count] %>
+            </td>
+            <td class="left-lined <%= "completed_appointments_count-#{year}-#{month}" %>">
+              <%= activities[:completed_appointments_count] %>
+            </td>
+          </tr>
+        <% end %>
+      <tfoot>
+        <tr>
+          <td class="total">Total</td>
+          <td class="left-lined <%= "loans_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:loans_count] } %>
+          </td>
+          <td class="left-lined <%= "renewals_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:renewals_count] } %>
+          </td>
+          <td class="left-lined <%= "active_members_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:active_members_count] } %>
+          </td>
+          <td class="left-lined <%= "new_members_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:new_members_count] } %>
+          </td>
+          <td class="left-lined <%= "pending_members_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:pending_members_count] } %>
+          </td>
+          <td class="left-lined <%= "appointments_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:appointments_count] } %>
+          </td>
+          <td class="left-lined <%= "completed_appointments_count-#{year}" %>">
+            <%= activities_by_month.map(&:second).sum { |a| a[:completed_appointments_count] } %>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+    <br>
+    <br>
+  </div>
+<% end %>

--- a/app/views/admin/reports/monthly_activities/index.html.erb
+++ b/app/views/admin/reports/monthly_activities/index.html.erb
@@ -13,6 +13,7 @@
     <tr>
       <th>Month</th>
       <th class="left-lined">Loans</th>
+      <th class="left-lined">Renewals</th>
       <th>Members</th>
       <th class="left-lined">New</th>
       <th>Pending</th>
@@ -26,6 +27,7 @@
         <% year, month = date.split("-") %>
         <td><%= Date::MONTHNAMES[month.to_i] %> <%= year %></td>
         <td class="left-lined"><%= activities[:loans_count] %></td>
+        <td class="left-lined"><%= activities[:renewals_count] %></td>
         <td class="left-lined"><%= activities[:active_members_count] %></td>
         <td class="left-lined"><%= activities[:new_members_count] %></td>
         <td class="left-lined"><%= activities[:pending_members_count] %></td>
@@ -37,6 +39,7 @@
     <tr>
       <td>Total</td>
       <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:loans_count] } %></td>
+      <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:renewals_count] } %></td>
       <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:active_members_count] } %></td>
       <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:new_members_count] } %></td>
       <td class="left-lined"><%= @monthly_activities.values.sum { |a| a[:pending_members_count] } %></td>

--- a/db/migrate/20250105181935_create_monthly_renewals.rb
+++ b/db/migrate/20250105181935_create_monthly_renewals.rb
@@ -1,0 +1,5 @@
+class CreateMonthlyRenewals < ActiveRecord::Migration[7.2]
+  def change
+    create_view :monthly_renewals
+  end
+end

--- a/db/migrate/20250122225005_update_monthly_loans_to_version_2.rb
+++ b/db/migrate/20250122225005_update_monthly_loans_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateMonthlyLoansToVersion2 < ActiveRecord::Migration[7.2]
+  def change
+    update_view :monthly_loans, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_05_181935) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1109,24 +1109,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_05_181935) do
     GROUP BY months.month
     ORDER BY months.month;
   SQL
-  create_view "monthly_loans", sql_definition: <<-SQL
-      WITH dates AS (
-           SELECT min(date_trunc('month'::text, loans.created_at)) AS startm,
-              max(date_trunc('month'::text, loans.created_at)) AS endm
-             FROM loans
-          ), months AS (
-           SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
-             FROM dates
-          )
-   SELECT (date_part('year'::text, months.month))::integer AS year,
-      (date_part('month'::text, months.month))::integer AS month,
-      count(DISTINCT l.id) AS loans_count,
-      count(DISTINCT l.member_id) AS active_members_count
-     FROM (months
-       LEFT JOIN loans l ON ((date_trunc('month'::text, l.created_at) = months.month)))
-    GROUP BY months.month
-    ORDER BY months.month;
-  SQL
   create_view "monthly_members", sql_definition: <<-SQL
       WITH dates AS (
            SELECT min(date_trunc('month'::text, members.created_at)) AS startm,
@@ -1160,6 +1142,25 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_05_181935) do
      FROM (months
        LEFT JOIN loans l ON ((date_trunc('month'::text, l.created_at) = months.month)))
     WHERE (l.initial_loan_id IS NOT NULL)
+    GROUP BY months.month
+    ORDER BY months.month;
+  SQL
+  create_view "monthly_loans", sql_definition: <<-SQL
+      WITH dates AS (
+           SELECT min(date_trunc('month'::text, loans.created_at)) AS startm,
+              max(date_trunc('month'::text, loans.created_at)) AS endm
+             FROM loans
+          ), months AS (
+           SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
+             FROM dates
+          )
+   SELECT (EXTRACT(year FROM months.month))::integer AS year,
+      (EXTRACT(month FROM months.month))::integer AS month,
+      count(DISTINCT l.id) AS loans_count,
+      count(DISTINCT l.member_id) AS active_members_count
+     FROM (months
+       LEFT JOIN loans l ON ((date_trunc('month'::text, l.created_at) = months.month)))
+    WHERE (l.initial_loan_id IS NULL)
     GROUP BY months.month
     ORDER BY months.month;
   SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_18_224853) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_05_181935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1142,6 +1142,24 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_18_224853) do
       count(DISTINCT m.id) FILTER (WHERE (m.status = 1)) AS new_members_count
      FROM (months
        LEFT JOIN members m ON ((date_trunc('month'::text, m.created_at) = months.month)))
+    GROUP BY months.month
+    ORDER BY months.month;
+  SQL
+  create_view "monthly_renewals", sql_definition: <<-SQL
+      WITH dates AS (
+           SELECT min(date_trunc('month'::text, loans.created_at)) AS startm,
+              max(date_trunc('month'::text, loans.created_at)) AS endm
+             FROM loans
+          ), months AS (
+           SELECT generate_series(dates.startm, dates.endm, 'P1M'::interval) AS month
+             FROM dates
+          )
+   SELECT (EXTRACT(year FROM months.month))::integer AS year,
+      (EXTRACT(month FROM months.month))::integer AS month,
+      count(DISTINCT l.id) AS renewals_count
+     FROM (months
+       LEFT JOIN loans l ON ((date_trunc('month'::text, l.created_at) = months.month)))
+    WHERE (l.initial_loan_id IS NOT NULL)
     GROUP BY months.month
     ORDER BY months.month;
   SQL

--- a/db/views/monthly_loans_v02.sql
+++ b/db/views/monthly_loans_v02.sql
@@ -1,0 +1,16 @@
+WITH dates AS
+         (SELECT min(date_trunc('month', created_at)) AS startm,
+                 max(date_trunc('month', created_at)) AS endm
+          FROM loans),
+     months AS
+         (SELECT generate_series(startm, endm, '1 month') AS month
+          FROM dates)
+SELECT extract(YEAR FROM months.month) ::integer AS year,
+       extract(MONTH FROM months.month)::integer AS month,
+       count(DISTINCT l.id)                      AS loans_count,
+       count(DISTINCT l.member_id)               AS active_members_count
+FROM months
+         LEFT  JOIN loans l ON date_trunc('month', l.created_at) = months.month
+WHERE l.initial_loan_id IS NULL
+GROUP BY months.month
+ORDER BY months.month;

--- a/db/views/monthly_renewals_v01.sql
+++ b/db/views/monthly_renewals_v01.sql
@@ -1,0 +1,15 @@
+WITH dates AS
+         (SELECT min(date_trunc('month', created_at)) AS startm,
+                 max(date_trunc('month', created_at)) AS endm
+          FROM loans),
+     months AS
+         (SELECT generate_series(startm, endm, '1 month') AS month
+          FROM dates)
+SELECT extract(YEAR FROM months.month) ::integer AS year,
+       extract(MONTH FROM months.month)::integer AS month,
+       count(DISTINCT l.id)                      AS renewals_count
+FROM months
+         LEFT  JOIN loans l ON date_trunc('month', l.created_at) = months.month
+WHERE l.initial_loan_id IS NOT NULL
+GROUP BY months.month
+ORDER BY months.month;

--- a/test/system/admin/reports/monthly_activities_test.rb
+++ b/test/system/admin/reports/monthly_activities_test.rb
@@ -38,100 +38,119 @@ module Admin
       sign_in_as_admin
     end
 
+    # Table for 2021
     # ╔═══════════════╦══════════════════════════════════╦═════════════════════╦════════════════════════════╗
     # ║               ║ Activity                         ║ Members             ║ Appointments               ║
     # ├───────────────┼──────────────────────────────────┼─────────────────────┼────────────────────────────┤
     # ║ Month         ║ Loans     ║ Renewals  ║ Members  ║ New      ║ Pending  ║ Scheduled     ║ Completed  ║
     # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
-    # ║ November 2021 ║ 0         ║ 0         ║ 0        ║ 1        ║ 0        ║ 0             ║ 0          ║
-    # ║ December 2021 ║ 1         ║ 0         ║ 1        ║ 0        ║ 0        ║ 1             ║ 1          ║
-    # ║ January 2022  ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
+    # ║ November      ║ 0         ║ 0         ║ 0        ║ 1        ║ 0        ║ 0             ║ 0          ║
+    # ║ December      ║ 1         ║ 0         ║ 1        ║ 0        ║ 0        ║ 1             ║ 1          ║
     # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
-    # ║ Total         ║ 4         ║ 1         ║ 2        ║ 3        ║ 1        ║ 3             ║ 2          ║
+    # ║ Total         ║ 1         ║ 0         ║ 1        ║ 1        ║ 0        ║ 1             ║ 1          ║
+    # ╚═══════════════╩═══════════╩═══════════╩══════════╩══════════╩══════════╩═══════════════╩════════════╝
+    # Table for 2022
+    # ╔═══════════════╦══════════════════════════════════╦═════════════════════╦════════════════════════════╗
+    # ║               ║ Activity                         ║ Members             ║ Appointments               ║
+    # ├───────────────┼──────────────────────────────────┼─────────────────────┼────────────────────────────┤
+    # ║ Month         ║ Loans     ║ Renewals  ║ Members  ║ New      ║ Pending  ║ Scheduled     ║ Completed  ║
+    # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
+    # ║ January       ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
+    # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
+    # ║ Total         ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
     # ╚═══════════════╩═══════════╩═══════════╩══════════╩══════════╩══════════╩═══════════════╩════════════╝
     test "table is populated accordingly" do
       visit admin_reports_monthly_activities_url
 
-      assert_selector ".monthly-adjustments"
-      within(".monthly-adjustments") do
-        # ║               ║ Activity             ║ Members             ║ Appointments               ║
-        within("thead > tr:nth-child(1)") do
-          within("th:nth-child(2)") { assert_text("Activity") }
-          within("th:nth-child(3)") { assert_text("Members") }
-          within("th:nth-child(4)") { assert_text("Appointments") }
+      assert_selector "#year-2021"
+      assert_selector "#year-2022"
+
+      # table headings
+      ["#year-2021", "#year-2022"].each do |selector|
+        within("#year-2021") do
+          within("thead > tr:nth-child(1)") do
+            within("th:nth-child(2)") { assert_text("Activity") }
+            within("th:nth-child(3)") { assert_text("Members") }
+            within("th:nth-child(4)") { assert_text("Appointments") }
+          end
+
+          within("thead > tr:nth-child(2)") do
+            within("th:nth-child(1)") { assert_text("Month") }
+
+            within("th:nth-child(2)") { assert_text("Loans") }
+            within("th:nth-child(3)") { assert_text("Renewals") }
+            within("th:nth-child(4)") { assert_text("Members") }
+
+            within("th:nth-child(5)") { assert_text("New") }
+            within("th:nth-child(6)") { assert_text("Pending") }
+
+            within("th:nth-child(7)") { assert_text("Scheduled") }
+            within("th:nth-child(8)") { assert_text("Completed") }
+          end
         end
+      end
 
-        # ║ Month         ║ Loans     ║ Renewals  ║ Members  ║ New      ║ Pending  ║ Scheduled     ║ Completed  ║
-        within("thead > tr:nth-child(2)") do
-          within("th:nth-child(1)") { assert_text("Month") }
-
-          within("th:nth-child(2)") { assert_text("Loans") }
-          within("th:nth-child(3)") { assert_text("Renewals") }
-          within("th:nth-child(4)") { assert_text("Members") }
-
-          within("th:nth-child(5)") { assert_text("New") }
-          within("th:nth-child(6)") { assert_text("Pending") }
-
-          within("th:nth-child(7)") { assert_text("Scheduled") }
-          within("th:nth-child(8)") { assert_text("Completed") }
-        end
-
-        # ║ November 2021 ║ 0         ║ 0         ║ 0        ║ 1        ║ 0        ║ 0             ║ 0          ║
+      within("#year-2021") do
         within("tbody > tr:nth-child(1)") do
-          within("td:nth-child(1)") { assert_text("November 2021") }
+          within("td.month") { assert_text("November") }
 
-          within("td:nth-child(2)") { assert_text("0") }
-          within("td:nth-child(3)") { assert_text("0") }
-          within("td:nth-child(4)") { assert_text("0") }
-
-          within("td:nth-child(5)") { assert_text("1") }
-          within("td:nth-child(6)") { assert_text("0") }
-
-          within("td:nth-child(7)") { assert_text("0") }
-          within("td:nth-child(8)") { assert_text("0") }
+          within("td.loans_count-2021-11") { assert_text("0") }
+          within("td.renewals_count-2021-11") { assert_text("0") }
+          within("td.active_members_count-2021-11") { assert_text("0") }
+          within("td.new_members_count-2021-11") { assert_text("1") }
+          within("td.pending_members_count-2021-11") { assert_text("0") }
+          within("td.appointments_count-2021-11") { assert_text("0") }
+          within("td.completed_appointments_count-2021-11") { assert_text("0") }
         end
 
-        # ║ December 2021 ║ 1         ║ 0         ║ 1        ║ 0        ║ 0        ║ 1             ║ 1          ║
         within("tbody > tr:nth-child(2)") do
-          within("td:nth-child(1)") { assert_text("December 2021") }
+          within("td.month") { assert_text("December") }
 
-          within("td:nth-child(2)") { assert_text("1") }
-          within("td:nth-child(3)") { assert_text("0") }
-          within("td:nth-child(4)") { assert_text("1") }
-
-          within("td:nth-child(5)") { assert_text("0") }
-          within("td:nth-child(6)") { assert_text("0") }
-
-          within("td:nth-child(7)") { assert_text("1") }
-          within("td:nth-child(8)") { assert_text("1") }
+          within("td.loans_count-2021-12") { assert_text("1") }
+          within("td.renewals_count-2021-12") { assert_text("0") }
+          within("td.active_members_count-2021-12") { assert_text("1") }
+          within("td.new_members_count-2021-12") { assert_text("0") }
+          within("td.pending_members_count-2021-12") { assert_text("0") }
+          within("td.appointments_count-2021-12") { assert_text("1") }
+          within("td.completed_appointments_count-2021-12") { assert_text("1") }
         end
 
-        # ║ January 2022  ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
-        within("tbody > tr:nth-child(3)") do
-          within("td:nth-child(1)") { assert_text("January 2022") }
-
-          within("td:nth-child(2)") { assert_text("3") }
-          within("td:nth-child(3)") { assert_text("1") }
-          within("td:nth-child(4)") { assert_text("1") }
-          within("td:nth-child(5)") { assert_text("2") }
-          within("td:nth-child(6)") { assert_text("1") }
-          within("td:nth-child(7)") { assert_text("2") }
-          within("td:nth-child(8)") { assert_text("1") }
-        end
-
-        # ║ Total         ║ 4         ║ 1         ║ 2        ║ 3        ║ 1        ║ 3             ║ 2          ║
         within("tfoot > tr") do
-          within("td:nth-child(1)") { assert_text("Total") }
+          within("td.total") { assert_text("Total") }
 
-          within("td:nth-child(2)") { assert_text("4") }
-          within("td:nth-child(3)") { assert_text("1") }
-          within("td:nth-child(4)") { assert_text("2") }
+          within("td.loans_count-2021") { assert_text("1") }
+          within("td.renewals_count-2021") { assert_text("0") }
+          within("td.active_members_count-2021") { assert_text("1") }
+          within("td.new_members_count-2021") { assert_text("1") }
+          within("td.pending_members_count-2021") { assert_text("0") }
+          within("td.appointments_count-2021") { assert_text("1") }
+          within("td.completed_appointments_count-2021") { assert_text("1") }
+        end
+      end
 
-          within("td:nth-child(5)") { assert_text("3") }
-          within("td:nth-child(6)") { assert_text("1") }
+      within("#year-2022") do
+        within("tbody > tr:nth-child(1)") do
+          within("td.month") { assert_text("January") }
 
-          within("td:nth-child(7)") { assert_text("3") }
-          within("td:nth-child(8)") { assert_text("2") }
+          within("td.loans_count-2022-1") { assert_text("3") }
+          within("td.renewals_count-2022-1") { assert_text("1") }
+          within("td.active_members_count-2022-1") { assert_text("1") }
+          within("td.new_members_count-2022-1") { assert_text("2") }
+          within("td.pending_members_count-2022-1") { assert_text("1") }
+          within("td.appointments_count-2022-1") { assert_text("2") }
+          within("td.completed_appointments_count-2022-1") { assert_text("1") }
+        end
+
+        within("tfoot > tr") do
+          within("td.total") { assert_text("Total") }
+
+          within("td.loans_count-2022") { assert_text("3") }
+          within("td.renewals_count-2022") { assert_text("1") }
+          within("td.active_members_count-2022") { assert_text("1") }
+          within("td.new_members_count-2022") { assert_text("2") }
+          within("td.pending_members_count-2022") { assert_text("1") }
+          within("td.appointments_count-2022") { assert_text("2") }
+          within("td.completed_appointments_count-2022") { assert_text("1") }
         end
       end
     end

--- a/test/system/admin/reports/monthly_activities_test.rb
+++ b/test/system/admin/reports/monthly_activities_test.rb
@@ -55,9 +55,9 @@ module Admin
     # ├───────────────┼──────────────────────────────────┼─────────────────────┼────────────────────────────┤
     # ║ Month         ║ Loans     ║ Renewals  ║ Members  ║ New      ║ Pending  ║ Scheduled     ║ Completed  ║
     # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
-    # ║ January       ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
+    # ║ January       ║ 2         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
     # ╠═══════════════╬═══════════╬═══════════╬══════════╬══════════╬══════════╬═══════════════╬════════════╣
-    # ║ Total         ║ 3         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
+    # ║ Total         ║ 2         ║ 1         ║ 1        ║ 2        ║ 1        ║ 2             ║ 1          ║
     # ╚═══════════════╩═══════════╩═══════════╩══════════╩══════════╩══════════╩═══════════════╩════════════╝
     test "table is populated accordingly" do
       visit admin_reports_monthly_activities_url
@@ -132,7 +132,7 @@ module Admin
         within("tbody > tr:nth-child(1)") do
           within("td.month") { assert_text("January") }
 
-          within("td.loans_count-2022-1") { assert_text("3") }
+          within("td.loans_count-2022-1") { assert_text("2") }
           within("td.renewals_count-2022-1") { assert_text("1") }
           within("td.active_members_count-2022-1") { assert_text("1") }
           within("td.new_members_count-2022-1") { assert_text("2") }
@@ -144,7 +144,7 @@ module Admin
         within("tfoot > tr") do
           within("td.total") { assert_text("Total") }
 
-          within("td.loans_count-2022") { assert_text("3") }
+          within("td.loans_count-2022") { assert_text("2") }
           within("td.renewals_count-2022") { assert_text("1") }
           within("td.active_members_count-2022") { assert_text("1") }
           within("td.new_members_count-2022") { assert_text("2") }


### PR DESCRIPTION
# What it does

This adds a renewals column to the activities report and breaks the report into different tables by year.

# Why it is important

#1653

# UI Change Screenshot
![failures_test_table_is_populated_accordingly](https://github.com/user-attachments/assets/f9308031-3097-4279-9703-4a3777f71a13)

# Implementation notes

The number of renewals for the month is the number of loans created with an `initial_loan_id` and I changed the `monthly_loans` view to only contain loans without an `initial_loan_id`.
