### PR TITLE
Support C tools

### DIFF
--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -1,4 +1,5 @@
-.items_in_maintenance {
+.items_in_maintenance,
+.borrow_policy_approvals {
   --border-color: rgb(206.3684210526, 195.2236842105, 188.1315789474);
   --box-shadow: 0 0 0 0.1rem rgba(47, 120, 144, 0.2);
   --blue: #2f7890;

--- a/app/controllers/account/borrow_policy_approvals_controller.rb
+++ b/app/controllers/account/borrow_policy_approvals_controller.rb
@@ -1,0 +1,14 @@
+module Account
+  class BorrowPolicyApprovalsController < BaseController
+    def create
+      borrow_policy = BorrowPolicy.find(params[:borrow_policy_id])
+
+      BorrowPolicyApproval.find_or_create_by!(
+        borrow_policy:,
+        member: current_user.member
+      )
+
+      redirect_to item_path(params[:item_id]), status: :see_other, success: "Approval requested."
+    end
+  end
+end

--- a/app/controllers/admin/borrow_policies_controller.rb
+++ b/app/controllers/admin/borrow_policies_controller.rb
@@ -27,7 +27,7 @@ module Admin
     end
 
     def borrow_policy_params
-      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit, :member_renewable, :consumable, :rules)
+      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit, :member_renewable, :consumable, :rules, :requires_approval)
     end
   end
 end

--- a/app/controllers/admin/borrow_policies_controller.rb
+++ b/app/controllers/admin/borrow_policies_controller.rb
@@ -1,9 +1,12 @@
 module Admin
   class BorrowPoliciesController < BaseController
-    before_action :set_borrow_policy, only: [:edit, :update]
+    before_action :set_borrow_policy, only: [:edit, :update, :show]
 
     def index
       @borrow_policies = BorrowPolicy.alpha_by_code
+    end
+
+    def show
     end
 
     def edit

--- a/app/controllers/admin/borrow_policy_approvals_controller.rb
+++ b/app/controllers/admin/borrow_policy_approvals_controller.rb
@@ -1,10 +1,11 @@
 module Admin
   class BorrowPolicyApprovalsController < BaseController
+    include Pagy::Backend
     before_action :set_borrow_policy, only: [:index]
 
     def index
       @q = @borrow_policy.borrow_policy_approvals.order(created_at: :desc).ransack(params[:q])
-      @borrow_policy_approvals = @q.result.includes(:member)
+      @pagy, @borrow_policy_approvals = pagy(@q.result.includes(:member))
     end
 
     private

--- a/app/controllers/admin/borrow_policy_approvals_controller.rb
+++ b/app/controllers/admin/borrow_policy_approvals_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class BorrowPolicyApprovalsController < BaseController
+    before_action :set_borrow_policy, only: [:index]
+
+    def index
+      @q = @borrow_policy.borrow_policy_approvals.order(created_at: :desc).ransack(params[:q])
+      @borrow_policy_approvals = @q.result.includes(:member)
+    end
+
+    private
+
+    def set_borrow_policy
+      @borrow_policy = BorrowPolicy.find(params[:borrow_policy_id])
+    end
+  end
+end

--- a/app/controllers/admin/borrow_policy_approvals_controller.rb
+++ b/app/controllers/admin/borrow_policy_approvals_controller.rb
@@ -1,17 +1,34 @@
 module Admin
   class BorrowPolicyApprovalsController < BaseController
     include Pagy::Backend
-    before_action :set_borrow_policy, only: [:index]
+    before_action :set_borrow_policy
+    before_action :set_borrow_policy_approval, only: %i[edit update]
 
     def index
       @q = @borrow_policy.borrow_policy_approvals.order(created_at: :desc).ransack(params[:q])
       @pagy, @borrow_policy_approvals = pagy(@q.result.includes(:member))
     end
 
+    def edit
+    end
+
+    def update
+      @borrow_policy_approval.update!(borrow_policy_params)
+      redirect_to admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), status: :see_other, success: "Successfully updated Borrow Policy Approval"
+    end
+
     private
 
     def set_borrow_policy
       @borrow_policy = BorrowPolicy.find(params[:borrow_policy_id])
+    end
+
+    def set_borrow_policy_approval
+      @borrow_policy_approval = @borrow_policy.borrow_policy_approvals.find(params[:id])
+    end
+
+    def borrow_policy_params
+      params.require(:borrow_policy_approval).permit(:status, :status_reason)
     end
   end
 end

--- a/app/mailers/borrow_policy_approval_mailer.rb
+++ b/app/mailers/borrow_policy_approval_mailer.rb
@@ -1,0 +1,50 @@
+class BorrowPolicyApprovalMailer < ApplicationMailer
+  before_action :generate_uuid
+  after_action :set_uuid_header
+  after_action :store_notification
+
+  def approved
+    @borrow_policy_approval = params[:borrow_policy_approval]
+    @member = @borrow_policy_approval.member
+    @borrow_policy = @borrow_policy_approval.borrow_policy
+    @library = @member.library
+    @subject = "You have been approved to borrow #{@borrow_policy.code} #{@borrow_policy.name} tools"
+    mail(to: @member.email, subject: @subject)
+  end
+
+  def rejected
+    @borrow_policy_approval = params[:borrow_policy_approval]
+    @member = @borrow_policy_approval.member
+    @borrow_policy = @borrow_policy_approval.borrow_policy
+    @library = @member.library
+    @subject = "You have not been approved to borrow #{@borrow_policy.code} #{@borrow_policy.name} tools at this time"
+    mail(to: @member.email, subject: @subject)
+  end
+
+  def revoked
+    @borrow_policy_approval = params[:borrow_policy_approval]
+    @member = @borrow_policy_approval.member
+    @borrow_policy = @borrow_policy_approval.borrow_policy
+    @library = @member.library
+    @subject = "You may no longer borrow #{@borrow_policy.code} #{@borrow_policy.name} tools"
+    mail(to: @member.email, subject: @subject)
+  end
+
+  private
+
+  def generate_uuid
+    @uuid = SecureRandom.uuid
+  end
+
+  def set_uuid_header
+    headers["X-SMTPAPI"] = {
+      unique_args: {
+        uuid: @uuid
+      }
+    }.to_json
+  end
+
+  def store_notification
+    Notification.create!(member: @member, uuid: @uuid, action: action_name, address: @member.email, subject: @subject, library: @library)
+  end
+end

--- a/app/models/borrow_policy.rb
+++ b/app/models/borrow_policy.rb
@@ -4,6 +4,7 @@ class BorrowPolicy < ApplicationRecord
   }
 
   has_many :borrow_policy_approvals, dependent: :destroy
+  has_many :items
 
   validates :name,
     presence: true, uniqueness: {scope: :library_id, case_sensitive: false}

