### PR TITLE
Validate that reservation changes will cover existing loans.

### DIFF
--- a/app/models/reservation_hold.rb
+++ b/app/models/reservation_hold.rb
@@ -21,11 +21,7 @@ class ReservationHold < ApplicationRecord
 
   # Total number of items that were reserved
   def loaned_quantity
-    if item_pool.uniquely_numbered?
-      reservation_loans.size
-    else
-      reservation_loans.pluck(:quantity).sum
-    end
+    reservation_loans.sum(:quantity)
   end
 
   # Do all held items have an associated loaned item?
@@ -36,6 +32,10 @@ class ReservationHold < ApplicationRecord
   # How many more items are needed to satisfy this hold?
   def remaining_quantity
     quantity - loaned_quantity
+  end
+
+  def uniquely_numbered?
+    item_pool.uniquely_numbered?
   end
 
   private
@@ -49,9 +49,9 @@ class ReservationHold < ApplicationRecord
   end
 
   def ensure_quantity_covers_existing_loans
-    number_required_by_loans = reservation_loans.sum(:quantity)
-    if quantity < number_required_by_loans
-      message = "#{number_required_by_loans} are required by existing loans"
+    required_by_loans = loaned_quantity
+    if quantity < required_by_loans
+      message = "#{required_by_loans} are required by existing loans"
       errors.add(:quantity, message)
     end
   end

--- a/app/models/reservation_loan.rb
+++ b/app/models/reservation_loan.rb
@@ -4,8 +4,9 @@ class ReservationLoan < ApplicationRecord
   belongs_to :reservation_hold
   belongs_to :reservation
 
-  validate :reservation_hold_quantity_not_exceeded
   validates :reservable_item_id, uniqueness: {scope: :reservation_hold_id, message: "has already been added"}
+  validates :quantity, numericality: {only_integer: true, greater_than: 0, allow_nil: true}
+  validate :reservation_hold_quantity_not_exceeded
   validate :item_is_available
 
   acts_as_tenant :library

--- a/app/models/reservation_loan.rb
+++ b/app/models/reservation_loan.rb
@@ -15,6 +15,10 @@ class ReservationLoan < ApplicationRecord
   scope :checked_out, -> { where.not(checked_out_at: nil).and(where(checked_in_at: nil)) }
   scope :pending_or_checked_out, -> { pending.or(checked_out) }
 
+  def uniquely_numbered?
+    reservable_item.present?
+  end
+
   private
 
   def reservation_hold_quantity_not_exceeded

--- a/app/views/admin/reservations/reservation_loans/_reservation_hold.html.erb
+++ b/app/views/admin/reservations/reservation_loans/_reservation_hold.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <% reservation_hold.reservation_loans.each do |reservation_loan| %>
     <tr id="<%= dom_id(reservation_loan) %>">
-      <% if reservation_loan.quantity %>
+      <% if reservation_loan.reservable_item.blank? %>
         <td>*</td>
       <% else %>
         <td><%= reservation_loan.reservable_item.number %></td>
@@ -38,7 +38,7 @@
     <tr class="text-italic">
       <td colspan="2">
         <%= pluralize reservation_hold.remaining_quantity, "more item" %> needed
-        <%= link_to "View available", admin_item_pool_path(reservation_hold.item_pool), target: "_blank" %>
+        <%= link_to "View available", admin_item_pool_reservable_items_path(reservation_hold.item_pool), target: "_blank" %>
       </td>
       <td>
         <% if !reservation_hold.item_pool.uniquely_numbered? %>

--- a/app/views/admin/reservations/reservation_loans/_reservation_hold.html.erb
+++ b/app/views/admin/reservations/reservation_loans/_reservation_hold.html.erb
@@ -9,10 +9,10 @@
   </tr>
   <% reservation_hold.reservation_loans.each do |reservation_loan| %>
     <tr id="<%= dom_id(reservation_loan) %>">
-      <% if reservation_loan.reservable_item.blank? %>
-        <td>*</td>
-      <% else %>
+      <% if reservation_loan.uniquely_numbered? %>
         <td><%= reservation_loan.reservable_item.number %></td>
+      <% else %>
+        <td>*</td>
       <% end %>
       <td>
         <% if reservation.manager.state == :building %>
@@ -41,7 +41,7 @@
         <%= link_to "View available", admin_item_pool_reservable_items_path(reservation_hold.item_pool), target: "_blank" %>
       </td>
       <td>
-        <% if !reservation_hold.item_pool.uniquely_numbered? %>
+        <% if !reservation_hold.uniquely_numbered? %>
           <%= button_to "Add all",
                 admin_reservation_loans_path(reservation),
                 method: :post,

