### PR TITLE
basic search enhancement: break ties with item status

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -96,8 +96,8 @@ class ItemsController < ApplicationController
             ended_at IS NULL
             AND (expires_at IS NULL OR expires_at > NOW())
           GROUP BY item_id
-         ) AS active_holds
-         ON active_holds.item_id = items.id"
+         ) AS active_hold_counts
+         ON active_hold_counts.item_id = items.id"
       )
       .joins(
         "LEFT JOIN loans AS active_loans
@@ -121,7 +121,7 @@ class ItemsController < ApplicationController
                     WHEN active_loans.due_at < NOW() THEN 4  -- overdue
                     ELSE 3  -- checked out
                   END
-                WHEN borrow_policies.uniquely_numbered AND active_holds.item_id IS NOT NULL THEN 2  -- on hold
+                WHEN borrow_policies.uniquely_numbered AND active_hold_counts.item_id IS NOT NULL THEN 2  -- on hold
                 ELSE 1  -- available
               END
             WHEN items.status = 'maintenance' THEN 5  -- in maintenance

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -85,8 +85,51 @@ class ItemsController < ApplicationController
       return item_scope
     end
 
-    scope = item_scope.search_by_anything(@query)
-    scope.select("#{scope.pg_search_rank_table_alias}.rank", "items.*")
+    scope = item_scope.search_by_anything(@query).with_pg_search_rank
+
+    scope
+      .joins(
+        "LEFT JOIN (
+          SELECT item_id, COUNT(*) as active_hold_count
+          FROM holds
+          WHERE
+            ended_at IS NULL
+            AND (expires_at IS NULL OR expires_at > NOW())
+          GROUP BY item_id
+         ) AS active_holds
+         ON active_holds.item_id = items.id"
+      )
+      .joins(
+        "LEFT JOIN loans AS active_loans
+         ON active_loans.item_id = items.id
+         AND active_loans.ended_at IS NULL
+         AND active_loans.uniquely_numbered"
+      )
+      .joins(
+        "LEFT JOIN borrow_policies
+         ON items.borrow_policy_id = borrow_policies.id"
+      )
+      .select(
+        "#{scope.pg_search_rank_table_alias}.rank",
+        "items.*",
+        "
+          CASE
+            WHEN items.status = 'active' THEN
+              CASE
+                WHEN active_loans.id IS NOT NULL THEN
+                  CASE
+                    WHEN active_loans.due_at < NOW() THEN 4  -- overdue
+                    ELSE 3  -- checked out
+                  END
+                WHEN borrow_policies.uniquely_numbered AND active_holds.item_id IS NOT NULL THEN 2  -- on hold
+                ELSE 1  -- available
+              END
+            WHEN items.status = 'maintenance' THEN 5  -- in maintenance
+            ELSE 6  -- unavailable
+          END AS search_priority
+        "
+      )
+      .reorder("#{scope.pg_search_rank_table_alias}.rank desc", "search_priority")
   end
 
   def filter_by_available(item_scope)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -64,8 +64,8 @@ class Item < ApplicationRecord
 
   scope :search_and_order_by_availability, ->(query) {
     item_scope = search_by_anything(query)
-    .with_pg_search_rank
-    .joins(
+      .with_pg_search_rank
+      .joins(
         "LEFT JOIN (
           SELECT item_id, COUNT(*) as active_hold_count
           FROM holds
@@ -84,10 +84,10 @@ class Item < ApplicationRecord
       )
       .left_joins(:borrow_policy)
 
-      item_scope.select(
-        "#{item_scope.pg_search_rank_table_alias}.rank",
-        "items.*",
-        "
+    item_scope.select(
+      "#{item_scope.pg_search_rank_table_alias}.rank",
+      "items.*",
+      "
           CASE
             WHEN items.status = 'active' THEN
               CASE
@@ -103,7 +103,7 @@ class Item < ApplicationRecord
             ELSE 6  -- unavailable
           END AS search_priority
         "
-      )
+    )
       .reorder("#{item_scope.pg_search_rank_table_alias}.rank desc", "search_priority")
   }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -62,6 +62,51 @@ class Item < ApplicationRecord
 
   scope :by_name, -> { order(name: :asc) }
 
+  scope :search_and_order_by_availability, ->(query) {
+    item_scope = search_by_anything(query)
+    .with_pg_search_rank
+    .joins(
+        "LEFT JOIN (
+          SELECT item_id, COUNT(*) as active_hold_count
+          FROM holds
+          WHERE
+            ended_at IS NULL
+            AND (expires_at IS NULL OR expires_at > NOW())
+          GROUP BY item_id
+         ) AS active_hold_counts
+         ON active_hold_counts.item_id = items.id"
+      )
+      .joins(
+        "LEFT JOIN loans AS active_loans
+         ON active_loans.item_id = items.id
+         AND active_loans.ended_at IS NULL
+         AND active_loans.uniquely_numbered"
+      )
+      .left_joins(:borrow_policy)
+
+      item_scope.select(
+        "#{item_scope.pg_search_rank_table_alias}.rank",
+        "items.*",
+        "
+          CASE
+            WHEN items.status = 'active' THEN
+              CASE
+                WHEN active_loans.id IS NOT NULL THEN
+                  CASE
+                    WHEN active_loans.due_at < NOW() THEN 4  -- overdue
+                    ELSE 3  -- checked out
+                  END
+                WHEN borrow_policies.uniquely_numbered AND active_hold_counts.item_id IS NOT NULL THEN 2  -- on hold
+                ELSE 1  -- available
+              END
+            WHEN items.status = 'maintenance' THEN 5  -- in maintenance
+            ELSE 6  -- unavailable
+          END AS search_priority
+        "
+      )
+      .reorder("#{item_scope.pg_search_rank_table_alias}.rank desc", "search_priority")
+  }
+
   validates :name, presence: true
   validates :borrow_policy_id, inclusion: {in: ->(item) { BorrowPolicy.pluck(:id) }}
   validates :url, format: {with: URI::DEFAULT_PARSER.make_regexp, message: "must be a valid URL", allow_blank: true}