--- a/app/models/borrow_policy.rb
+++ b/app/models/borrow_policy.rb
@@ -3,6 +3,8 @@ class BorrowPolicy < ApplicationRecord
     greater_than_or_equal_to: 0, less_than_or_equal_to: 10
   }
 
+  has_many :borrow_policy_approvals, dependent: :destroy
+
   validates :name,
     presence: true, uniqueness: {scope: :library_id, case_sensitive: false}
   validates :duration,

--- a/app/models/borrow_policy_approval.rb
+++ b/app/models/borrow_policy_approval.rb
@@ -1,0 +1,11 @@
+class BorrowPolicyApproval < ApplicationRecord
+  enum :status, {
+    approved: "approved",
+    rejected: "rejected",
+    requested: "requested",
+    revoked: "revoked"
+  }, validate: true
+
+  belongs_to :borrow_policy
+  belongs_to :member
+end

--- a/app/models/borrow_policy_approval.rb
+++ b/app/models/borrow_policy_approval.rb
@@ -8,4 +8,6 @@ class BorrowPolicyApproval < ApplicationRecord
 
   belongs_to :borrow_policy
   belongs_to :member
+
+  validates :borrow_policy_id, uniqueness: {scope: :member_id}
 end

--- a/app/models/borrow_policy_approval.rb
+++ b/app/models/borrow_policy_approval.rb
@@ -10,4 +10,8 @@ class BorrowPolicyApproval < ApplicationRecord
   belongs_to :member
 
   validates :borrow_policy_id, uniqueness: {scope: :member_id}
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[status]
+  end
 end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -142,5 +142,13 @@ class Hold < ApplicationRecord
     unless item.holdable?
       errors.add(:item, "can not be placed on hold")
     end
+
+    borrow_policy_approval = member.borrow_policy_approvals.find_by(borrow_policy: item.borrow_policy)
+
+    return unless item.borrow_policy.requires_approval?
+
+    unless borrow_policy_approval&.approved?
+      errors.add(:borrow_policy, "requires approval")
+    end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,7 @@
 class Member < ApplicationRecord
   has_many :acceptances, class_name: "AgreementAcceptance", dependent: :destroy
   has_many :adjustments, dependent: :destroy
+  has_many :borrow_policy_approvals, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
   has_many :loans, dependent: :destroy

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -2,6 +2,7 @@ class Member < ApplicationRecord
   has_many :acceptances, class_name: "AgreementAcceptance", dependent: :destroy
   has_many :adjustments, dependent: :destroy
   has_many :borrow_policy_approvals, dependent: :destroy
+  has_many :borrow_policies, through: :borrow_policy_approvals
   has_many :notifications, dependent: :destroy
 
   has_many :loans, dependent: :destroy

--- a/app/views/admin/borrow_policies/_form.html.erb
+++ b/app/views/admin/borrow_policies/_form.html.erb
@@ -12,6 +12,7 @@
   <%= form.check_box :member_renewable %>
   <%= form.check_box :consumable, hint: "Automatically end loans, decrement item quantity, and retire items when quantity reaches zero. Use for seeds and other items that are not returned." %>
   <%= form.check_box :default, hint: "Use as the default policy for new items" %>
+  <%= form.check_box :requires_approval, hint: "Controls whether or not members need to be approved by a librarian before borrowing these tools." %>
   <%= form.rich_text_area :rules, hint: "Displayed for all items associated with this policy" %>
 
   <%= form.actions do %>

--- a/app/views/admin/borrow_policies/index.html.erb
+++ b/app/views/admin/borrow_policies/index.html.erb
@@ -11,19 +11,19 @@
     <%= tag.div "Uniquely Numbered", class: "responsive-table-header" %>
     <%= tag.div "Consumable", class: "responsive-table-header" %>
     <%= tag.div "Default", class: "responsive-table-header" %>
-    <%= tag.div "", class: "responsive-table-header" %>
+    <%= tag.div "Requires Approval", class: "responsive-table-header" %>
 
     <% @borrow_policies.each do |borrow_policy| %>
-      <%= tag.div "#{borrow_policy.code} #{borrow_policy.name}", class: "responsive-table-cell" %>
+      <%= tag.div class: "responsive-table-cell" do %>
+        <%= link_to "#{borrow_policy.code} #{borrow_policy.name}", admin_borrow_policy_path(borrow_policy) %>
+      <% end %>
       <%= tag.div borrow_policy.duration, class: "responsive-table-cell" %>
       <%= tag.div borrow_policy.fine, class: "responsive-table-cell" %>
       <%= tag.div borrow_policy.fine_period, class: "responsive-table-cell" %>
       <%= tag.div borrow_policy.uniquely_numbered, class: "responsive-table-cell" %>
       <%= tag.div borrow_policy.consumable, class: "responsive-table-cell" %>
       <%= tag.div borrow_policy.default, class: "responsive-table-cell" %>
-      <%= tag.div class: "responsive-table-cell" do %>
-        <%= link_to "Edit", edit_admin_borrow_policy_path(borrow_policy) %>
-      <% end %>
+      <%= tag.div borrow_policy.requires_approval, class: "responsive-table-cell" %>
     <% end %>
   </div>
 

--- a/app/views/admin/borrow_policies/show.html.erb
+++ b/app/views/admin/borrow_policies/show.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :header do %>
   <%= index_header "#{@borrow_policy.code} #{@borrow_policy.name}" do %>
+    <%= link_to "Manage Approvals", admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), class: "btn" %>
     <%= link_to "Edit", edit_admin_borrow_policy_path(@borrow_policy), class: "btn" %>
   <% end %>
 <% end %>

--- a/app/views/admin/borrow_policies/show.html.erb
+++ b/app/views/admin/borrow_policies/show.html.erb
@@ -1,21 +1,57 @@
-<p>
-  <strong>Name:</strong>
-  <%= @borrow_policy.name %>
-</p>
+<%= content_for :header do %>
+  <%= index_header "#{@borrow_policy.code} #{@borrow_policy.name}" do %>
+    <%= link_to "Edit", edit_admin_borrow_policy_path(@borrow_policy), class: "btn" %>
+  <% end %>
+<% end %>
 
-<p>
-  <strong>Duration:</strong>
-  <%= @borrow_policy.duration %>
-</p>
+<div class="columns">
+  <div class="column col-4 col-sm-12">
+    <div class="panel item-panel">
+      <div class="panel-body">
+        <h2 class="h3" id="panel-heading">Configuration</h2>
+        <dl aria-labelledby="panel-heading">
+          <dt>Duration</dt>
+          <dd><%= @borrow_policy.duration %></dd>
 
-<p>
-  <strong>Fine cents:</strong>
-  <%= @borrow_policy.fine_cents %>
-</p>
+          <dt>Fine</dt>
+          <dd><%= @borrow_policy.fine %></dd>
 
-<p>
-  <strong>Fine period:</strong>
-  <%= @borrow_policy.fine_period %>
-</p>
+          <dt>Fine Period</dt>
+          <dd><%= @borrow_policy.fine_period %></dd>
 
