### PR TITLE
Show maintenance tags

### DIFF
--- a/app/controllers/admin/reports/items_in_maintenance_controller.rb
+++ b/app/controllers/admin/reports/items_in_maintenance_controller.rb
@@ -3,7 +3,7 @@ module Admin
     class ItemsInMaintenanceController < BaseController
       def index
         params[:q] ||= {"s" => "created_at desc"}
-        @q = Ticket.all.where.not(status: %w[resolved retired]).has_tags(params[:tags_name_in]).ransack(params[:q])
+        @q = Ticket.all.where.not(status: %w[resolved retired]).has_tags(params[:q][:tag_eq]).ransack(params[:q])
         @tickets = @q.result.includes(:item)
       end
     end

--- a/app/controllers/admin/reports/items_in_maintenance_controller.rb
+++ b/app/controllers/admin/reports/items_in_maintenance_controller.rb
@@ -6,7 +6,6 @@ module Admin
         @q = Ticket.all.where.not(status: %w[resolved retired]).has_tags(params[:tags_name_in]).ransack(params[:q])
         @tickets = @q.result.includes(:item)
       end
-
     end
   end
 end

--- a/app/controllers/admin/reports/items_in_maintenance_controller.rb
+++ b/app/controllers/admin/reports/items_in_maintenance_controller.rb
@@ -3,9 +3,10 @@ module Admin
     class ItemsInMaintenanceController < BaseController
       def index
         params[:q] ||= {"s" => "created_at desc"}
-        @q = Ticket.all.where.not(status: %w[resolved retired]).ransack(params[:q])
+        @q = Ticket.all.where.not(status: %w[resolved retired]).has_tags(params[:tags_name_in]).ransack(params[:q])
         @tickets = @q.result.includes(:item)
       end
+
     end
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -41,13 +41,13 @@ class Ticket < ApplicationRecord
   scope :active, -> { where(status: Ticket.statuses.values_at(:assess, :parts, :repairing)) }
   scope :newest_first, -> { order(created_at: :desc) }
   # used for filtering--if no tags are selected, don't filter by tags
-  scope :has_tags, ->(tags) do  
-    if tags.present? 
-      tagged_with(tags) 
+  scope :has_tags, ->(tags) do
+    if tags.present?
+      tagged_with(tags)
     else
       all
     end
-  end 
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     %w[created_at updated_at title status]

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -40,6 +40,14 @@ class Ticket < ApplicationRecord
 
   scope :active, -> { where(status: Ticket.statuses.values_at(:assess, :parts, :repairing)) }
   scope :newest_first, -> { order(created_at: :desc) }
+  # used for filtering--if no tags are selected, don't filter by tags
+  scope :has_tags, ->(tags) do  
+    if tags.present? 
+      tagged_with(tags) 
+    else
+      all
+    end
+  end 
 
   def self.ransackable_attributes(auth_object = nil)
     %w[created_at updated_at title status]

--- a/app/views/admin/reports/items_in_maintenance/index.html.erb
+++ b/app/views/admin/reports/items_in_maintenance/index.html.erb
@@ -4,35 +4,39 @@
 
 <section class="filters-container">
   <h2>Filters</h2>
-  <%= search_form_for(@q, url: admin_reports_items_in_maintenance_index_path, class: "filters-form") do |f| %>
+  <%= form_with(url: admin_reports_items_in_maintenance_index_path, class: "filters-form", method: :get) do |f| %>
     <div class="filters-form-fields">
       <div class="filter-column item-and-ticket-filters">
         <div class="filter-row item-filters">
           <div class="filter-field name">
-            <%= f.label :item_name_cont, "Item Name" %>
-            <%= f.search_field :item_name_cont %>
+            <%= f.label :"q[item_name_cont]", "Item Name" %>
+            <%= f.search_field :"q[item_name_cont]"  %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :item_status_eq, "Item Status" %>
-            <%= f.select :item_status_eq, Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true} %>
+            <%= f.label :"[q]item_status_eq", "Item Status" %>
+            <%= f.select :"[q]item_status_eq", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true} %>
           </div>
 
           <div class="filter-field number">
-            <%= f.label :item_number_cont, "Item Number" %>
-            <%= f.search_field :item_number_eq %>
+            <%= f.label :"[q]item_number_eq", "Item Number" %>
+            <%= f.search_field :"[q]item_number_eq" %>
           </div>
-        </div>
+
 
         <div class="filter-row ticket-filters">
           <div class="filter-field title">
