### PR TITLE
Adjust fields in item and member exporters.

### DIFF
--- a/app/lib/item_exporter.rb
+++ b/app/lib/item_exporter.rb
@@ -6,18 +6,22 @@ class ItemExporter
   end
 
   def export(stream)
+    converter = HTMLToMarkdown.new
     columns = %w[
-      id name description size brand model serial strength power_source
+      size brand model serial strength power_source
       other_names quantity checkout_notice status
       location_area location_shelf
       purchase_link purchase_price myturn_item_type url
       created_at updated_at
     ]
     headers = [
+      "id",
       "complete_number",
       "code",
       "number",
+      "name",
       "categories",
+      "description",
       "item_url",
       *columns
     ]
@@ -25,10 +29,13 @@ class ItemExporter
     @items.includes(:borrow_policy, :category_nodes, :rich_text_description).in_batches(of: 100) do |items|
       items.each do |item|
         stream.write(CSV.generate_line([
+          item.id,
           item.complete_number,
           item.borrow_policy.code,
           item.number,
+          item.name,
           item.category_nodes.map { |cn| cn.path_names.join("//") }.sort.join("; "),
+          converter.convert(item.description),
           "https://app.chicagotoollibrary.org/admin/items/#{item.id}",
           *columns.map { |c| item.send(c) }
         ]))

--- a/app/lib/member_exporter.rb
+++ b/app/lib/member_exporter.rb
@@ -53,7 +53,7 @@ class MemberExporter
   private
 
   def year_headers
-    @year_range.flat_map { |year| ["#{year}_amount", "#{year}_started_at"] }
+    @year_range.flat_map { |year| ["#{year}_amount", "#{year}_started_on", "#{year}_ended_on"] }
   end
 
   def year_values(member)
@@ -61,11 +61,11 @@ class MemberExporter
       started_at = member["#{year}_started_at"]
       amount = member["#{year}_amount"].to_i
       if started_at
-        [amount / 100, started_at.to_fs(:short_date)]
+        [amount / 100, started_at.to_fs(:short_date), (started_at + 1.year).to_fs(:short_date)]
       elsif amount > 0
-        [amount / 100, nil]
+        [amount / 100, nil, nil]
       else
-        [nil, nil]
+        [nil, nil, nil]
       end
     }
   end


### PR DESCRIPTION
# What it does

Based on feedback from staff, adds the expiration date for memberships as well as converting an item's description to markdown for easier bulk editing. We'll have to convert it back upon import.