### PR TITLE
Admins can mark appointments as pulled in addition to pending and complete

### DIFF
--- a/app/controllers/admin/appointment_detail_completions_controller.rb
+++ b/app/controllers/admin/appointment_detail_completions_controller.rb
@@ -8,7 +8,7 @@ module Admin
       @appointment = Appointment.find(params[:appointment_id])
       @appointment.update!(completed_at: Time.current, staff_updating: true)
 
-      redirect_to admin_appointments_path, flash: {success: "Appointment completed."}, status: :see_other
+      render_appointment_to_turbo_stream
     end
 
     def destroy

--- a/app/controllers/admin/appointment_detail_pulls_controller.rb
+++ b/app/controllers/admin/appointment_detail_pulls_controller.rb
@@ -8,7 +8,7 @@ module Admin
       @appointment = Appointment.find(params[:appointment_id])
       @appointment.update!(pulled_at: Time.current, staff_updating: true)
 
-      redirect_to admin_appointments_path, flash: {success: "Appointment items pulled."}, status: :see_other
+      render_appointment_to_turbo_stream
     end
 
     def destroy

--- a/app/controllers/admin/appointment_detail_pulls_controller.rb
+++ b/app/controllers/admin/appointment_detail_pulls_controller.rb
@@ -1,0 +1,35 @@
+module Admin
+  class AppointmentDetailPullsController < BaseController
+    include ActionView::RecordIdentifier
+
+    before_action :are_appointments_enabled?
+
+    def create
+      @appointment = Appointment.find(params[:appointment_id])
+      @appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+      redirect_to admin_appointments_path, flash: {success: "Appointment items pulled."}, status: :see_other
+    end
+
+    def destroy
+      @appointment = Appointment.find(params[:appointment_id])
+      @appointment.update!(pulled_at: nil, staff_updating: true)
+
+      render_appointment_to_turbo_stream
+    end
+
+    private
+
+    def render_appointment_to_turbo_stream
+      respond_to do |format|
+        format.turbo_stream {
+          render turbo_stream:
+            turbo_stream.replace(
+              "#{dom_id(@appointment)}-complete",
+              render_to_string(partial: "admin/appointments/complete", locals: {appointment: @appointment})
+            )
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/admin/appointment_pulls_controller.rb
+++ b/app/controllers/admin/appointment_pulls_controller.rb
@@ -1,0 +1,55 @@
+module Admin
+  class AppointmentPullsController < BaseController
+    include ActionView::RecordIdentifier
+
+    before_action :are_appointments_enabled?
+
+    def create
+      @appointment = Appointment.find(params[:appointment_id])
+      @appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+      render_appointment_to_turbo_stream
+    end
+
+    def destroy
+      @appointment = Appointment.find(params[:appointment_id])
+      @appointment.update!(pulled_at: nil, staff_updating: true)
+
+      render_appointment_to_turbo_stream
+    end
+
+    private
+
+    def render_appointment_to_turbo_stream
+      if FeatureFlags.new_appointments_page_enabled?(params[:new])
+        respond_to do |format|
+          format.turbo_stream {
+            render turbo_stream: [
+              turbo_stream.replace(
+                "#{dom_id(@appointment)}-mobile",
+                render_to_string(partial: "admin/appointments/appointment_mobile", locals: {appointment: @appointment})
+              ),
+              turbo_stream.replace(
+                "#{dom_id(@appointment)}-desktop",
+                render_to_string(partial: "admin/appointments/appointment", locals: {appointment: @appointment})
+              ),
+              turbo_stream.action("arrangeAppointment", "#{dom_id(@appointment)}-desktop")
+            ]
+          }
+        end
+      else
+        respond_to do |format|
+          format.turbo_stream {
+            render turbo_stream: [
+              turbo_stream.replace(
+                dom_id(@appointment),
+                render_to_string(partial: "admin/appointments/appointment_orig", locals: {appointment: @appointment})
+              ),
+              turbo_stream.action("arrangeAppointment", dom_id(@appointment))
+            ]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -11,11 +11,14 @@ module Admin
         .includes(:member, loans: {item: :borrow_policy}, holds: {item: :borrow_policy})
 
       @pending_appointments = []
+      @pulled_appointments = []
       @completed_appointments = []
 
       @appointments.sort_by { |a| helpers.appointment_sort_key(a) }.each do |appointment|
         if appointment.completed?
           @completed_appointments << appointment
+        elsif appointment.pulled_at?
+          @pulled_appointments << appointment
         else
           @pending_appointments << appointment
         end

--- a/app/javascript/lib/appointments.js
+++ b/app/javascript/lib/appointments.js
@@ -3,9 +3,17 @@
 export function arrangeAppointment(id) {
   const element = document.getElementById(id)
   const isCompleted = element.classList.contains('completed')
-  const newParentSelector = isCompleted
-    ? '.completed-appointments'
-    : '.pending-appointments'
+  const isPulled = element.classList.contains('pulled')
+  let newParentSelector
+
+  if (isCompleted) {
+    newParentSelector = '.completed-appointments'
+  } else if (isPulled) {
+    newParentSelector = '.pulled-appointments'
+  } else {
+    newParentSelector = '.pending-appointments'
+  }
+
   const newParent = document.querySelector(newParentSelector)
 
   // Insert before an element with a higher sort key

--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -1,6 +1,6 @@
 <%= tag.tr(
       id: "#{dom_id(appointment)}-desktop",
-      class: "appointment #{appointment.completed? ? "completed" : "pending"}",
+      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?}",
       data: {sort_key: appointment_sort_key(appointment), appointment_id: appointment.id}
     ) do %>
   <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
@@ -26,8 +26,13 @@
     <% if appointment.completed? %>
       <%= button_to "restore", admin_appointment_completion_path(appointment, params: {new: true}),
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
-    <% else %>
+    <% elsif appointment.pulled_at? %>
+      <%= button_to "mark as not pulled", admin_appointment_pull_path(appointment, params: {new: true}),
+            method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "complete", admin_appointment_completion_path(appointment, params: {new: true}),
+            method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+    <% else %>
+      <%= button_to "pull items", admin_appointment_pull_path(appointment, params: {new: true}),
             method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
     <% end %>
   </td>

--- a/app/views/admin/appointments/_appointment_mobile.html.erb
+++ b/app/views/admin/appointments/_appointment_mobile.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id(appointment) %>-mobile" class="card <%= "completed" if appointment.completed? %>">
+<div id="<%= dom_id(appointment) %>-mobile" class="card <%= "completed" if appointment.completed? %> <%= "pulled" if appointment.pulled_at? && !appointment.completed? %>">
   <div class="card-header">
     <div class="card-title h5">
       <%= link_to preferred_or_default_name(appointment.member), admin_member_path(appointment.member) %>
@@ -58,8 +58,13 @@
     <% if appointment.completed? %>
       <%= button_to "Restore", admin_appointment_completion_path(appointment, new: true),
             method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
-    <% else %>
+    <% elsif appointment.pulled_at? %>
+      <%= button_to "Mark As Not Pulled", admin_appointment_pull_path(appointment, params: {new: true}),
+            method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "Complete", admin_appointment_completion_path(appointment, new: true),
+            method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
+    <% else %>
+      <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: true}),
             method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
     <% end %>
   </div>

