### PR TITLE
Capture misc metadata from imported items in a column

### DIFF
--- a/app/models/reservable_item.rb
+++ b/app/models/reservable_item.rb
@@ -8,6 +8,9 @@ class ReservableItem < ApplicationRecord
   has_many :reservation_loans
   has_one_attached :image
 
+  store_accessor :myturn_metadata,
+    :image_url, :dimensions, :weight, :item_type, :supplier
+
   enum :power_source, {
     solar: "solar",
     gas: "gas",
@@ -23,4 +26,13 @@ class ReservableItem < ApplicationRecord
   monetize :purchase_price_cents,
     allow_nil: true,
     disable_validation: true
+
+  def import_myturn_image
+    return if myturn_metadata["image_url"].blank?
+
+    url = URI.parse(myturn_metadata["image_url"])
+    filename = File.basename(url.path)
+    downloaded_image = url.open
+    image.attach(io: downloaded_image, filename:)
+  end
 end

--- a/db/migrate/20250202194446_add_myturn_meta_to_reservable_items.rb
+++ b/db/migrate/20250202194446_add_myturn_meta_to_reservable_items.rb
@@ -1,0 +1,5 @@
+class AddMyturnMetaToReservableItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :reservable_items, :myturn_metadata, :jsonb, default: "{}"
+  end
+end

--- a/db/migrate/20250202194446_add_myturn_meta_to_reservable_items.rb
+++ b/db/migrate/20250202194446_add_myturn_meta_to_reservable_items.rb
@@ -1,5 +1,5 @@
 class AddMyturnMetaToReservableItems < ActiveRecord::Migration[7.2]
   def change
-    add_column :reservable_items, :myturn_metadata, :jsonb, default: "{}"
+    add_column :reservable_items, :myturn_metadata, :jsonb, default: {}
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_02_194446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -769,6 +769,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
     t.string "location_shelf"
     t.string "purchase_link"
     t.string "url"
+    t.jsonb "myturn_metadata", default: "{}"
     t.index ["creator_id"], name: "index_reservable_items_on_creator_id"
     t.index ["item_pool_id"], name: "index_reservable_items_on_item_pool_id"
     t.index ["library_id"], name: "index_reservable_items_on_library_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -769,7 +769,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_02_194446) do
     t.string "location_shelf"
     t.string "purchase_link"
     t.string "url"
-    t.jsonb "myturn_metadata", default: "{}"
+    t.jsonb "myturn_metadata", default: {}
     t.index ["creator_id"], name: "index_reservable_items_on_creator_id"
     t.index ["item_pool_id"], name: "index_reservable_items_on_item_pool_id"
     t.index ["library_id"], name: "index_reservable_items_on_library_id"

--- a/lib/tasks/myturn_import.rake
+++ b/lib/tasks/myturn_import.rake
@@ -109,7 +109,14 @@ namespace :myturn do
               brand: row["Manufacturer"],
               model: row["Model"],
               serial: row["Serial Number"],
-              purchase_price: (Money.new(row["Replacement Cost"]) if row["Replacement Cost"])
+              purchase_price: (Money.new(row["Replacement Cost"]) if row["Replacement Cost"]),
+              myturn_metadata: {
+                image_url: row["Image"].presence.try(:chomp, "|"),
+                dimensions: row["Dimensions"].presence,
+                weight: row["Weight"].presence,
+                item_type: row["Item Type"].presence,
+                supplier: row["Source / Supplier"].presence
+              }.compact
             )
           rescue ActiveRecord::RecordInvalid => e
             puts e


### PR DESCRIPTION
# What it does

Adds a new `jsonb` column to `reservable_items` to store arbitrary key/value metadata from imported items. This gives us a way to persist some data that doesn't map cleanly into our schema for future use. One example is that this gives us a way to capture the image URL for each item that we can later fetch and store properly.