-<%= link_to "Edit", edit_admin_borrow_policy_path(@borrow_policy) %> |
+          <dt>Uniquely Numbered</dt>
+          <dd><%= @borrow_policy.uniquely_numbered %></dd>
+
+          <dt>Consumable</dt>
+          <dd><%= @borrow_policy.consumable %></dd>
+
+          <dt>Default</dt>
+          <dd><%= @borrow_policy.default %></dd>
+
+          <dt>Requires Approval</dt>
+          <dd><%= @borrow_policy.requires_approval %></dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+  <div class="column col-sm-12 col-8">
+    <section>
+      <h2>Rules</h2>
+      <%= @borrow_policy.rules %>
+    </section>
+    <section>
+      <h2>Stats</h2>
+
+      <p><b><%= number_with_delimiter(@borrow_policy.items.count) %> items</b> associated with this borrow policy.</p>
+
+      <p>
+        There are <b><%= number_with_delimiter(@borrow_policy.borrow_policy_approvals.count) %> borrow policy approvals</b>
+        in total, with
+        <%= number_with_delimiter(@borrow_policy.borrow_policy_approvals.requested.count) %> requested,
+        <%= number_with_delimiter(@borrow_policy.borrow_policy_approvals.approved.count) %> approved,
+        <%= number_with_delimiter(@borrow_policy.borrow_policy_approvals.rejected.count) %> rejected, and
+        <%= number_with_delimiter(@borrow_policy.borrow_policy_approvals.revoked.count) %> revoked
+      </p>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/borrow_policy_approvals/edit.html.erb
+++ b/app/views/admin/borrow_policy_approvals/edit.html.erb
@@ -10,7 +10,7 @@
 
   <% status_options = options_for_select(BorrowPolicyApproval.statuses.values.map { |status| [status.capitalize, status] }, @borrow_policy_approval.status) %>
   <%= form.select :status, status_options %>
-  <%= form.text_area :status_reason %>
+  <%= form.text_area :status_reason, hint: "This will be sent in an email notification to the member, prefaced with 'This is because:'" %>
 
   <%= form.actions do %>
     <%= form.submit "Update" %>

--- a/app/views/admin/borrow_policy_approvals/edit.html.erb
+++ b/app/views/admin/borrow_policy_approvals/edit.html.erb
@@ -1,0 +1,18 @@
+<%= content_for :header do %>
+  <%= index_header "Edit Approval for #{preferred_or_default_name(@borrow_policy_approval.member)}'s use of #{@borrow_policy.code} #{@borrow_policy.name} tools" do %>
+    <%= link_to "Borrow Policy", admin_borrow_policy_path(@borrow_policy), class: "btn" %>
+    <%= link_to "Member", admin_member_path(@borrow_policy_approval.member), class: "btn" %>
+  <% end %>
+<% end %>
+
+<%= form_with(model: @borrow_policy_approval, builder: SpectreFormBuilder, url: admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval), method: :patch, data: {controller: "form"}, id: dom_id(@borrow_policy_approval)) do |form| %>
+  <%= form.errors %>
+
+  <% status_options = options_for_select(BorrowPolicyApproval.statuses.values.map { |status| [status.capitalize, status] }, @borrow_policy_approval.status) %>
+  <%= form.select :status, status_options %>
+  <%= form.text_area :status_reason %>
+
+  <%= form.actions do %>
+    <%= form.submit "Update" %>
+  <% end %>
+<% end %>

--- a/app/views/admin/borrow_policy_approvals/index.html.erb
+++ b/app/views/admin/borrow_policy_approvals/index.html.erb
@@ -25,6 +25,7 @@
         <th>Member</th>
         <th>Status</th>
         <th>Status Reason</th>
+        <th>Actions</th>
       </tr>
       <% @borrow_policy_approvals.each do |borrow_policy_approval| %>
         <tr>
@@ -35,7 +36,10 @@
             <%= borrow_policy_approval.status.capitalize %>
           </td>
           <td>
-            <%= borrow_policy_approval.status_reason %>
+            <%= truncate(borrow_policy_approval.status_reason, length: 40) %>
+          </td>
+          <td>
+            <%= link_to "Edit", edit_admin_borrow_policy_borrow_policy_approval_path(borrow_policy_approval.borrow_policy, borrow_policy_approval) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/borrow_policy_approvals/index.html.erb
+++ b/app/views/admin/borrow_policy_approvals/index.html.erb
@@ -1,0 +1,46 @@
+<%= content_for :header do %>
+  <%= index_header "Approvals for #{@borrow_policy.code} #{@borrow_policy.name}" %>
+<% end %>
+
+<section class="filters-container">
+  <h2>Filters</h2>
+  <%= search_form_for(@q, url: admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), class: "filters-form") do |f| %>
+    <div class="filters-form-fields">
+      <div class="filter-field status">
+        <%= f.label :status_eq, "Status" %>
+        <%= f.select :status_eq, [["Approved", "approved"], ["Rejected", "rejected"], ["Requested", "requested"], ["Revoked", "revoked"]], {include_blank: true} %>
+      </div>
+    </div>
+
+    <div class="filter-button-container">
+      <%= f.submit "Filter", class: "btn" %>
+    </div>
+  <% end %>
+</section>
+
+<% if @borrow_policy_approvals.any? %>
+  <div class="column col-12">
+    <table class="table">
+      <tr>
+        <th>Member</th>
+        <th>Status</th>
+        <th>Status Reason</th>
+      </tr>
+      <% @borrow_policy_approvals.each do |borrow_policy_approval| %>
+        <tr>
+          <td>
+            <%= link_to preferred_or_default_name(borrow_policy_approval.member), admin_member_path(borrow_policy_approval.member) %>
+          </td>
+          <td>
+            <%= borrow_policy_approval.status.capitalize %>
+          </td>
+          <td>
+            <%= borrow_policy_approval.status_reason %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% else %>
+  <%= empty_state "There are no borrow policy approvals." %>
+<% end %>

--- a/app/views/admin/borrow_policy_approvals/index.html.erb
+++ b/app/views/admin/borrow_policy_approvals/index.html.erb
@@ -41,6 +41,7 @@
       <% end %>
     </table>
   </div>
+  <%== pagy_bootstrap_nav(@pagy) %>
 <% else %>
   <%= empty_state "There are no borrow policy approvals." %>
 <% end %>

--- a/app/views/borrow_policy_approval_mailer/approved.mjml
+++ b/app/views/borrow_policy_approval_mailer/approved.mjml
@@ -1,0 +1,21 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @subject %></mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      Hi there!
+    </mj-text>
+
+    <mj-text>
+      You have been approved to place holds on and borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools.
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/borrow_policy_approval_mailer/approved.text.erb
+++ b/app/views/borrow_policy_approval_mailer/approved.text.erb
@@ -1,0 +1,3 @@
+Hi there!
+
+You have been approved to place holds on and borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools.