--- a/app/views/admin/appointments/_appointment_orig.html.erb
+++ b/app/views/admin/appointments/_appointment_orig.html.erb
@@ -1,6 +1,6 @@
 <%= tag.tr(
       id: dom_id(appointment),
-      class: "appointment #{appointment.completed? ? "completed" : "pending"}",
+      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?}",
       data: {sort_key: appointment_sort_key(appointment), appointment_id: appointment.id}
     ) do %>
   <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
@@ -33,8 +33,13 @@
     <% if appointment.completed? %>
       <%= button_to "Restore", admin_appointment_completion_path(appointment), params: {new: false},
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
-    <% else %>
+    <% elsif appointment.pulled_at? %>
+      <%= button_to "Mark As Not Pulled", admin_appointment_pull_path(appointment, params: {new: false}),
+            method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "Complete", admin_appointment_completion_path(appointment), params: {new: false},
+            method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+    <% else %>
+      <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: false}),
             method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
     <% end %>
   </td>

--- a/app/views/admin/appointments/_complete.html.erb
+++ b/app/views/admin/appointments/_complete.html.erb
@@ -8,7 +8,7 @@
     <%= button_to "Mark As Not Pulled", admin_appointment_detail_pull_path(appointment),
           method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
   <% else %>
-    <%= button_to "Pulled Items", admin_appointment_detail_pull_path(appointment),
+    <%= button_to "Pull Items", admin_appointment_detail_pull_path(appointment),
           method: :post, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
   <% end %>
 