-            <%= f.label :title_cont, "Ticket Title" %>
-            <%= f.search_field :title_cont %>
+            <%= f.label :"[q]title_cont", "Ticket Title" %>
+            <%= f.search_field :"[q]title_cont" %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :status_eq, "Ticket Status" %>
-            <%= f.select :status_eq, [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true} %>
+            <%= f.label :"[q]status_eq", "Ticket Status" %>
+            <%= f.select :"[q]status_eq", [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true} %>
+          </div>
+          <div class="filter-field tag">
+            <%= f.label :tags_name_in, "Tag" %>
+            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true} %>      
           </div>
         </div>
       </div>
@@ -40,25 +44,25 @@
       <div class="filter-column date-filters">
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :created_at_gteq, "Created After" %>
-            <%= f.date_field :created_at_gteq %>
+            <%= f.label :"[q]created_at_gteq", "Created After" %>
+            <%= f.date_field :"[q]created_at_gteq" %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :created_at_lteq, "Created Before" %>
-            <%= f.date_field :created_at_lteq %>
+            <%= f.label :"[q]created_at_lteq", "Created Before" %>
+            <%= f.date_field :"[q]created_at_lteq" %>
           </div>
         </div>
 
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :updated_at_gteq, "Updated After" %>
-            <%= f.date_field :updated_at_gteq %>
+            <%= f.label :"[q]updated_at_gteq", "Updated After" %>
+            <%= f.date_field :"[q]updated_at_gteq" %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :updated_at_lteq, "Updated Before" %>
-            <%= f.date_field :updated_at_lteq %>
+            <%= f.label :"[q]updated_at_lteq", "Updated Before" %>
+            <%= f.date_field :"[q]updated_at_lteq" %>
           </div>
         </div>
       </div>
@@ -80,6 +84,7 @@
         <th>Categories</th>
         <th><%= sort_link(@q, :title, "Title") %></th>
         <th><%= sort_link(@q, :status, "Status") %></th>
+        <th><%= sort_link(@q, :tag_list, "Tags") %></th>
         <th><%= sort_link(@q, :created_at, "Created") %></th>
         <th><%= sort_link(@q, :updated_at, "Updated") %></th>
       </tr>
@@ -102,6 +107,9 @@
           </td>
           <td>
             <%= ticket.status %>
+          </td>
+          <td>
+            <%= ticket.tag_list %>
           </td>
           <td>
             <%= ticket.created_at.to_formatted_s(:short_date) %>

--- a/app/views/admin/reports/items_in_maintenance/index.html.erb
+++ b/app/views/admin/reports/items_in_maintenance/index.html.erb
@@ -4,39 +4,39 @@
 
 <section class="filters-container">
   <h2>Filters</h2>
-  <%= form_with(url: admin_reports_items_in_maintenance_index_path, class: "filters-form", method: :get) do |f| %>
+  <%= search_form_for(@q, url: admin_reports_items_in_maintenance_index_path, class: "filters-form") do |f| %>
     <div class="filters-form-fields">
       <div class="filter-column item-and-ticket-filters">
         <div class="filter-row item-filters">
           <div class="filter-field name">
-            <%= f.label :"q[item_name_cont]", "Item Name" %>
-            <%= f.search_field :"q[item_name_cont]", value: params.dig(:q, :item_name_cont) %>
+            <%= f.label :item_name_cont, "Item Name" %>
+            <%= f.search_field :item_name_cont %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :"q[item_status_eq]", "Item Status" %>
-            <%= f.select :"q[item_status_eq]", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true, selected: params.dig(:q, :item_status_eq)} %>
+            <%= f.label :item_status_eq, "Item Status" %>
+            <%= f.select :item_status_eq, Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true} %>
           </div>
 
           <div class="filter-field number">
-            <%= f.label :"q[item_number_eq]", "Item Number" %>
-            <%= f.search_field :"q[item_number_eq]", value: params.dig(:q, :item_number_eq) %>
+            <%= f.label :item_number_cont, "Item Number" %>
+            <%= f.search_field :item_number_eq %>
           </div>
         </div>
+
         <div class="filter-row ticket-filters">
           <div class="filter-field title">
-            <%= f.label :"q[title_cont]", "Ticket Title" %>
-            <%= f.search_field :"q[title_cont]", value: params.dig(:q, :title_cont) %>
+            <%= f.label :title_cont, "Ticket Title" %>
+            <%= f.search_field :title_cont %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :"q[status_eq]", "Ticket Status" %>
-            <%= f.select :"q[status_eq]", [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true, selected: params.dig(:q, :status_eq)} %>
+            <%= f.label :status_eq, "Ticket Status" %>
+            <%= f.select :status_eq, [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true} %>
           </div>