--- a/app/views/borrow_policy_approval_mailer/rejected.mjml
+++ b/app/views/borrow_policy_approval_mailer/rejected.mjml
@@ -1,0 +1,30 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @subject %></mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      Hi there!
+    </mj-text>
+
+    <mj-text>
+      Unfortunately, you have not been approved to borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools at this time.
+    </mj-text>
+
+    <% if @borrow_policy_approval.status_reason? %>
+      <mj-text>
+        This is because:
+      </mj-text>
+      <mj-text>
+        <%= @borrow_policy_approval.status_reason %>
+      </mj-text>
+    <% end %>
+  </mj-column>
+</mj-section>

--- a/app/views/borrow_policy_approval_mailer/rejected.text.erb
+++ b/app/views/borrow_policy_approval_mailer/rejected.text.erb
@@ -1,0 +1,9 @@
+Hi there!
+
+Unfortunately, you have not been approved to borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools at this time.
+
+<% if @borrow_policy_approval.status_reason? %>
+This is because:
+
+<%= @borrow_policy_approval.status_reason %>
+<% end %>

--- a/app/views/borrow_policy_approval_mailer/revoked.mjml
+++ b/app/views/borrow_policy_approval_mailer/revoked.mjml
@@ -1,0 +1,30 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= image_url "logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @subject %></mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      Hi there!
+    </mj-text>
+
+    <mj-text>
+      Unfortunately, you are no longer approved to borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools at this time.
+    </mj-text>
+
+    <% if @borrow_policy_approval.status_reason? %>
+      <mj-text>
+        This is because:
+      </mj-text>
+      <mj-text>
+        <%= @borrow_policy_approval.status_reason %>
+      </mj-text>
+    <% end %>
+  </mj-column>
+</mj-section>

--- a/app/views/borrow_policy_approval_mailer/revoked.text.erb
+++ b/app/views/borrow_policy_approval_mailer/revoked.text.erb
@@ -1,0 +1,9 @@
+Hi there!
+
+Unfortunately, you are no longer approved to borrow <%= "#{@borrow_policy.code} #{@borrow_policy.name}" %> tools at this time.
+
+<% if @borrow_policy_approval.status_reason? %>
+This is because:
+
+<%= @borrow_policy_approval.status_reason %>
+<% end %>

--- a/app/views/borrow_policy_approvals/_request_borrow_policy_approval.html.erb
+++ b/app/views/borrow_policy_approvals/_request_borrow_policy_approval.html.erb
@@ -1,0 +1,1 @@
+<%= button_to "Request approval", account_borrow_policy_approvals_path(item_id: item.id, borrow_policy_id: item.borrow_policy_id), class: "btn btn-primary", remote: true, data: {disable_with: "Requesting..."} %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -66,6 +66,7 @@
 
         <% if user_signed_in? %>
           <% current_user_has_checked_out = @item.checked_out_exclusive_loan && @item.checked_out_exclusive_loan.member == current_user.member %>
+          <% borrow_policy_approval = current_user.member.borrow_policy_approvals.find_by(borrow_policy: @item.borrow_policy) %>
           <div class="card">
             <div class="card-header">
               <h5 class="card-title">
@@ -73,13 +74,28 @@
                   You have this item checked out
                 <% elsif @current_hold %>
                   You have this item on hold
+                <% elsif @item.borrow_policy.requires_approval? && !borrow_policy_approval&.approved? %>
+                  <% if borrow_policy_approval&.requested? %>
+                    You have requested approval to borrow this kind of item
+                  <% elsif borrow_policy_approval&.rejected? || borrow_policy_approval&.revoked? %>
+                    You cannot borrow this kind of item at this time
+                  <% else %>
+                    You can request approval to borrow this kind of item
+                  <% end %>
                 <% else %>
                   You can place this item on hold
                 <% end %>
               </h5>
             </div>
             <div class="card-body">
-              <% if @item.available? %>
+               <% if @item.borrow_policy.requires_approval? && !borrow_policy_approval&.approved? %>
+                <% if borrow_policy_approval&.requested? %>
+                  <p>Once you're approved you'll be able to place a hold and borrow this kind of item.</p>
+                <% elsif borrow_policy_approval&.rejected? || borrow_policy_approval&.revoked? %>
+                <% else %>
+                  <p>Once you're approved to borrow this item you can return here to place a hold on it.</p>
+                <% end %>
+              <% elsif @item.available? %>
                 <% if @item.active_holds.empty? %>
                   <p>
                     If you place this item on hold you will be <b>first</b> on the waiting list.
@@ -126,6 +142,10 @@
                 <%= render partial: "items/place_hold_on/item_user_checked_out", locals: {loan: @item.checked_out_exclusive_loan} %>
               <% elsif @current_hold %>
                 <%= render partial: "items/place_hold_on/item_already_with_a_hold", locals: {hold: @current_hold} %>
+              <% elsif @item.borrow_policy.requires_approval? && borrow_policy_approval.blank? %>
+                <%= render partial: "borrow_policy_approvals/request_borrow_policy_approval", locals: {item: @item} %>
+              <% elsif @item.borrow_policy.requires_approval? && !borrow_policy_approval&.approved? %>
+# render nothing %>
               <% else %>
                 <%= render partial: "items/place_hold_on/item", locals: {item: @item} %>
               <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -145,7 +145,7 @@
               <% elsif @item.borrow_policy.requires_approval? && borrow_policy_approval.blank? %>
                 <%= render partial: "borrow_policy_approvals/request_borrow_policy_approval", locals: {item: @item} %>
               <% elsif @item.borrow_policy.requires_approval? && !borrow_policy_approval&.approved? %>
-# render nothing %>
+                <!-- render nothing -->
               <% else %>
                 <%= render partial: "items/place_hold_on/item", locals: {item: @item} %>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
     resources :organization_members, only: [:show, :edit, :update, :destroy]
     resources :documents, only: [:show, :edit, :update, :index]
     resources :borrow_policies, only: [:index, :edit, :update, :show] do
-      resources :borrow_policy_approvals, only: [:index], path: :approvals
+      resources :borrow_policy_approvals, only: [:index, :edit, :update], path: :approvals
     end
     resources :categories, except: :show
     resources :gift_memberships

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
     end
     resources :organization_members, only: [:show, :edit, :update, :destroy]
     resources :documents, only: [:show, :edit, :update, :index]