--- a/db/migrate/20250205054754_modify_reservation_loans_quantity.rb
+++ b/db/migrate/20250205054754_modify_reservation_loans_quantity.rb
@@ -1,0 +1,7 @@
+class ModifyReservationLoansQuantity < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :reservation_loans, :quantity, false, 1
+    change_column_default :reservation_loans, :quantity, from: nil, to: 1
+    change_column_comment :reservation_loans, :quantity, from: "For item pools without uniquely numbered items", to: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_05_054754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -769,6 +769,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
     t.string "location_shelf"
     t.string "purchase_link"
     t.string "url"
+    t.jsonb "myturn_metadata", default: "{}"
     t.index ["creator_id"], name: "index_reservable_items_on_creator_id"
     t.index ["item_pool_id"], name: "index_reservable_items_on_item_pool_id"
     t.index ["library_id"], name: "index_reservable_items_on_library_id"
@@ -793,7 +794,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_225005) do
   create_table "reservation_loans", force: :cascade do |t|
     t.bigint "reservation_hold_id", null: false
     t.bigint "reservable_item_id"
-    t.integer "quantity", comment: "For item pools without uniquely numbered items"
+    t.integer "quantity", default: 1, null: false
     t.bigint "library_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -769,7 +769,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_05_054754) do
     t.string "location_shelf"
     t.string "purchase_link"
     t.string "url"
-    t.jsonb "myturn_metadata", default: "{}"
     t.index ["creator_id"], name: "index_reservable_items_on_creator_id"
     t.index ["item_pool_id"], name: "index_reservable_items_on_item_pool_id"
     t.index ["library_id"], name: "index_reservable_items_on_library_id"

--- a/test/factories/item_pools.rb
+++ b/test/factories/item_pools.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :item_pool do
     creator { association(:user) }
     sequence(:name) { |n| "Item Pool ##{n}" }
+    trait :unnumbered do
+      uniquely_numbered { false }
+      unnumbered_count { 1 }
+    end
   end
 end

--- a/test/factories/reservation_loans.rb
+++ b/test/factories/reservation_loans.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :reservation_loan do
+    quantity { 1 }
   end
 end

--- a/test/models/reservation_hold_test.rb
+++ b/test/models/reservation_hold_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ReservationHoldTest < ActiveSupport::TestCase
+  test "prevents deletion with a dependent reservation hold" do
+    reservable_item = create(:reservable_item)
+    reservation_hold = create(:reservation_hold, item_pool: reservable_item.item_pool)
+
+    assert_equal reservation_hold.quantity, 1
+
+    create(:reservation_loan, reservation: reservation_hold.reservation, reservation_hold:, reservable_item:)
+
+    assert_raises ActiveRecord::InvalidForeignKey do
+      reservation_hold.destroy
+    end
+  end
+
+  test "prevents reducing quantity beyond what is relied on by loans" do
+    reservable_items = [create(:reservable_item)]
+    reservable_items += 4.times.map do
+      create(:reservable_item, item_pool: reservable_items.first.item_pool)
+    end
+    reservation_hold = create(:reservation_hold, item_pool: reservable_items.first.item_pool, quantity: 4)
+
+    assert_equal reservation_hold.quantity, 4
+
+    3.times do |i|
+      create(:reservation_loan,
+        reservation: reservation_hold.reservation,
+        reservable_item: reservable_items[i],
+        reservation_hold:)
+    end
+
+    reservation_hold.quantity = 2
+    refute reservation_hold.valid?
+    assert_equal reservation_hold.errors[:quantity], ["3 are required by existing loans"]
+  end
+
+  test "prevents reducing quantity beyond what is relied on by loans on unnumbered items" do
+    item_pool = create(:item_pool, :unnumbered, unnumbered_count: 5)
+    reservation_hold = create(:reservation_hold, item_pool: item_pool, quantity: 4)
+
+    assert_equal reservation_hold.quantity, 4
+
+    create(:reservation_loan,
+      reservation: reservation_hold.reservation,
+      quantity: 3,
+      reservation_hold:)
+
+    reservation_hold.quantity = 2
+    refute reservation_hold.valid?
+    assert_equal reservation_hold.errors[:quantity], ["3 are required by existing loans"]
+  end
+end


### PR DESCRIPTION
# What it does

Adds a validation to close a gap in how we were validating `ReservationHolds`. Currently, it's possible to reduce the `quantity` of a `ReservationHold` beneath what's would be required by existing `ReservationLoan` objects. So you could have 4 items added to a reservation, but only 3 "reserved" via `ReservationHold` objects. This breaks the lending model's guarantees, which are based around the `ReservationHold` being the source of truth for item availability.

In the last meetup we had a good chat about other ways to handle this situation, which I think are worth exploring as we iterate on the UI. For now, though, I'd just like to maintain data integrity so we don't end up promising more items than we can actually lend out.

Previously, only some `ReservationLoan` objects had a value for `quantity` (those that were for items that aren't uniquely numbered). By always having a value for that field, though, we can simply some of the logic and  do things like `reservation_loans.sum(:quantity)` to count how many items are expected from the loans associated with a `ReservationHold`.