### PR TITLE
Added ability for admin users to reset members' passwords

### DIFF
--- a/app/controllers/admin/members/passwords_controller.rb
+++ b/app/controllers/admin/members/passwords_controller.rb
@@ -1,0 +1,27 @@
+module Admin
+  module Members
+    class PasswordsController < BaseController
+      def edit
+        @user = @member.user
+        @user.password = User.generate_temporary_password
+      end
+
+      def update
+        @user = @member.user
+
+        if @user.update(user_params)
+          MemberMailer.with(member: @member, new_password: @user.password).admin_reset_password.deliver_now
+          redirect_to admin_member_url(@member), success: "Successfully reset member's password"
+        else
+          render :edit, status: 422
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:password)
+      end
+    end
+  end
+end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -104,6 +104,14 @@ class MemberMailer < ApplicationMailer
     mail(to: @member.email, subject: @subject)
   end
 
+  def admin_reset_password
+    @member = params[:member]
+    @new_password = params[:new_password]
+    @library = @member.library
+    @subject = "Your password has been reset by a librarian"
+    mail(to: @member.email, subject: @subject)
+  end
+
   private
 
   def pluralize(count, word)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ApplicationRecord
     find_by(arel_table[:email].lower.eq(email.downcase))
   end
 
+  def self.generate_temporary_password
+    Devise.friendly_token.first(6)
+  end
+
   def roles
     case role
     when "member"

--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -48,10 +48,12 @@
         <div class="dropdown">
           <a href="#" class="dropdown-toggle" data-turbo="false" tabindex="0">
             <i class="icon icon-more-vert"></i>
+            <span class="visually-hidden">More tabs</span>
           </a>
           <ul class="menu text-left">
             <li class="menu-item"><%= link_to "Previous Holds", history_admin_member_holds_path(@member) %></li>
             <li class="menu-item"><%= link_to "Notifications", admin_member_notifications_path(@member) %></li>
+            <li class="menu-item"><%= link_to "Reset Password", edit_admin_member_passwords_path(@member) %></li>
           </ul>
         </div>
       </li>

--- a/app/views/admin/members/passwords/edit.html.erb
+++ b/app/views/admin/members/passwords/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render "admin/members/profile" do %>
+  <h2>Reset Password</h2>
+
+  <%= form_with(model: @member.user, url: admin_member_passwords_path(@member), builder: SpectreFormBuilder) do |form| %>
+    <%= form.errors %>
+
+    <%= form.text_field :password, label: "Temporary Password", type: "password" %>
+
+    <%= form.actions do %>
+      <%= form.submit "Reset Password", data: {turbo_confirm: "Are you sure you want to reset this member's password?"} %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/member_mailer/admin_reset_password.mjml
+++ b/app/views/member_mailer/admin_reset_password.mjml
@@ -1,0 +1,33 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @subject %></mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      Hi there!
+    </mj-text>
+
+    <mj-text>
+      We've assigned your account a temporary password of: <%= @new_password %>
+    </mj-text>
+
+    <mj-text>
+      You should be able to use your email and that password to <%= link_to "sign in here", new_user_session_url %>.
+    </mj-text>
+
+    <mj-text>
+      You can then reset your password to one only you know on <%= link_to "this page", edit_account_password_url %>.
+    </mj-text>
+
+    <mj-text>
+      (That page is also available by clicking "Membership" at the top and then the "Edit Password" button at the top right.)
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/member_mailer/admin_reset_password.text.erb
+++ b/app/views/member_mailer/admin_reset_password.text.erb
@@ -1,0 +1,9 @@
+Hi there!
+
+We've assigned your account a temporary password of: <%= @new_password %>
+
+You should be able to use your email and that password to sign in here: <%= new_user_session_url %>
+
+You can then reset your password to one only you know on this page: <%= edit_account_password_url %>
+
+(That page is also available by clicking "Membership" at the top and then the "Edit Password" button at the top right.)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
 
         resources :loan_summaries, only: :index
         resources :notes
+        resource :passwords, only: [:edit, :update]
       end
 
       member do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -61,6 +61,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   def assert_delivered_email(to:, second_to_last: false, &block)
     delivered_mail = second_to_last ? ActionMailer::Base.deliveries[-2] : ActionMailer::Base.deliveries.last
+    assert delivered_mail, "no email was delivered"
     assert_equal [to], delivered_mail.to
 
     assert delivered_mail.body.parts.size == 2, "non multipart email was sent!"

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -124,4 +124,20 @@ class MemberMailerTest < ApplicationSystemTestCase
       assert_includes text, item_name, "mail should include item name (#{item_name}) in text part"
     end
   end