--- a/app/views/admin/appointments/_complete.html.erb
+++ b/app/views/admin/appointments/_complete.html.erb
@@ -2,8 +2,13 @@
   <% if appointment.completed? %>
     <%= button_to "Restore", admin_appointment_detail_completion_path(appointment),
           method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
-  <% else %>
+  <% elsif appointment.pulled_at? %>
     <%= button_to "Complete", admin_appointment_detail_completion_path(appointment),
+          method: :post, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
+    <%= button_to "Mark As Not Pulled", admin_appointment_detail_pull_path(appointment),
+          method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
+  <% else %>
+    <%= button_to "Pulled Items", admin_appointment_detail_pull_path(appointment),
           method: :post, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
   <% end %>
 

--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -44,6 +44,33 @@
           </tbody>
         </table>
 
+        <br>
+        <br>
+
+        <h2>Pulled Appointments</h2>
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="time">Time</th>
+              <th class="member">Member</th>
+              <th class="items">Pickup Items</th>
+              <th class="items">Dropoff Items</th>
+              <th class="notes">Notes</th>
+              <th></th>
+            </tr>
+          </thead>
+
+          <tbody class="pulled-appointments">
+            <% @pulled_appointments.each do |appointment, index| %>
+              <%= render partial: "appointment", locals: {appointment: appointment} %>
+            <% end %>
+          </tbody>
+        </table>
+
+        <br>
+        <br>
+
         <h2>Completed Appointments</h2>
 
         <table class="table">
@@ -67,6 +94,11 @@
       </div>
       <div class="show-xs">
         <% @pending_appointments.each do |appointment, index| %>
+          <div class="mt-2">
+            <%= render partial: "appointment_mobile", locals: {appointment: appointment} %>
+          </div>
+        <% end %>
+        <% @pulled_appointments.each do |appointment, index| %>
           <div class="mt-2">
             <%= render partial: "appointment_mobile", locals: {appointment: appointment} %>
           </div>

--- a/app/views/admin/appointments/index_orig.html.erb
+++ b/app/views/admin/appointments/index_orig.html.erb
@@ -43,6 +43,32 @@
         </tbody>
       </table>
 
+      <br>
+      <br>
+
+      <h2>Pulled Appointments</h2>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="time">Time</th>
+            <th class="member">Member</th>
+            <th class="items">Items</th>
+            <th class="notes">Notes</th>
+            <th></th>
+          </tr>
+        </thead>
+
+        <tbody class="pulled-appointments">
+          <% @pulled_appointments.each do |appointment| %>
+            <%= render partial: "appointment_orig", locals: {appointment: appointment} %>
+          <% end %>
+        <tbody>
+      </table>
+
+      <br>
+      <br>
+
       <h2>Completed Appointments</h2>
 
       <table class="table">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
       resource :completion, only: [:create, :destroy], controller: :appointment_completions
       resource :pull, only: [:create, :destroy], controller: :appointment_pulls
       resource :detail_completion, only: [:create, :destroy], controller: :appointment_detail_completions
+      resource :detail_pull, only: [:create, :destroy], controller: :appointment_detail_pulls
     end
     resources :manage_features, only: [:index, :update]
     resources :items do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
       resources :checkouts, only: [:create], controller: :appointment_checkouts
       resources :checkins, only: [:create], controller: :appointment_checkins
       resource :completion, only: [:create, :destroy], controller: :appointment_completions
