### PR TITLE
Ensure that if the renewal email has been sent, the renewal banner is also showing in app

### DIFF
--- a/app/views/account/_membership_renewal_message.html.erb
+++ b/app/views/account/_membership_renewal_message.html.erb
@@ -1,4 +1,4 @@
-<% if current_member.last_membership && (current_member.last_membership.ended? || current_member.last_membership.ends_within?(29.days.since)) %>
+<% if current_member.last_membership && (current_member.last_membership.ended? || current_member.last_membership.ends_within?(30.days.since)) %>
   <div class="toast toast-warning">
     <p><strong>Your membership <%= current_member.last_membership.status_text %>.</strong> To continue to borrow tools, please renew.</p>
     <%= link_to "Renew Membership", renewal_path, class: "btn btn-lg btn-default" %>

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -33,7 +33,7 @@ namespace :email do
 
   desc "Send membership renewal reminder emails"
   task send_membership_renewal_reminders: :environment do
-    Membership.where(ended_at: (Date.current + 30.days).all_day).find_each do |membership|
+    Membership.where(ended_at: 30.days.from_now.all_day).find_each do |membership|
       member = membership.member
       amount = member.last_membership&.amount || Money.new(0)
       MemberMailer.with(member: member, amount: amount).membership_renewal_reminder.deliver_now

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -3,7 +3,11 @@ FactoryBot.define do
     library { Library.first || create(:library) }
     member { association(:member, :with_user) }
     started_at { 1.month.ago }
-    after(:build) { |m| m.ended_at = m.started_at + 364.days if m.started_at }
+    after(:build) do |m|
+      if m.started_at && !m.ended_at?
+        m.ended_at = m.started_at + 364.days
+      end
+    end
 
     factory :pending_membership do
       started_at { nil }

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -189,9 +189,8 @@ class MembershipTest < ActiveSupport::TestCase
 
   test "prevents a member from having an overlapping earlier membership" do
     member = create(:member)
-    membership = create(:membership, member: member)
-
-    earlier_membership = build(:membership, member: member, ended_at: membership.started_at + 1.second)
+    membership = create(:membership, member:, started_at: 1.week.ago, ended_at: 3.days.ago)
+    earlier_membership = build(:membership, member:, started_at: membership.ended_at - 1.second, ended_at: membership.ended_at + 1.year)
     refute earlier_membership.valid?
     assert_equal ["can't overlap with another membership"], earlier_membership.errors[:base]
   end

--- a/test/system/membership_renewal_test.rb
+++ b/test/system/membership_renewal_test.rb
@@ -80,7 +80,7 @@ class MembershipRenewalTest < ApplicationSystemTestCase
   end
 
   test "renews membership that expires soon" do
-    @membership = create(:membership, member: @member, created_at: 336.days.ago, started_at: 336.days.ago, ended_at: 29.days.since)
+    @membership = create(:membership, member: @member, created_at: 336.days.ago, started_at: 336.days.ago, ended_at: 30.days.since)
     visit account_home_url
 
     assert_content "Your membership ends on"
@@ -102,7 +102,7 @@ class MembershipRenewalTest < ApplicationSystemTestCase
   end
 
   test "renewing before end and pay through square", :remote do
-    @membership = create(:membership, member: @member, created_at: 336.days.ago, started_at: 336.days.ago, ended_at: 29.days.since)
+    @membership = create(:membership, member: @member, created_at: 336.days.ago, started_at: 336.days.ago, ended_at: 30.days.since)
     assert_equal 1, @member.memberships.count
 
     visit account_home_url


### PR DESCRIPTION
# What it does

Fixes a bug where a user would receive their renewal notice email and then visit the site and be unable to see the "Renew Membership" banner (they could click the link in the email but didn't)

# Why it is important

#1889 A member ran into this issue the other day

# Implementation notes

The memberships factory was steamrolling the `ended_at` so I tweaked it to prevent the steamrolling, but that led to me having to tweak the dates in a membership validation test.
