### PR TITLE
Added an admin layout level notification for today's unpulled appointments

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -11,8 +11,10 @@ class Appointment < ApplicationRecord
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
   scope :today_or_later, -> { where("starts_at > ?", Time.zone.now.beginning_of_day).order(:starts_at) }
+  scope :only_today, -> { where(starts_at: Time.zone.now.all_day) }
   scope :chronologically, -> { order("starts_at ASC") }
   scope :simultaneous, ->(appointment) { where(starts_at: appointment.starts_at, ends_at: appointment.ends_at).where.not(id: appointment.id) }
+  scope :not_pulled, -> { where(pulled_at: nil) }
 
   attr_accessor :member_updating, :staff_updating
 

--- a/app/views/layouts/_unpulled_appointments_for_today_banner.html.erb
+++ b/app/views/layouts/_unpulled_appointments_for_today_banner.html.erb
@@ -1,0 +1,14 @@
+<% unpulled_appointments_for_today_count = Appointment.only_today.not_pulled.count %>
+<% if unpulled_appointments_for_today_count > 0 %>
+  <div class="app-banner">
+    <div class="header-header">
+      <div class="container grid-lg">
+        <p>
+          <%= link_to admin_appointments_path do %>
+            There <%= "is".pluralize unpulled_appointments_for_today_count %> <%= pluralize unpulled_appointments_for_today_count, "unpulled appointment" %> for today.
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -228,6 +228,8 @@
       </div>
     <% end %>
 
+    <%= render partial: "layouts/unpulled_appointments_for_today_banner" %>
+
     <% if content_for? :header %>
       <div class="app-header">
         <div class="header-header">

--- a/test/system/admin/appointments_notifications_test.rb
+++ b/test/system/admin/appointments_notifications_test.rb
@@ -1,0 +1,35 @@
+require "application_system_test_case"
+
+module Admin
+  class AppointmentNotificationsTest < ApplicationSystemTestCase
+    include AdminHelper
+
+    setup do
+      sign_in_as_admin
+    end
+
+    test "the not pulled notification message is not displayed when there aren't any unpulled appointments for today" do
+      today = Time.zone.today
+      create(:appointment, holds: [create(:hold)], starts_at: 3.days.ago, ends_at: 3.days.ago + 10.minutes)
+      create(:appointment, holds: [create(:hold)], starts_at: today.at_noon, ends_at: today.at_noon + 10.minutes, pulled_at: 3.hours.ago)
+
+      # the specific path doesn't matter as long as it's in the admin interface
+      visit admin_organizations_path
+
+      refute_text "unpulled"
+    end
+
+    test "the not pulled notification message is displayed when there are unpulled appointments for today" do
+      today = Time.zone.today
+      create(:appointment, holds: [create(:hold)], starts_at: 1.day.ago, ends_at: 1.day.ago + 10.minutes)
+      create(:appointment, holds: [create(:hold)], starts_at: today.at_noon, ends_at: today.at_noon + 10.minutes, pulled_at: 3.hours.ago)
+      create(:appointment, holds: [create(:hold)], starts_at: today.at_noon + 20.minutes, ends_at: today.at_noon + 30.minutes, pulled_at: nil)
+      create(:appointment, holds: [create(:hold)], starts_at: today.at_noon + 40.minutes, ends_at: today.at_noon + 50.minutes, pulled_at: nil)
+
+      # the specific path doesn't matter as long as it's in the admin interface
+      visit admin_organizations_path
+
+      assert_text "unpulled appointments"
+    end
+  end
+end


### PR DESCRIPTION
# What it does

Adds a banner to the admin layout that shows how many unpulled appointments there are for today. 

# Why it is important

#1849

# UI Change Screenshot

Just the unpulled appointments notification:
![Screenshot 2025-03-01 at 12 02 40 PM](https://github.com/user-attachments/assets/df7c9da0-896d-40f0-b7a2-f6f35dae0bac)

The unpulled appointments notification alongside the renewal requests notification:
![Screenshot 2025-03-01 at 12 02 17 PM](https://github.com/user-attachments/assets/3bac7dcd-455f-4bcb-8f81-f704b8fd0063)


# Implementation notes

Any feedback is appreciated!