+      resource :pull, only: [:create, :destroy], controller: :appointment_pulls
       resource :detail_completion, only: [:create, :destroy], controller: :appointment_detail_completions
     end
     resources :manage_features, only: [:index, :update]

--- a/db/migrate/20250223214915_add_pulled_at_to_appointments.rb
+++ b/db/migrate/20250223214915_add_pulled_at_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddPulledAtToAppointments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :appointments, :pulled_at, :datetime, precision: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_05_054754) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_23_214915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -239,6 +239,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_05_054754) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "completed_at", precision: nil
+    t.datetime "pulled_at", precision: nil
     t.index ["member_id"], name: "index_appointments_on_member_id"
   end
 

--- a/test/controllers/admin/appointment_detail_completions_controller_test.rb
+++ b/test/controllers/admin/appointment_detail_completions_controller_test.rb
@@ -18,7 +18,7 @@ module Admin
     test "completes an appointment" do
       post admin_appointment_detail_completion_path(@appointment), as: :turbo_stream
 
-      assert_redirected_to admin_appointments_path
+      assert_response :success
       assert @appointment.reload.completed_at
     end
 

--- a/test/system/admin/appointments/details_test.rb
+++ b/test/system/admin/appointments/details_test.rb
@@ -15,7 +15,7 @@ module Admin
     test "an admin can mark a pending appointment as pulled" do
       visit admin_appointment_path(@appointment)
 
-      click_on "Pulled Items"
+      click_on "Pull Items"
 
       assert_text "Complete"
       assert_text "Mark As Not Pulled"
@@ -33,7 +33,7 @@ module Admin
 
       click_on "Mark As Not Pulled"
 
-      assert_text "Pulled Items"
+      assert_text "Pull Items"
 
       @appointment.reload
 

--- a/test/system/admin/appointments/details_test.rb
+++ b/test/system/admin/appointments/details_test.rb
@@ -1,0 +1,75 @@
+require "application_system_test_case"
+
+module Admin
+  class AppointmentDetailsTest < ApplicationSystemTestCase
+    setup do
+      starts_at = Time.current.beginning_of_day + 8.hours
+
+      @member = create(:member)
+      @hold = create(:hold, member: @member)
+      @appointment = create(:appointment, member: @member, holds: [@hold], starts_at: starts_at + 2.hours, ends_at: starts_at + 4.hours)
+
+      sign_in_as_admin
+    end
+
+    test "an admin can mark a pending appointment as pulled" do
+      visit admin_appointment_path(@appointment)
+
+      click_on "Pulled Items"
+
+      assert_text "Complete"
+      assert_text "Mark As Not Pulled"
+
+      @appointment.reload
+
+      assert @appointment.pulled_at?
+      refute @appointment.completed_at?
+    end
+
+    test "an admin can mark a pulled appointment as pending" do
+      @appointment.update!(pulled_at: Time.current)
+
+      visit admin_appointment_path(@appointment)
+
+      click_on "Mark As Not Pulled"
+
+      assert_text "Pulled Items"
+
+      @appointment.reload
+
+      refute @appointment.pulled_at?
+      refute @appointment.completed_at?
+    end
+
+    test "an admin can mark a pulled appointment as complete" do
+      @appointment.update!(pulled_at: Time.current)
+
+      visit admin_appointment_path(@appointment)
+
+      click_on "Complete"
+
+      assert_text "Restore"
+
+      @appointment.reload
+
+      assert @appointment.pulled_at?
+      assert @appointment.completed_at?
+    end
+
+    test "an admin can mark a complete appointment as pulled" do
+      @appointment.update!(pulled_at: Time.current, completed_at: Time.current)
+
+      visit admin_appointment_path(@appointment)
+
+      click_on "Restore"
+
+      assert_text "Mark As Not Pulled"
+      assert_text "Complete"
+
+      @appointment.reload
+
+      assert @appointment.pulled_at?
+      refute @appointment.completed_at?
+    end
+  end
+end