-
           <div class="filter-field tag">
-            <%= f.label :tags_name_in, "Tag" %>
-            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true, selected: params[:tags_name_in]} %>
+            <%= f.label :tag_eq, "Tag" %>
+            <%= f.select :tag_eq, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true, selected: params[:q][:tag_eq]} %>
           </div>
         </div>
       </div>
@@ -44,25 +44,25 @@
       <div class="filter-column date-filters">
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :"q[created_at_gteq]", "Created After" %>
-            <%= f.date_field :"q[created_at_gteq]", value: params.dig(:q, :created_at_gteq) %>
+            <%= f.label :created_at_gteq, "Created After" %>
+            <%= f.date_field :created_at_gteq %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :"q[created_at_lteq]", "Created Before" %>
-            <%= f.date_field :"q[created_at_lteq]", value: params.dig(:q, :created_at_lteq) %>
+            <%= f.label :created_at_lteq, "Created Before" %>
+            <%= f.date_field :created_at_lteq %>
           </div>
         </div>
 
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :"q[updated_at_gteq]", "Updated After" %>
-            <%= f.date_field :"q[updated_at_gteq]", value: params.dig(:q, :updated_at_gteq) %>
+            <%= f.label :updated_at_gteq, "Updated After" %>
+            <%= f.date_field :updated_at_gteq %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :"q[updated_at_lteq]", "Updated Before" %>
-            <%= f.date_field :"q[updated_at_lteq]", value: params.dig(:q, :updated_at_lteq) %>
+            <%= f.label :updated_at_lteq, "Updated Before" %>
+            <%= f.date_field :updated_at_lteq %>
           </div>
         </div>
       </div>

--- a/app/views/admin/reports/items_in_maintenance/index.html.erb
+++ b/app/views/admin/reports/items_in_maintenance/index.html.erb
@@ -10,33 +10,33 @@
         <div class="filter-row item-filters">
           <div class="filter-field name">
             <%= f.label :"q[item_name_cont]", "Item Name" %>
-            <%= f.search_field :"q[item_name_cont]", value: params.dig(:q, :item_name_cont)  %>
+            <%= f.search_field :"q[item_name_cont]", value: params.dig(:q, :item_name_cont) %>
           </div>
 
           <div class="filter-field status">
             <%= f.label :"q[item_status_eq]", "Item Status" %>
-            <%= f.select :"q[item_status_eq]", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true, selected: params.dig(:q, :item_status_eq)}%>
+            <%= f.select :"q[item_status_eq]", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true, selected: params.dig(:q, :item_status_eq)} %>
           </div>
 
           <div class="filter-field number">
             <%= f.label :"q[item_number_eq]", "Item Number" %>
             <%= f.search_field :"q[item_number_eq]", value: params.dig(:q, :item_number_eq) %>
           </div>
-
-
+        </div>
         <div class="filter-row ticket-filters">
           <div class="filter-field title">
             <%= f.label :"q[title_cont]", "Ticket Title" %>
-            <%= f.search_field :"q[title_cont]",  value: params.dig(:q, :title_cont) %>
+            <%= f.search_field :"q[title_cont]", value: params.dig(:q, :title_cont) %>
           </div>
 
           <div class="filter-field status">
             <%= f.label :"q[status_eq]", "Ticket Status" %>
             <%= f.select :"q[status_eq]", [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true, selected: params.dig(:q, :status_eq)} %>
           </div>
+
           <div class="filter-field tag">
             <%= f.label :tags_name_in, "Tag" %>
-            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true, selected: params[:tags_name_in]} %>      
+            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true, selected: params[:tags_name_in]} %>
           </div>
         </div>
       </div>

--- a/app/views/admin/reports/items_in_maintenance/index.html.erb
+++ b/app/views/admin/reports/items_in_maintenance/index.html.erb
@@ -10,33 +10,33 @@
         <div class="filter-row item-filters">
           <div class="filter-field name">
             <%= f.label :"q[item_name_cont]", "Item Name" %>
-            <%= f.search_field :"q[item_name_cont]"  %>
+            <%= f.search_field :"q[item_name_cont]", value: params.dig(:q, :item_name_cont)  %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :"[q]item_status_eq", "Item Status" %>
-            <%= f.select :"[q]item_status_eq", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true} %>
+            <%= f.label :"q[item_status_eq]", "Item Status" %>
+            <%= f.select :"q[item_status_eq]", Item.statuses.values.sort.map { |value| [value.humanize, value] }, {include_blank: true, selected: params.dig(:q, :item_status_eq)}%>
           </div>
 
           <div class="filter-field number">