-    resources :borrow_policies, only: [:index, :edit, :update]
+    resources :borrow_policies, only: [:index, :edit, :update, :show]
     resources :categories, except: :show
     resources :gift_memberships
     resources :questions, except: [:destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,9 @@ Rails.application.routes.draw do
     end
     resources :organization_members, only: [:show, :edit, :update, :destroy]
     resources :documents, only: [:show, :edit, :update, :index]
-    resources :borrow_policies, only: [:index, :edit, :update, :show]
+    resources :borrow_policies, only: [:index, :edit, :update, :show] do
+      resources :borrow_policy_approvals, only: [:index], path: :approvals
+    end
     resources :categories, except: :show
     resources :gift_memberships
     resources :questions, except: [:destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   namespace :account do
     resources :appointments, only: [:index, :new, :create, :edit, :update, :destroy]
+    resources :borrow_policy_approvals, only: [:create]
     resources :holds, only: [:index, :create, :destroy] do
       get :history, to: "holds#history", on: :collection
     end

--- a/db/devdata/borrow_policies.yml
+++ b/db/devdata/borrow_policies.yml
@@ -35,6 +35,7 @@
   code: C
   renewal_limit: 52
   consumable: false
+  requires_approval: true
 - id: 4
   name: Single Use
   duration: 1

--- a/db/migrate/20250314201009_add_c_tool_support.rb
+++ b/db/migrate/20250314201009_add_c_tool_support.rb
@@ -1,0 +1,24 @@
+class AddCToolSupport < ActiveRecord::Migration[7.2]
+  def change
+    add_column :borrow_policies, :requires_approval, :boolean, null: false, default: false
+
+    create_enum :borrow_policy_approval_status, %w[
+      approved
+      rejected
+      requested
+      revoked
+    ], force: :cascade
+
+    create_table :borrow_policy_approvals do |t|
+      t.belongs_to :borrow_policy, null: false, foreign_key: true, index: true
+      t.belongs_to :member, null: false, foreign_key: true, index: true
+      t.index %i[borrow_policy_id member_id], unique: true
+
+      t.enum :status, enum_type: :borrow_policy_approval_status, null: false, index: true, default: "requested"
+
+      t.text :status_reason
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_23_214915) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_14_201009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_214915) do
   create_enum :answer_type, [
     "text",
     "integer",
+  ], force: :cascade
+
+  create_enum :borrow_policy_approval_status, [
+    "approved",
+    "rejected",
+    "requested",
+    "revoked",
   ], force: :cascade
 
   create_enum :item_attachment_kind, [
@@ -337,8 +344,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_214915) do
     t.boolean "member_renewable", default: false, null: false
     t.integer "library_id"
     t.boolean "consumable", default: false
+    t.boolean "requires_approval", default: false, null: false
     t.index ["code", "library_id"], name: "index_borrow_policies_on_code_and_library_id", unique: true
     t.index ["library_id", "name"], name: "index_borrow_policies_on_library_id_and_name", unique: true
+  end
+
+  create_table "borrow_policy_approvals", force: :cascade do |t|
+    t.bigint "borrow_policy_id", null: false
+    t.bigint "member_id", null: false
+    t.enum "status", default: "requested", null: false, enum_type: "borrow_policy_approval_status"
+    t.text "status_reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["borrow_policy_id", "member_id"], name: "idx_on_borrow_policy_id_member_id_f2459be3a6", unique: true
+    t.index ["borrow_policy_id"], name: "index_borrow_policy_approvals_on_borrow_policy_id"
+    t.index ["member_id"], name: "index_borrow_policy_approvals_on_member_id"
+    t.index ["status"], name: "index_borrow_policy_approvals_on_status"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -951,6 +972,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_214915) do
   add_foreign_key "agreement_acceptances", "members"
   add_foreign_key "answers", "reservations"
   add_foreign_key "answers", "stems"
+  add_foreign_key "borrow_policy_approvals", "borrow_policies"
+  add_foreign_key "borrow_policy_approvals", "members"
   add_foreign_key "categories", "categories", column: "parent_id"
   add_foreign_key "categorizations", "categories"
   add_foreign_key "gift_memberships", "memberships"

--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -175,7 +175,7 @@ namespace :devdata do
     membership.start!
 
     holds.times do
-      item = random_model(Item.active.available.without_active_holds)
+      item = random_model(Item.active.available.without_active_holds.where.not(borrow_policy_id: BorrowPolicy.select(:id).where(requires_approval: true)))
       Hold.create!(member: member, item: item, creator: member.user)
     end
 

--- a/test/controllers/account/borrow_policy_approvals_controller_test.rb
+++ b/test/controllers/account/borrow_policy_approvals_controller_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+module Account
+  class BorrowPolicyApprovalsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @borrow_policy = create(:borrow_policy, :requires_approval)
+      @item = create(:item, borrow_policy: @borrow_policy)
+      @member = create(:verified_member_with_membership)
+      @user = create(:user, member: @member)
+      sign_in @user
+    end
+
+    test "creates a borrow policy approval for the borrow policy when one doesn't already exist" do
+      assert_difference("BorrowPolicyApproval.count", 1) do
+        post account_borrow_policy_approvals_url, params: {item_id: @item.id, borrow_policy_id: @borrow_policy.id}
+      end
+
+      assert_redirected_to item_url(@item.id)
+
+      borrow_policy_approval = BorrowPolicyApproval.last!
+      assert_equal @member, borrow_policy_approval.member
+      assert_equal @borrow_policy, borrow_policy_approval.borrow_policy
+      assert_equal "requested", borrow_policy_approval.status
+      assert flash[:success].present?
+      assert flash[:error].blank?
+    end
+
+    test "does not create a borrow policy approval when one already exists" do
+      create(:borrow_policy_approval, borrow_policy: @borrow_policy, member: @member)
+
+      assert_difference("BorrowPolicyApproval.count", 0) do
+        post account_borrow_policy_approvals_url, params: {item_id: @item.id, borrow_policy_id: @borrow_policy.id}
+      end
+
+      assert_redirected_to item_url(@item.id)
+
+      assert flash[:success].present?
+      assert flash[:error].blank?
+    end
+  end
+end

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -30,7 +30,7 @@ module Admin
 
     test "should update borrow_policy" do
       @borrow_policy = create(:default_borrow_policy)
-      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true}}
+      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true, requires_approval: true}}
 
       @borrow_policy.reload
       assert_equal 10, @borrow_policy.duration
@@ -39,6 +39,7 @@ module Admin
       assert_equal "New name", @borrow_policy.name
       assert_equal "Q", @borrow_policy.code
       assert_equal true, @borrow_policy.member_renewable
+      assert_equal true, @borrow_policy.requires_approval
     end
   end
 end

