### PR TITLE
Wrap user emails in our standard email layout

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,9 +1,38 @@
 class UserMailer < Devise::Mailer
   default from: "Chicago Tool Library <team@chicagotoollibrary.org>"
+  layout "mailer"
+
   after_action :store_notification
+
+  def initialize_from_record(record)
+    super # load user
+    @library = @user.library
+    @logo = :small
+  end
+
+  def confirmation_instructions(*args)
+    @title = "Please confirm your email"
+    super
+  end
+
+  def email_changed(*args)
+    @title = "Your email has changed"
+    super
+  end
+
+  def password_change(*args)
+    @title = "Your password has changed"
+    super
+  end
+
+  def reset_password_instructions(*args)
+    @title = "Reset your password"
+    super
+  end
 
   def store_notification
     Notification.create!(
+      library: @library,
       action: action_name,
       address: mail.to.join(","),
       member: @user.member,

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,0 @@
-<p>Welcome <%= @email %>!</p>
-
-<p>You can confirm your account email through the link below:</p>
-
-<p><%= link_to "Confirm my account", confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.mjml
+++ b/app/views/devise/mailer/confirmation_instructions.mjml
@@ -1,0 +1,11 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>Welcome <%= @email %>!</p>
+
+      <p>You can confirm your account email through the link below:</p>
+
+      <p><%= link_to "Confirm my account", confirmation_url(@resource, confirmation_token: @token) %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,5 @@
+Welcome <%= @email %>!
+
+You can confirm your account email through the link below:
+
+<%= confirmation_url(@resource, confirmation_token: @token) %>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,0 @@
-<p>Hello <%= @email %>!</p>
-
-<% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
-<% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
-<% end %>

--- a/app/views/devise/mailer/email_changed.mjml
+++ b/app/views/devise/mailer/email_changed.mjml
@@ -1,0 +1,13 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>Hello <%= @email %>!</p>
+
+      <% if @resource.try(:unconfirmed_email?) %>
+        <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+      <% else %>
+        <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+      <% end %>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/devise/mailer/email_changed.text.erb
+++ b/app/views/devise/mailer/email_changed.text.erb
@@ -1,0 +1,7 @@
+Hello <%= @email %>!
+
+<% if @resource.try(:unconfirmed_email?) %>
+We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.
+<% else %>
+We're contacting you to notify you that your email has been changed to <%= @resource.email %>.
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/password_change.mjml
+++ b/app/views/devise/mailer/password_change.mjml
@@ -1,0 +1,9 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>Hello <%= @resource.email %>!</p>
+
+      <p>We're contacting you to notify you that your password has been changed.</p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/devise/mailer/password_change.text.erb
+++ b/app/views/devise/mailer/password_change.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @resource.email %>!
+
+We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to "Change my password", edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/reset_password_instructions.mjml
+++ b/app/views/devise/mailer/reset_password_instructions.mjml
@@ -1,0 +1,14 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>Hello <%= @resource.email %>!</p>
+
+      <p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+      <p><%= link_to "Change my password", edit_password_url(@resource, reset_password_token: @token) %></p>
+
+      <p>If you didn't request this, please ignore this email.</p>
+      <p>Your password won't change until you access the link above and create a new one.</p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
-
-<p>Click the link below to unlock your account:</p>
-
-<p><%= link_to "Unlock my account", unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/mailer/unlock_instructions.mjml
+++ b/app/views/devise/mailer/unlock_instructions.mjml
@@ -1,0 +1,13 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>Hello <%= @resource.email %>!</p>
+
+      <p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+      <p>Click the link below to unlock your account:</p>
+
+      <p><%= link_to "Unlock my account", unlock_url(@resource, unlock_token: @token) %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,0 +1,7 @@
+Hello <%= @resource.email %>!
+
+Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+
+Click the link below to unlock your account:
+
+<%= link_to "Unlock my account", unlock_url(@resource, unlock_token: @token) %>

--- a/app/views/layouts/mailer.html.mjml
+++ b/app/views/layouts/mailer.html.mjml
@@ -54,10 +54,26 @@
     </mj-style>
   </mj-head>
   <mj-body background-color="#F4F4F4">
+    <% if @logo == :small %>
+      <mj-section>
+        <mj-column padding-top="20px">
+          <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+        </mj-column>
+      </mj-section>
+    <% end %>
+    <% if @title.present? %>
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @title %></mj-text>
+      </mj-column>
+    </mj-section>
+    <% end %>
+    
     <%= yield %>
 
     <mj-section>
       <mj-column>
+        <mj-divider border-width="1px" border-style="dashed" border-color="lightgrey" />
         <mj-text>
           <p>If you have any questions, please email us at <%= mail_to @library.email %>.</p>
           <p>See you at the library!</p>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,6 +1,9 @@
+<% if @title.present? %>## <%= @title -%> ##
+
+<% end %>
 <%= yield %>
 
-<%= HTMLToMarkdown.new.convert(render partial: "member_mailer/donation", formats: [:html]) -%> 
+<%= HTMLToMarkdown.new.convert(render(partial: "member_mailer/donation", formats: [:html])) -%>
 
 <% unless @library.email_banner1.blank? %>
 
@@ -13,7 +16,7 @@
 
 ---
 
-If you have any questions, please email us at <%= @library.email  %>.
+If you have any questions, please email us at <%= @library.email %>.
 
 See you at the library!
 

--- a/app/views/member_mailer/appointment_confirmation.html.erb
+++ b/app/views/member_mailer/appointment_confirmation.html.erb
@@ -1,5 +1,3 @@
-
-
 <mj-section>
   <mj-column padding-top="20px">
     <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,18 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+  def confirmation_instructions
+    UserMailer.confirmation_instructions(User.first, "token")
+  end
+
+  def email_changed
+    UserMailer.email_changed(User.first)
+  end
+
+  def password_change
+    UserMailer.password_change(User.first)
+  end
+
+  def reset_password_instructions
+    UserMailer.reset_password_instructions(User.first, "token")
+  end
+end


### PR DESCRIPTION
# What it does

This wraps the devise emails (email confirmation/password reset/etc) with the same layout we use for other emails. This has two benefits:

1. These emails now look more official to recipients
2. The emails are less minimal, which might have been a factor is our devise emails being flagged as "suspicious" by gmail.

# UI Change Screenshot

Here's an example of how devise emails now look:

<img width="717" alt="Screenshot 2025-03-10 at 4 38 58 PM" src="https://github.com/user-attachments/assets/6ae21aa1-ccbd-4edb-8e2c-07b5dad11e95" />

# Implementation notes

* I also took this opportunity to setup mailer previews for the devise emails, so we can preview them along with our other emails.