### PR DESCRIPTION
# What it does

This PR makes a small change to search behavior. If two items have the same pg_search score, ties will now be broken by item status (currently, items with the same score are just sorted by item ID). Specifically, the sort order will be available > on hold > checked out > overdue > in maintenance.

# Why it is important

This seems like a common sense change. It has minimal impact since it's just breaking ties.

# UI Change Screenshot

Currently, it's common for overdue/checked out/etc. items to be ranked above available items in search results:

<img width="667" alt="Untitled" src="https://github.com/user-attachments/assets/3ed083df-a532-4f4a-b02e-61b088c86235" />

After the change, ties will be broken by item status so available items will be ranked first. (Note that the item status is only being used to break ties for now, so overdue items can still appear at the top of the results if they have a higher pg_search score.)

<img width="667" alt="Untitled 3" src="https://github.com/user-attachments/assets/4ea476b4-210a-463f-9baa-ba61b361a939" />


# Implementation notes

The logic I used to define the item status mirrors the logic defined in `css_class_and_status_label` in `app/helpers/items_helper.rb`. That appears to be the code used to generate the "Available", "Overdue", etc. labels next to the item names in the search results.

https://github.com/chicago-tool-library/circulate/blob/92f37e6792dc72c478320f7349b1d9f70eda9d7d/app/helpers/items_helper.rb#L162-L180

Some questions and discussion points before we merge this change:
* Is there a better way (performance, maintainability, etc.) of implementing the sorting logic? Any way to reuse existing logic? I had to use a lot of raw SQL, which probably isn't ideal.
  + also, check that my logic looks correct
* Do we want to make additional (larger) changes to the sorting logic? Something beyond breaking ties, like if an item is overdue multiply pg_search score by 0.9. I was thinking we'd merge this change first and then make any larger changes in a subsequent PR, but we could do it here too.
* Do we need to add/update any tests?