+
+  test "can deliver an admin reset password email" do
+    new_password = User.generate_temporary_password
+    member = create(:member)
+
+    email = MemberMailer.with(member:, new_password:).admin_reset_password
+
+    assert_emails(1) { email.deliver_now }
+
+    assert_delivered_email(to: member.email) do |html, text, _, subject|
+      assert_equal "Your password has been reset by a librarian", subject
+
+      assert_includes text, new_password, "mail should include the new password in text part"
+      assert_includes html, new_password, "mail should include the new password in html part"
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -63,4 +63,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal original_user, User.find_by_case_insensitive_email(original_user.email.downcase)
     assert_nil User.find_by_case_insensitive_email("myMixedCaseEmail@example.co")
   end
+
+  test ".generate_temporary_password is a unique 6 character string" do
+    result = User.generate_temporary_password
+    assert_equal result.class, String
+    assert_equal result.size, 6
+    refute_equal result, User.generate_temporary_password
+  end
 end

--- a/test/system/admin/members/member_password_reset_test.rb
+++ b/test/system/admin/members/member_password_reset_test.rb
@@ -1,0 +1,90 @@
+require "application_system_test_case"
+
+class Admin::MemberPasswordResetTest < ApplicationSystemTestCase
+  def member
+    @member ||= create(:verified_member, :with_user)
+  end
+
+  setup do
+    @generated_password = User.generate_temporary_password
+
+    sign_in_as_admin
+    visit admin_member_url(member)
+  end
+
+  test "an admin can reset a member's password a specific value" do
+    within(".tab-action") do
+      click_on "More tabs"
+      click_on "Reset Password"
+    end
+
+    assert_current_path edit_admin_member_passwords_path(member)
+
+    new_password = "new-password"
+
+    fill_in "user_password", with: new_password
+
+    accept_confirm { click_on "Reset Password" }
+
+    assert_text "Successfully reset member's password"
+
+    assert member.user.reload.valid_password?(new_password), "Failed to update password"
+  end
+
+  test "an admin can reset a member's password to a generated value" do
+    User.stub(:generate_temporary_password, @generated_password) do
+      within(".tab-action") do
+        click_on "More tabs"
+        click_on "Reset Password"
+      end
+
+      assert_current_path edit_admin_member_passwords_path(member)
+
+      assert_selector "input[value='#{@generated_password}']"
+    end
+
+    accept_confirm { click_on "Reset Password" }
+
+    assert_text "Successfully reset member's password"
+
+    assert member.user.reload.valid_password?(@generated_password), "Failed to update password"
+  end
+
+  test "an admin sees errors when trying to set a user's password to something invalid" do
+    within(".tab-action") do
+      click_on "More tabs"
+      click_on "Reset Password"
+    end
+
+    fill_in "user_password", with: ""
+
+    accept_confirm { click_on "Reset Password" }
+
+    assert_text "Please correct the errors below!"
+    assert_text "can't be blank"
+  end
+
+  test "resetting a member's password sends them an email" do
+    User.stub(:generate_temporary_password, @generated_password) do
+      within(".tab-action") do
+        click_on "More tabs"
+        click_on "Reset Password"
+      end
+
+      assert_current_path edit_admin_member_passwords_path(member)
+
+      assert_selector "input[value='#{@generated_password}']"
+    end
+
+    accept_confirm { click_on "Reset Password" }
+
+    assert_text "Successfully reset member's password"
+
+    assert_delivered_email(to: member.email) do |html, text, _attachments, subject|
+      assert_equal subject, "Your password has been reset by a librarian"
+
+      assert_includes html, @generated_password
+      assert_includes text, @generated_password
+    end
+  end
+end


### PR DESCRIPTION
# What it does

This allows admins to reset members' passwords to a random or custom value

# Why it is important

#1621 

# UI Change Screenshot

How to navigate to the reset password link:
![Screenshot 2025-02-22 at 3 49 07 PM](https://github.com/user-attachments/assets/3b2b9a66-1f2e-4311-9e13-e7e6941c33e1)

The reset password form:
![Screenshot 2025-02-22 at 3 49 16 PM](https://github.com/user-attachments/assets/ba92be52-6381-4b13-ac58-e447340e827e)

The reset password form with errors:
![Screenshot 2025-02-22 at 3 49 36 PM](https://github.com/user-attachments/assets/0e38f7ab-df9b-4958-8e48-fe70b1397c1f)

The success message after resetting a member's password
![Screenshot 2025-02-22 at 3 49 55 PM](https://github.com/user-attachments/assets/100f6648-8237-42f8-b371-dd8eac3b26dc)

The email member's receive when their password has been reset:
![Screenshot 2025-02-22 at 3 50 15 PM](https://github.com/user-attachments/assets/4102d869-ae24-4148-83d1-ac151aa29648)

# Implementation notes

I took @phinze's copy from [this gist](https://gist.github.com/phinze/c299a08afa3563408e399ccfa5b4591d) for the email. 