--- a/test/system/admin/appointments_test.rb
+++ b/test/system/admin/appointments_test.rb
@@ -26,38 +26,58 @@ module Admin
       sign_in_as_admin
     end
 
-    def assert_appointments_in_page(pending: [], completed: [])
+    def assert_appointments_in_page(pending: [], pulled: [], completed: [])
       pending_appointment_ids = all(".pending-appointments .appointment").map { |row| row["data-appointment-id"].to_i }
       assert_equal pending.map(&:id), pending_appointment_ids
+
+      pulled_appointment_ids = all(".pulled-appointments .appointment").map { |row| row["data-appointment-id"].to_i }
+      assert_equal pulled.map(&:id), pulled_appointment_ids
 
       completed_appointment_ids = all(".completed-appointments .appointment").map { |row| row["data-appointment-id"].to_i }
       assert_equal completed.map(&:id), completed_appointment_ids
     end
 
+    def id_selector(appointment)
+      "##{dom_id(appointment)}"
+    end
+
+    def pull_items_for_appointment(appointment)
+      within id_selector(appointment) do
+        click_on "Pull Items"
+      end
+    end
+
     def complete_appointment(appointment)
-      id = "#" + dom_id(appointment)
-      within id do
+      within id_selector(appointment) do
         click_on "Complete"
       end
     end
 
     def restore_appointment(appointment)
-      id = "#" + dom_id(appointment)
-      within id do
+      within id_selector(appointment) do
         click_on "Restore"
       end
     end
 
+    def mark_appointment_as_not_pulled(appointment)
+      within id_selector(appointment) do
+        click_on "Mark As Not Pulled"
+      end
+    end
+
+    def assert_appointment_pulled(appointment)
+      assert_selector("#{id_selector(appointment)}.pulled")
+      assert_selector(".pulled-appointments #{id_selector(appointment)}")
+    end
+
     def assert_appointment_completed(appointment)
-      id = dom_id(appointment)
-      assert_selector("##{id}.completed")
-      assert_selector(".completed-appointments ##{id}")
+      assert_selector("#{id_selector(appointment)}.completed")
+      assert_selector(".completed-appointments #{id_selector(appointment)}")
     end
 
     def assert_appointment_pending(appointment)
-      id = dom_id(appointment)
-      refute_selector("##{id}.completed")
-      assert_selector(".pending-appointments ##{id}")
+      refute_selector("#{id_selector(appointment)}.completed")
+      assert_selector(".pending-appointments #{id_selector(appointment)}")
     end
 
     test "moves appointments between lists" do
@@ -68,6 +88,17 @@ module Admin
         @appointment4,
         @appointment1,
         @appointment3
+      ]
+
+      pull_items_for_appointment(@appointment2)
+      assert_appointment_pulled(@appointment2)
+
+      assert_appointments_in_page pending: [
+        @appointment4,
+        @appointment1,
+        @appointment3
+      ], pulled: [
+        @appointment2
       ]
 
       complete_appointment(@appointment2)
@@ -82,6 +113,17 @@ module Admin
       ]
 
       restore_appointment(@appointment2)