--- a/test/controllers/admin/borrow_policy_approvals_controller_test.rb
+++ b/test/controllers/admin/borrow_policy_approvals_controller_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+module Admin
+  class BorrowPolicyApprovalsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @user = create(:admin_user)
+      @borrow_policy_approval = create(:borrow_policy_approval, :requested)
+      @borrow_policy = @borrow_policy_approval.borrow_policy
+      @member = @borrow_policy_approval.member
+      sign_in @user
+    end
+
+    test "update sends an email when updating to approved" do
+      assert_emails(1) do
+        patch(
+          admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval),
+          params: {borrow_policy_approval: {status: "approved"}}
+        )
+      end
+
+      assert_equal "approved", @borrow_policy_approval.reload.status
+
+      mail = ActionMailer::Base.deliveries.last
+
+      assert_equal [@member.email], mail.to
+      assert_includes mail.subject, "have been approved to borrow"
+    end
+
+    test "update sends an email when updating to rejected" do
+      assert_emails(1) do
+        patch(
+          admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval),
+          params: {borrow_policy_approval: {status: "rejected"}}
+        )
+      end
+
+      assert_equal "rejected", @borrow_policy_approval.reload.status
+
+      mail = ActionMailer::Base.deliveries.last
+
+      assert_equal [@member.email], mail.to
+      assert_includes mail.subject, "have not been approved to borrow"
+    end
+
+    test "update sends an email when updating to revoked" do
+      assert_emails(1) do
+        patch(
+          admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval),
+          params: {borrow_policy_approval: {status: "revoked"}}
+        )
+      end
+
+      assert_equal "revoked", @borrow_policy_approval.reload.status
+
+      mail = ActionMailer::Base.deliveries.last
+
+      assert_equal [@member.email], mail.to
+      assert_includes mail.subject, "no longer borrow"
+    end
+
+    test "update does not send an email when updating to requested" do
+      assert_emails(0) do
+        patch(
+          admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval),
+          params: {borrow_policy_approval: {status: "requested"}}
+        )
+      end
+    end
+
+    test "update does not send an email when the status has not been changed" do
+      @borrow_policy_approval.update!(status: "approved")
+      assert_emails(0) do
+        patch(
+          admin_borrow_policy_borrow_policy_approval_path(@borrow_policy, @borrow_policy_approval),
+          params: {borrow_policy_approval: {status: "approved"}}
+        )
+      end
+    end
+  end
+end

--- a/test/factories/borrow_policies.rb
+++ b/test/factories/borrow_policies.rb
@@ -11,6 +11,11 @@ FactoryBot.define do
     description { "What this policy is used for" }
     uniquely_numbered { true }
     member_renewable { false }
+    requires_approval { false }
+
+    trait :requires_approval do
+      requires_approval { true }
+    end
 
     factory :member_renewable_borrow_policy do
       member_renewable { true }

--- a/test/factories/borrow_policy_approvals.rb
+++ b/test/factories/borrow_policy_approvals.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :borrow_policy_approval do
+    borrow_policy { association(:borrow_policy, :requires_approval) }
+    member { association(:verified_member) }
+
+    trait :approved do
+      status { "approved" }
+      status_reason { ["Long time member in good standing", "Cool person", "Pure of heart"].sample }
+    end
+
+    trait :rejected do
+      status { "rejected" }
+      status_reason { ["Too new", "Tends to break things"].sample }
+    end
+
+    trait :requested do
+      status { "requested" }
+    end
+
+    trait :revoked do
+      status { "revoked" }
+      status_reason { ["Broke too many things", "Never returned the last item"].sample }
+    end
+  end
+end

--- a/test/mailers/borrow_policy_approval_mailer_test.rb
+++ b/test/mailers/borrow_policy_approval_mailer_test.rb
@@ -1,0 +1,57 @@
+require "application_system_test_case"
+
+class BorrowPolicyApprovalMailerTest < ApplicationSystemTestCase
+  include Lending
+
+  setup do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "can deliver an email when approval has been approved" do
+    borrow_policy_approval = create(:borrow_policy_approval, :approved)
+    member = borrow_policy_approval.member
+    borrow_policy = borrow_policy_approval.borrow_policy
+
+    email = BorrowPolicyApprovalMailer.with(borrow_policy_approval:).approved
+
+    assert_emails(1) { email.deliver_now }
+
+    assert_delivered_email(to: member.email) do |text, html, _, subject|
+      assert_equal "You have been approved to borrow #{borrow_policy.code} #{borrow_policy.name} tools", subject
+      assert_includes text, "approved", "mail should include the approval status in text part"
+      assert_includes html, "approved", "mail should include the approval status in html part"
+    end
+  end
+
+  test "can deliver an email when approval has been rejected" do
+    borrow_policy_approval = create(:borrow_policy_approval, :rejected)
+    member = borrow_policy_approval.member
+    borrow_policy = borrow_policy_approval.borrow_policy
+
+    email = BorrowPolicyApprovalMailer.with(borrow_policy_approval:).rejected
+
+    assert_emails(1) { email.deliver_now }
+
+    assert_delivered_email(to: member.email) do |text, html, _, subject|
+      assert_equal "You have not been approved to borrow #{borrow_policy.code} #{borrow_policy.name} tools at this time", subject
+      assert_includes text, "not been approved", "mail should include the approval status in text part"
+      assert_includes html, "not been approved", "mail should include the approval status in html part"
+    end
+  end
+
+  test "can deliver an email when approval has been revoked" do
+    borrow_policy_approval = create(:borrow_policy_approval, :revoked)
+    member = borrow_policy_approval.member
+    borrow_policy = borrow_policy_approval.borrow_policy
+
+    email = BorrowPolicyApprovalMailer.with(borrow_policy_approval:).revoked
+
+    assert_emails(1) { email.deliver_now }
+
+    assert_delivered_email(to: member.email) do |text, html, _, subject|
+      assert_equal "You may no longer borrow #{borrow_policy.code} #{borrow_policy.name} tools", subject
+      assert_includes text, "no longer approved to borrow", "mail should include the approval status in text part"
+      assert_includes html, "no longer approved to borrow", "mail should include the approval status in html part"
+    end
+  end
+end

--- a/test/mailers/previews/borrow_policy_approval_mailer_preview.rb
+++ b/test/mailers/previews/borrow_policy_approval_mailer_preview.rb
@@ -1,0 +1,32 @@
+# Preview all emails at http://localhost:3000/rails/mailers/borrow_policy_approval_mailer
+class BorrowPolicyApprovalMailerPreview < ActionMailer::Preview
+  def approved
+    borrow_policy_approval = borrow_policy_approval(BorrowPolicyApproval.statuses[:approved])
+    BorrowPolicyApprovalMailer.with(borrow_policy_approval:).approved
+  end
+
+  def rejected
+    borrow_policy_approval = borrow_policy_approval(BorrowPolicyApproval.statuses[:rejected])
+    BorrowPolicyApprovalMailer.with(borrow_policy_approval:).rejected
+  end
+
+  def revoked
+    borrow_policy_approval = borrow_policy_approval(BorrowPolicyApproval.statuses[:revoked])
+    BorrowPolicyApprovalMailer.with(borrow_policy_approval:).revoked
+  end
+
+  private
+
+  def borrow_policy_approval(status)
+    library = Library.first!
+    borrow_policy = BorrowPolicy.find_by(requires_approval: true, library:)
+
+    borrow_policy_approval = BorrowPolicyApproval
+      .create_with(member: Member.find_by!(library:))
+      .find_or_create_by(borrow_policy:)
+
+    borrow_policy_approval.update!(status:)
+
+    borrow_policy_approval
+  end
+end