-            <%= f.label :"[q]item_number_eq", "Item Number" %>
-            <%= f.search_field :"[q]item_number_eq" %>
+            <%= f.label :"q[item_number_eq]", "Item Number" %>
+            <%= f.search_field :"q[item_number_eq]", value: params.dig(:q, :item_number_eq) %>
           </div>
 
 
         <div class="filter-row ticket-filters">
           <div class="filter-field title">
-            <%= f.label :"[q]title_cont", "Ticket Title" %>
-            <%= f.search_field :"[q]title_cont" %>
+            <%= f.label :"q[title_cont]", "Ticket Title" %>
+            <%= f.search_field :"q[title_cont]",  value: params.dig(:q, :title_cont) %>
           </div>
 
           <div class="filter-field status">
-            <%= f.label :"[q]status_eq", "Ticket Status" %>
-            <%= f.select :"[q]status_eq", [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true} %>
+            <%= f.label :"q[status_eq]", "Ticket Status" %>
+            <%= f.select :"q[status_eq]", [["Assess", "assess"], ["Parts", "parts"], ["Repairing", "repairing"]], {include_blank: true, selected: params.dig(:q, :status_eq)} %>
           </div>
           <div class="filter-field tag">
             <%= f.label :tags_name_in, "Tag" %>
-            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true} %>      
+            <%= f.select :tags_name_in, ActsAsTaggableOn::Tag.most_used.pluck(:name), {include_blank: true, selected: params[:tags_name_in]} %>      
           </div>
         </div>
       </div>
@@ -44,25 +44,25 @@
       <div class="filter-column date-filters">
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :"[q]created_at_gteq", "Created After" %>
-            <%= f.date_field :"[q]created_at_gteq" %>
+            <%= f.label :"q[created_at_gteq]", "Created After" %>
+            <%= f.date_field :"q[created_at_gteq]", value: params.dig(:q, :created_at_gteq) %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :"[q]created_at_lteq", "Created Before" %>
-            <%= f.date_field :"[q]created_at_lteq" %>
+            <%= f.label :"q[created_at_lteq]", "Created Before" %>
+            <%= f.date_field :"q[created_at_lteq]", value: params.dig(:q, :created_at_lteq) %>
           </div>
         </div>
 
         <div class="filter-row">
           <div class="filter-field">
-            <%= f.label :"[q]updated_at_gteq", "Updated After" %>
-            <%= f.date_field :"[q]updated_at_gteq" %>
+            <%= f.label :"q[updated_at_gteq]", "Updated After" %>
+            <%= f.date_field :"q[updated_at_gteq]", value: params.dig(:q, :updated_at_gteq) %>
           </div>
 
           <div class="filter-field">
-            <%= f.label :"[q]updated_at_lteq", "Updated Before" %>
-            <%= f.date_field :"[q]updated_at_lteq" %>
+            <%= f.label :"q[updated_at_lteq]", "Updated Before" %>
+            <%= f.date_field :"q[updated_at_lteq]", value: params.dig(:q, :updated_at_lteq) %>
           </div>
         </div>
       </div>
@@ -84,7 +84,7 @@
         <th>Categories</th>
         <th><%= sort_link(@q, :title, "Title") %></th>
         <th><%= sort_link(@q, :status, "Status") %></th>
-        <th><%= sort_link(@q, :tag_list, "Tags") %></th>
+        <th>Tags</th>
         <th><%= sort_link(@q, :created_at, "Created") %></th>
         <th><%= sort_link(@q, :updated_at, "Updated") %></th>
       </tr>


### PR DESCRIPTION
# What it does
- Addresses #1804: Adds the ticket tags to the "items in maintenance" report as well as a filter for the tags. This currently allows you to filter on one tag at a time--if we need to filter by multiple tags at once, we'll need to update this! 

# Why it is important

Makes tags more helpful!


# UI Change Screenshot

<img width="1428" alt="Screenshot 2025-02-20 at 12 27 31 PM" src="https://github.com/user-attachments/assets/93bff036-8388-429e-925e-9c17ef74e317" />


# Implementation notes

There is a strange bug where if you refresh the page occasionally, it'll prepopulate old params into the filter fields (it will not filter the results). This is annoying, but I thought it would not come up that often. I think it has to do with the fact that I had to switch to a non-ransack form helper because it was difficult to include the tags in the ransack search (it should be compatible, but it that part of Ransack seems stale--Ransack recently required that you have to allowlist everything you search by explicitly, which I could not do easily with tags). 