+      assert_appointment_pulled(@appointment2)
+
+      assert_appointments_in_page pending: [
+        @appointment4,
+        @appointment1,
+        @appointment3
+      ], pulled: [
+        @appointment2
+      ]
+
+      mark_appointment_as_not_pulled(@appointment2)
       assert_appointment_pending(@appointment2)
 
       assert_appointments_in_page pending: [
@@ -95,36 +137,51 @@ module Admin
     test "keeps appointments in order when changing lists" do
       visit appointment_in_schedule_path(@appointment1)
 
-      complete_appointment(@appointment3)
-      assert_appointment_completed(@appointment3)
+      pull_items_for_appointment(@appointment3)
+      assert_appointment_pulled(@appointment3)
 
-      complete_appointment(@appointment2)
-      assert_appointment_completed(@appointment2)
+      pull_items_for_appointment(@appointment2)
+      assert_appointment_pulled(@appointment2)
 
-      complete_appointment(@appointment1)
-      assert_appointment_completed(@appointment1)
+      pull_items_for_appointment(@appointment1)
+      assert_appointment_pulled(@appointment1)
 
       assert_appointments_in_page pending: [
         @appointment4
-      ], completed: [
+      ], pulled: [
         @appointment2,
         @appointment1,
         @appointment3
       ]
 
-      restore_appointment(@appointment2)
+      mark_appointment_as_not_pulled(@appointment2)
       assert_appointment_pending(@appointment2)
 
       assert_appointments_in_page pending: [
         @appointment2,
         @appointment4
-      ], completed: [
+      ], pulled: [
         @appointment1,
         @appointment3
       ]
     end
 
+    test "marks an appointment as pulled" do
+      visit appointment_in_schedule_path(@appointment2)
+
+      pull_items_for_appointment(@appointment2)
+      assert_appointment_pulled(@appointment2)
+
+      assert @appointment2.reload.pulled_at.present?
+
+      mark_appointment_as_not_pulled(@appointment2)
+
+      assert_appointment_pending(@appointment2)
+      assert @appointment2.reload.pulled_at.nil?
+    end
+
     test "marks an appointment as completed" do
+      @appointment2.update!(pulled_at: Time.current)
       visit appointment_in_schedule_path(@appointment2)
 
       complete_appointment(@appointment2)
@@ -134,7 +191,7 @@ module Admin
 
       restore_appointment(@appointment2)
 
-      assert_appointment_pending(@appointment2)
+      assert_appointment_pulled(@appointment2)
       assert @appointment2.reload.completed_at.nil?
     end
   end


### PR DESCRIPTION
# What it does

When looking at the appointments index, admins will now see three groups of appointments: pending, pulled, and completed. They can move appointments between these three states and the page will update accordingly.

They can also make these same changes on the appointment details/show page.

# Why it is important

#1848

# UI Change Screenshot

Mobile version of the appointments index:
![Screenshot 2025-02-23 at 5 15 05 PM](https://github.com/user-attachments/assets/7d8ed7a7-b5ec-4d94-948a-0578ed1a9153)

Desktop version of the appointments index (the version before the feature flag):
![Screenshot 2025-02-23 at 5 15 38 PM](https://github.com/user-attachments/assets/49a74ad9-210b-4496-be39-25f361667d70)

Desktop version of the appointments index (the version after the feature flag):
![Screenshot 2025-02-23 at 5 15 21 PM](https://github.com/user-attachments/assets/d3649e25-2314-44dd-9e2b-aeef65ddbf79)

Show page for a pending appointment:
![Screenshot 2025-02-23 at 5 59 28 PM](https://github.com/user-attachments/assets/f8912faf-8ea4-4a54-abff-57e0f44c0cbd)

Show page for a pulled appointment:
![Screenshot 2025-02-23 at 5 58 06 PM](https://github.com/user-attachments/assets/4f586b5c-c3d4-4f8c-ad7c-000e5aa115ae)

Show page for a completed appointment:
![Screenshot 2025-02-23 at 5 58 18 PM](https://github.com/user-attachments/assets/24f31ae6-36c9-47c0-b8f6-26759dbc8b13)

# Implementation notes

I added a `pulled_at` column to the `appointment` since completion as a concept is represented by a `completed_at` column. There is probably some sort of refactoring that could be done around representing this state, but I think there's a larger refactor that might be good.

There's a more than fair amount of duplication floating around here. Specifically, there are mobile and desktop versions of appointment partials, new and original versions of the index page and partials, and a few controllers that I duped for this. 

Before refactoring or drying anything up I think we need to find out more about how librarians are using these pages. Do they always use the old or the new version of the index page? Is there a better way to represent the index page that's more useful and doesn't require desktop and mobile specific markup?

That said, I think the verbosity of this is probably fine for the near term and I'd rather be sure we dry things up the right way then guess and end up painting ourselves into a corner. Plus, I think this will definitely make things better for the librarians so I'm happy to put any refactoring off to get this to them sooner.