--- a/test/models/borrow_policy_approval_test.rb
+++ b/test/models/borrow_policy_approval_test.rb
@@ -31,5 +31,14 @@ class BorrowPolicyApprovalTest < ActiveSupport::TestCase
     refute borrow_policy_approval.save
 
     assert_equal ["is not included in the list"], borrow_policy_approval.errors[:status]
+
+    existing_borrow_policy_approval = create(:borrow_policy_approval, :approved)
+
+    borrow_policy_approval.member = existing_borrow_policy_approval.member
+    borrow_policy_approval.borrow_policy = existing_borrow_policy_approval.borrow_policy
+
+    refute borrow_policy_approval.save
+
+    assert_equal ["has already been taken"], borrow_policy_approval.errors[:borrow_policy_id]
   end
 end

--- a/test/models/borrow_policy_approval_test.rb
+++ b/test/models/borrow_policy_approval_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class BorrowPolicyApprovalTest < ActiveSupport::TestCase
+  [
+    :borrow_policy_approval,
+    %i[borrow_policy_approval approved],
+    %i[borrow_policy_approval rejected],
+    %i[borrow_policy_approval requested],
+    %i[borrow_policy_approval revoked]
+  ].each do |factory_name|
+    test "#{Array(factory_name).join(", ")} is a valid factory/trait" do
+      borrow_policy_approval = build(*factory_name)
+      borrow_policy_approval.valid?
+      assert_equal({}, borrow_policy_approval.errors.messages)
+    end
+  end
+
+  test "validations" do
+    borrow_policy_approval = BorrowPolicyApproval.new
+
+    borrow_policy_approval.status = nil
+
+    refute borrow_policy_approval.save
+
+    assert_equal ["must exist"], borrow_policy_approval.errors[:borrow_policy]
+    assert_equal ["must exist"], borrow_policy_approval.errors[:member]
+    assert_equal ["is not included in the list"], borrow_policy_approval.errors[:status]
+
+    borrow_policy_approval.status = "foo"
+
+    refute borrow_policy_approval.save
+
+    assert_equal ["is not included in the list"], borrow_policy_approval.errors[:status]
+  end
+end

--- a/test/models/borrow_policy_test.rb
+++ b/test/models/borrow_policy_test.rb
@@ -1,6 +1,21 @@
 require "test_helper"
 
 class BorrowPolicyTest < ActiveSupport::TestCase
+  [
+    :borrow_policy,
+    [:borrow_policy, :requires_approval],
+    :member_renewable_borrow_policy,
+    :unnumbered_borrow_policy,
+    :consumable_borrow_policy,
+    :default_borrow_policy
+  ].each do |factory_name|
+    test "#{Array(factory_name).join(", ")} is a valid factory/trait" do
+      borrow_policy = build(*factory_name)
+      borrow_policy.valid?
+      assert_equal({}, borrow_policy.errors.messages)
+    end
+  end
+
   test "sets other borrow policies to not be default" do
     old_policy = BorrowPolicy.create!(name: "Old", code: "O", default: true)
     assert old_policy.reload.default

--- a/test/system/account/holds_test.rb
+++ b/test/system/account/holds_test.rb
@@ -1,0 +1,105 @@
+require "application_system_test_case"
+
+module Account
+  class HoldsTest < ApplicationSystemTestCase
+    setup do
+      @member = create(:verified_member_with_membership)
+      login_as @member.user
+    end
+
+    test "placing a hold on an item that doesn't require approval" do
+      borrow_policy = create(:borrow_policy)
+      item = create(:item, borrow_policy:)
+
+      visit item_path(item)
+
+      assert_text "You can place this item on hold"
+
+      assert_difference("Hold.count", 1) do
+        click_on "Place a hold"
+      end
+
+      assert_text "Hold placed."
+
+      hold = Hold.first!
+
+      assert_equal item, hold.item
+      assert_equal @member, hold.member
+    end
+
+    test "requesting approval to place a hold on an item that does require approval" do
+      borrow_policy = create(:borrow_policy, :requires_approval)
+      item = create(:item, borrow_policy:)
+
+      visit item_path(item)
+
+      assert_text "You can request approval to borrow this kind of item"
+      refute_text "Place a hold"
+
+      assert_difference("BorrowPolicyApproval.count", 1) do
+        click_on "Request approval"
+        assert_text "Approval requested."
+      end
+
+      borrow_policy_approval = BorrowPolicyApproval.first!
+
+      assert_equal borrow_policy, borrow_policy_approval.borrow_policy
+      assert_equal @member, borrow_policy_approval.member
+      assert_equal "requested", borrow_policy_approval.status
+    end
+
+    test "trying to create a hold on an item that requires approval but approval hasn't been approved" do
+      borrow_policy = create(:borrow_policy, :requires_approval)
+      item = create(:item, borrow_policy:)
+      create(:borrow_policy_approval, :requested, borrow_policy:, member: @member)
+
+      visit item_path(item)
+
+      assert_text "You have requested approval to borrow this kind of item"
+      refute_text "Place a hold"
+    end
+
+    test "trying to create a hold on an item that requires approval but approval has been rejected" do
+      borrow_policy = create(:borrow_policy, :requires_approval)
+      item = create(:item, borrow_policy:)
+      create(:borrow_policy_approval, :rejected, borrow_policy:, member: @member)
+
+      visit item_path(item)
+
+      assert_text "You cannot borrow this kind of item at this time"
+      refute_text "Place a hold"
+    end
+
+    test "trying to create a hold on an item that requires approval but approval has been revoked" do
+      borrow_policy = create(:borrow_policy, :requires_approval)
+      item = create(:item, borrow_policy:)
+      create(:borrow_policy_approval, :revoked, borrow_policy:, member: @member)
+
+      visit item_path(item)
+
+      assert_text "You cannot borrow this kind of item at this time"
+      refute_text "Place a hold"
+    end
+
+    test "creating a hold on an item that requires approval and approval is granted" do
+      borrow_policy = create(:borrow_policy, :requires_approval)
+      item = create(:item, borrow_policy:)
+      create(:borrow_policy_approval, :approved, borrow_policy:, member: @member)
+
+      visit item_path(item)
+
+      assert_text "You can place this item on hold"
+
+      assert_difference("Hold.count", 1) do
+        click_on "Place a hold"
+      end
+
+      assert_text "Hold placed."
+
+      hold = Hold.first!
+
+      assert_equal item, hold.item
+      assert_equal @member, hold.member
+    end
+  end
+end

--- a/test/system/account/loans_test.rb
+++ b/test/system/account/loans_test.rb
@@ -1,7 +1,7 @@
 require "application_system_test_case"
 
 module Account
-  class ReservationsTest < ApplicationSystemTestCase
+  class LoansTest < ApplicationSystemTestCase
     setup do
       @member = create(:verified_member_with_membership)
       login_as @member.user

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -95,4 +95,30 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
     refute_css("[href='#{admin_member_path(bpa_rejected.member)}']")
     refute_css("[href='#{admin_member_path(bpa_revoked.member)}']")
   end
+
+  test "editing a borrow policy approval" do
+    audited_as_admin do
+      @borrow_policy = create(:borrow_policy, requires_approval: true)
+    end
+
+    bpa_requested = create(:borrow_policy_approval, :requested, borrow_policy: @borrow_policy)
+
+    visit admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy)
+
+    click_on "Edit"
+
+    assert_text "#{@borrow_policy.code} #{@borrow_policy.name}"
+    assert_text preferred_or_default_name(bpa_requested.member)
+
+    select("Approved", from: "Status")
+    status_reason = "good member in good standing #{rand(100)}"
+    fill_in "Status reason", with: status_reason
+    click_on "Update"
+
+    assert_text "Successfully updated Borrow Policy Approval"
+
+    bpa_requested.reload
+    assert_equal "approved", bpa_requested.status
+    assert_equal status_reason, bpa_requested.status_reason
+  end
 end

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -21,6 +21,7 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
     fill_in "Renewal limit", with: "3"
     fill_in "Renewal limit", with: "3"
     fill_in "Fine period", with: "2"
+    first("label", text: "Requires approval").click # check
     click_on "Update Borrow policy"
 
     assert_text "Borrow policy was successfully updated"

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -23,4 +23,22 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
 
     assert_text "Borrow policy was successfully updated"
   end
+
+  test "viewing a borrow policy" do
+    audited_as_admin do
+      @borrow_policy = create(:borrow_policy, requires_approval: false)
+    end
+
+    visit admin_borrow_policy_path(@borrow_policy)
+
+    assert_text "#{@borrow_policy.code} #{@borrow_policy.name}"
+    assert_text "Duration\n#{@borrow_policy.duration}"
+    assert_text "Fine\n#{@borrow_policy.fine}"
+    assert_text "Fine Period\n#{@borrow_policy.fine_period}"
+    assert_text "Uniquely Numbered\n#{@borrow_policy.uniquely_numbered}"
+    assert_text "Consumable\n#{@borrow_policy.consumable}"
+    assert_text "Default\n#{@borrow_policy.default}"
+    assert_text "Requires Approval\n#{@borrow_policy.default}"
+    assert_text "Edit"
+  end
 end


### PR DESCRIPTION
# What it does

Allows borrow policies to be marked as requiring approval. If an item has a borrow policy that requires approval, members will have to request approval for that kind of item. Later, librarians/admins can approve/reject/revoke that approval.

# Why it is important

#1594 this one has been in the making for a bit

# UI Change Screenshot

Brace yourself, for they are legion.

## Members

When an item belongs to a borrow policy that requires approval, members will see this on the item show page:
![item show no approval record](https://github.com/user-attachments/assets/4eff5a99-aa60-4782-8c07-11557abff712)

Once they've requested approval they'll see:
![item show requested approval](https://github.com/user-attachments/assets/8fbe08c3-aad5-436f-866a-ffa3c606bf36)

If they end up approved:
![item show approved](https://github.com/user-attachments/assets/57ca848e-268b-432f-9de3-58e7bb7427d0)

And if they end up rejected or have their approval revoked:
![item show rejected](https://github.com/user-attachments/assets/ef8ccd6c-220e-479f-8ce9-8adaef6e43b4)

### Emails

Approved HTML email:
![approval email html](https://github.com/user-attachments/assets/1b900f9b-6e7e-4065-99ec-561ca6538d6f)

Approved text email:
![approval email text](https://github.com/user-attachments/assets/011bd707-d9db-43aa-adde-8d304a5059e2)

Rejected HTML email:
![rejected email html](https://github.com/user-attachments/assets/2055d990-e3c5-45e7-9285-e878e983474f)

Rejected text email:
![rejected email text](https://github.com/user-attachments/assets/f460ad75-071b-45b1-95f3-208ff3874f2c)

Revoked HTML email:
![revoked email html](https://github.com/user-attachments/assets/3de97d80-6994-4049-afea-825c023cd827)

Revoked text email:
![revoked email text](https://github.com/user-attachments/assets/e9969deb-997f-4cc7-b26c-36dcb8d6e231)

## Librarians

Updated the borrow policies index:
![borrow policies index](https://github.com/user-attachments/assets/dc257d0a-e4fd-4c01-954a-ec36fdeadd38)

There was a seemingly unused borrow policy show page (you'd need to know the url to access it) has been updated:
![borrow policy show](https://github.com/user-attachments/assets/098d90ec-27f9-4540-9e9a-4b9399533e06)

The borrow policy edit form now has the requires approval checkbox:
![borrow policy edit](https://github.com/user-attachments/assets/7a41154e-4c56-4294-b3be-ee8d57685419)

The "Manage Approvals" button takes librarians to the borrow policy approvals index for that borrow policy (by default they're sorted by `created_at` descending):
![borrow policy approvals index no filters](https://github.com/user-attachments/assets/46b8ecb3-b108-409d-adf8-af1dcdaddd14)

The borrow policy approvals index can be filtered/paginated:
![borrow policy approvals index with filters](https://github.com/user-attachments/assets/84d55811-257e-4a66-a006-72a9cff0d6a8)

Borrow policy approvals can be edited:
![borrow policy approval edit](https://github.com/user-attachments/assets/65c584ec-e222-4231-b46b-48547c559bce)

Updating a borrow policy approval takes you back to the borrow policy approvals index page:
![borrow policy approvals index with flash message](https://github.com/user-attachments/assets/94c1e34b-0d12-458b-ae76-0072ec8a2fd3)

# Implementation notes

The original card mentions a `revoked_at` and `revocation_reason`, but so far my implementation doesn't have the `revoked_at` and has a more generic `status_reason`. 

I think the `revoked_at` fell away because I rolled all of the statuses of the approval into a single enum. In place of the `revoked_at` field maybe we'd just want to add audited to the approvals? Then a librarian could see the whole history if there has been a bunch of back and forth on the approval.

I went with the more generic `status_reason` because I figured there could be reasonable notes for just about any status. Examples: "approved but probationary", "rejected because they just became a member", or "rejected because they've broken too many B tools". 

Speaking of, the `status_reason` shows up (if present) in the rejected and revoked emails.

If a librarian updates the the borrow policy approval without changing the status, no new email will be sent out.

Let me know what ya'll think! Nothing is too small or large to change!

**Note:** in the dev data, an example of a C tool is the item with the id `10893`