### PR TITLE
Track item accessories

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -120,3 +120,21 @@ body.admin {
   padding-left: 1rem;
   padding-top: 0.3rem;
 }
+
+ul.simple-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  &.of-accessories {
+    font-size: 14px;
+    padding-bottom: 4px;
+
+    li {
+      align-items: center;
+      display: flex;
+      justify-content: end;
+      gap: 0.75ch;
+    }
+  }
+}

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -92,7 +92,7 @@ module Admin
       params.require(:item).permit(
         :name, :other_names, :description, :size, :brand, :model, :serial, :number, :image, :status, :strength,
         :power_source, :borrow_policy_id, :quantity, :checkout_notice, :delete_image, :location_shelf, :location_area, :url,
-        :purchase_price, :purchase_link, :myturn_item_type, :holds_enabled, category_ids: []
+        :purchase_price, :purchase_link, :myturn_item_type, :holds_enabled, :accessories_text, category_ids: []
       )
     end
 

--- a/app/javascript/controllers/confirm_item_accessories_controller.js
+++ b/app/javascript/controllers/confirm_item_accessories_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['accessory', 'button']
+
+  handleCheck() {
+    const allChecked = this.accessoryTargets.every(
+      (checkbox) => checkbox.checked
+    )
+
+    this.buttonTarget.disabled = !allChecked
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -14,6 +14,8 @@ import CollapseController from './collapse_controller'
 
 import ConditionalFieldController from './conditional_field_controller'
 
+import ConfirmItemAccessoriesController from './confirm_item_accessories_controller'
+
 import DynamicFieldsController from './dynamic_fields_controller'
 
 import EmailSettingsEditorController from './email_settings_editor_controller'
@@ -46,6 +48,10 @@ application.register('appointment-date', AppointmentDateController)
 application.register('autocomplete', AutocompleteController)
 application.register('collapse', CollapseController)
 application.register('conditional-field', ConditionalFieldController)
+application.register(
+  'confirm-item-accessories',
+  ConfirmItemAccessoriesController
+)
 application.register('dynamic-fields', DynamicFieldsController)
 application.register('email-settings-editor', EmailSettingsEditorController)
 application.register('find-tool', FindToolController)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -189,6 +189,18 @@ class Item < ApplicationRecord
     end
   end
 
+  def accessories_text
+    accessories.join("\n")
+  end
+
+  def accessories_text=(value)
+    self.accessories = if value.present?
+      value.split(/\s*\n\s*/)
+    else
+      []
+    end
+  end
+
   private
 
   def cache_description_as_plain_text

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -21,24 +21,38 @@
         <% end %>
         </div>
         <div class="column col-sm-6 col-4">
-        <p><%= return_item.item.name %></p>
-        <p><%= link_to full_item_number(return_item.item), admin_item_path(return_item.item) %></p>
+          <p><%= return_item.item.name %></p>
+          <p><%= link_to full_item_number(return_item.item), admin_item_path(return_item.item) %></p>
         </div>
-        <div class="column col-sm-12 col-4 text-right">
-        <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]), class: "btn btn-primary", data: {disable_with: "Checking-in..."}, disabled: !return_item.checked_out? %>
-        <% if !return_item.checked_out? %>
-        <em>Item checked-in</em>
+        <div class="column col-sm-12 col-4 text-right" data-controller="confirm-item-accessories">
+          <% if return_item.item.accessories? && return_item.checked_out? %>
+            <ul class="simple-list of-accessories">
+              <% return_item.item.accessories.each do |accessory| %>
+                <li>
+                  <%= label_tag accessory, accessory %>
+                  <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+          <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]),
+                id: "checkin-#{return_item.id}",
+                class: "btn btn-primary",
+                data: {:disable_with => "Checking-in...", "confirm-item-accessories-target" => "button"},
+                disabled: !return_item.checked_out? || return_item.item.accessories? %>
+          <% if !return_item.checked_out? %>
+            <em>Item checked-in</em>
         <% end %>
         </div>
-        </div>
-        <% if return_item.item.checkout_notice? %>
+      </div>
+      <% if return_item.item.checkout_notice? %>
         <div class="info-box">
           <p>
             <strong>Checkout Notice:</strong><br>
             <%= return_item.item.checkout_notice %>
           </p>
         </div>
-      <% end %>
+    <% end %>
   <% end %>
 
   <% unless items_available_to_add_to_dropoff.empty? %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -22,22 +22,23 @@
       <div class="column col-sm-6 col-4">
         <p><%= pickup_item.item.name %></p>
         <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
-        <% if pickup_item.item.accessories? %>
-          <ul>
+      </div>
+      <div class="column col-sm-12 col-4 text-right checkout-button-column" data-controller="confirm-item-accessories">
+        <% if pickup_item.item.accessories? && pickup_item.active? %>
+          <ul class="simple-list of-accessories">
             <% pickup_item.item.accessories.each do |accessory| %>
               <li>
-                <%= checkbox_tag accessory %>
-                <%= label_tag accessory %>
+                <%= label_tag accessory, accessory %>
+                <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
               </li>
             <% end %>
           </ul>
         <% end %>
-      </div>
-      <div class="column col-sm-12 col-4 text-right checkout-button-column">
         <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]),
               id: "checkout-#{pickup_item.id}",
               class: "btn btn-primary btn-sm",
-              data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? || pickup_item.item.accessories? %>
+              data: {:disable_with => "Checking-out...", "confirm-item-accessories-target" => "button"},
+              disabled: !pickup_item.active? || !member.borrow? || pickup_item.item.accessories? %>
         <div class="checkout-button-group">
           <% if pickup_item.active? %>
             <%= button_to "Cancel Hold",

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -1,75 +1,84 @@
 <div class="panel-body">
   <div class="columns col-oneline">
-    <div class="column col-8"><h4>Items to be checked-out (<%= checkout_items_quantity_for_appointment %>)</h4></div>
+    <div class="column col-8">
+      <h4>Items to be checked-out (<%= checkout_items_quantity_for_appointment %>)</h4>
+    </div>
     <div class="column col-sm-12 col-4 text-right">
       <%#= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", turbo_confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
     </div>
   </div>
-
   <% appointment_pickup_items.each do |pickup_item| %>
     <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
           <% if pickup_item.item.image.attached? %>
-          <%= image_tag item_image_url(pickup_item.item.image, resize_to_limit: [160, 112]) %>
+            <%= image_tag item_image_url(pickup_item.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
-          <div class="image-placeholder"></div>
+            <div class="image-placeholder"></div>
           <% end %>
-          <% end %>
+        <% end %>
         <div class="divider"></div>
-
-        </div>
-
-        <div class="column col-sm-6 col-4">
+      </div>
+      <div class="column col-sm-6 col-4">
         <p><%= pickup_item.item.name %></p>
         <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
-        </div>
-        <div class="column col-sm-12 col-4 text-right checkout-button-column">
-        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), {class: "btn btn-primary btn-sm", data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow?} %>
+        <% if pickup_item.item.accessories? %>
+          <ul>
+            <% pickup_item.item.accessories.each do |accessory| %>
+              <li>
+                <%= checkbox_tag accessory %>
+                <%= label_tag accessory %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+      <div class="column col-sm-12 col-4 text-right checkout-button-column">
+        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]),
+              id: "checkout-#{pickup_item.id}",
+              class: "btn btn-primary btn-sm",
+              data: {disable_with: "Checking-out..."}, disabled: !pickup_item.active? || !member.borrow? || pickup_item.item.accessories? %>
         <div class="checkout-button-group">
           <% if pickup_item.active? %>
             <%= button_to "Cancel Hold",
                   admin_appointment_hold_path(@appointment, pickup_item), {
                     params: {cancel_hold: true},
-                    method: :delete,
-                    class: "btn btn-sm mt-2 float-right",
-                    data: {
-                      disable_with: "Canceling...",
-                      turbo_confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?"
-                    }
+                      method: :delete,
+                      class: "btn btn-sm mt-2 float-right",
+                      data: {
+                        disable_with: "Canceling...",
+                        turbo_confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?"
+                      }
                   } %>
             <%= button_to "Remove Item",
                   admin_appointment_hold_path(@appointment, pickup_item), {
                     params: {cancel_hold: false},
-                    method: :delete,
-                    class: "btn btn-sm mt-2 float-right",
-                    data: {
-                      disable_with: "Removing...",
-                      turbo_confirm: "Are you sure you want to remove this item from the appointment?"
-                    }
+                      method: :delete,
+                      class: "btn btn-sm mt-2 float-right",
+                      data: {
+                        disable_with: "Removing...",
+                        turbo_confirm: "Are you sure you want to remove this item from the appointment?"
+                      }
                   } %>
           <% end %>
           <% if !pickup_item.active? %>
             <em>Item checked-out</em>
           <% end %>
         </div>
+      </div>
+    </div>
+    <% if pickup_item.item.checkout_notice? %>
+      <div>
+        <div class="info-box">
+          <p>
+            <strong>Checkout Notice:</strong><br>
+            <%= pickup_item.item.checkout_notice %>
+          </p>
         </div>
-        </div>
-
-        <% if pickup_item.item.checkout_notice? %>
-        <div>
-          <div class="info-box">
-            <p>
-              <strong>Checkout Notice:</strong><br>
-              <%= pickup_item.item.checkout_notice %>
-            </p>
-          </div>
-        </div>
-        <% end %>
+      </div>
+    <% end %>
   <% end %>
-
   <div class="divider"></div>
-
   <div class="columns">
     <h5>Add an item to the appointment for check-out</h5>
     <%= form_with(model: [:admin, AppointmentHold.new], url: admin_appointment_holds_path(@appointment), method: :post, builder: SpectreFormBuilder) do |form| %>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -65,6 +65,8 @@
   <%= form.rich_text_area :description,
         hint: "Any details about the tool. Could be notes about parts, usage, etc and will appear on the tool's public page" %>
 
+  <%= form.text_area :accessories_text, label: "Accessories", hint: "Each accessory should be on its own line", value: item.accessories.join("\n") %>
+
   <%= form.text_area :checkout_notice, hint: "Shown when checking item out" %>
 
   <%= form.check_box :holds_enabled, label: "Allow holds to be placed on this item", hint: "Unchecking will hide but not delete existing holds." %>

--- a/app/views/admin/items/_item_panel.html.erb
+++ b/app/views/admin/items/_item_panel.html.erb
@@ -58,6 +58,16 @@
             <%= icon_stat "list", title: "hold list status" do %>
                 holds <%= @item.holds_enabled_status %>
             <% end %>
+
+            <% if @item.accessories? %>
+                <%= icon_stat "box", title: "accessories", css_class: "with-inner-stats" do %>
+                    <ul class="inner-stats">
+                        <% @item.accessories.each do |accessory| %>
+                            <li><%= accessory %></li>
+                        <% end %>
+                    </ul>
+                <% end %>
+            <% end %>
         </ul>
     </div>
 </div>

--- a/app/views/admin/loans/_form.html.erb
+++ b/app/views/admin/loans/_form.html.erb
@@ -24,10 +24,21 @@
     currently on loan to <%= link_to preferred_or_default_name(borrower), admin_member_path(borrower) %>
     and due on <%= checked_out_date(@item.checked_out_exclusive_loan.due_at) %>
   <% else %>
-    <%= button_tag class: "btn btn-primary" do %>
-      <%= feather_icon "upload" %>Lend
-    <% end %>
-    will be due on <%= checked_out_date(@loan.due_at) %>
+    <div data-controller="confirm-item-accessories">
+      <% if @item.accessories? %>
+        <ul class="simple-list of-accessories">
+          <% @item.accessories.each do |accessory| %>
+            <li>
+              <%= label_tag accessory, accessory %>
+              <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <%= button_tag id: "lend-#{@item.id}", class: "btn btn-primary", disabled: @item.accessories?, data: {"confirm-item-accessories-target" => "button"} do %>
+        <%= feather_icon "upload" %>Lend
+      <% end %>
+      will be due on <%= checked_out_date(@loan.due_at) %>
+    </div>
   <% end %>
-
 <% end %>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -86,8 +86,18 @@
                 </span>
               <% end %>
             </div>
-            <div class="column col-sm-12 col-4 text-right">
-              <%= button_to [:admin, summary.latest_loan], params: {loan: {ended: 1}}, method: :patch, class: "btn btn-primary mb-2", remote: true do %>
+            <div class="column col-sm-12 col-4 text-right" data-controller="confirm-item-accessories">
+              <% if summary.item.accessories? %>
+                <ul class="simple-list of-accessories">
+                  <% summary.item.accessories.each do |accessory| %>
+                    <li>
+                      <%= label_tag accessory, accessory %>
+                      <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
+              <%= button_to [:admin, summary.latest_loan], params: {loan: {ended: 1}}, method: :patch, id: "return-#{summary.item_id}", class: "btn btn-primary mb-2", remote: true, disabled: summary.item.accessories?, data: {"confirm-item-accessories-target" => "button"} do %>
                 <%= feather_icon "download" %>Return
               <% end %>
               <%= renewal_tooltop summary.latest_loan.within_renewal_limit?, summary.item.borrow_policy.renewal_limit do %>

--- a/db/migrate/20250410163403_add_accessories_to_items.rb
+++ b/db/migrate/20250410163403_add_accessories_to_items.rb
@@ -1,0 +1,5 @@
+class AddAccessoriesToItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :items, :accessories, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_04_163403) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_163403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -516,6 +516,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_04_163403) do
     t.integer "purchase_price_cents"
     t.string "myturn_item_type"
     t.boolean "holds_enabled", default: true
+    t.string "accessories", default: [], null: false, array: true
     t.index ["borrow_policy_id", "library_id"], name: "index_items_on_borrow_policy_id_and_library_id"
     t.index ["borrow_policy_id"], name: "index_items_on_borrow_policy_id"
     t.index ["library_id"], name: "index_items_on_library_id"

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -12,10 +12,12 @@ FactoryBot.define do
 
     factory :complete_item do
       brand { "Dewalt" }
+      model { "760S" }
       size { "1/4" }
       strength { "12v" }
       serial { "abcdefg" }
       power_source { Item.power_sources[:electric_battery] }
+      accessories { ["Blade", "Vacuum bag", "Charger"] }
     end
 
     factory :uncounted_item do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -315,4 +315,30 @@ class ItemTest < ActiveSupport::TestCase
 
     assert_not_includes(Item.available_now, item_in_maintenance)
   end
+
+  test "#accessories_text returns all of the accessories as a single string" do
+    random_value = rand(100).to_s
+    item = build(:item, accessories: ["foo", "bar", random_value])
+
+    assert_equal "foo\nbar\n#{random_value}", item.accessories_text
+  end
+
+  test "#accessories_text= assigns accessories to an array based on the given string" do
+    random_value = rand(100).to_s
+    item = build(:item)
+
+    item.accessories_text = "foo\n  bar  \n   #{random_value}"
+
+    assert_equal ["foo", "bar", random_value], item.accessories
+  end
+
+  test "#accessories_text= assigns accessories to an empty array when given nil or a blank string" do
+    item = build(:item)
+
+    item.accessories_text = "    "
+    assert_equal [], item.accessories
+
+    item.accessories_text = nil
+    assert_equal [], item.accessories
+  end
 end

--- a/test/system/admin/appointments/details_test.rb
+++ b/test/system/admin/appointments/details_test.rb
@@ -98,8 +98,23 @@ module Admin
     end
 
     test "an admin can see the accessories for an item that's to be returned" do
-      skip
+      @hold.destroy!
       @item.update!(accessories: ["foo", "bar", rand(100).to_s])
+      loan = create(:loan, :checked_out, item: @item)
+      @appointment.update!(loans: [loan])
+
+      visit admin_appointment_path(@appointment)
+
+      assert_css "button[disabled][id='checkin-#{loan.id}']"
+
+      @item.accessories.each do |accessory|
+        find("label", text: accessory).click # check checkbox
+      end
+
+      refute_css "button[disabled][id='checkin-#{loan.id}']"
+
+      click_on "Check-in"
+      assert_text "1 Item checked-in."
     end
   end
 end

--- a/test/system/admin/appointments/details_test.rb
+++ b/test/system/admin/appointments/details_test.rb
@@ -5,8 +5,9 @@ module Admin
     setup do
       starts_at = Time.current.beginning_of_day + 8.hours
 
-      @member = create(:member)
+      @member = create(:verified_member_with_membership)
       @hold = create(:hold, member: @member)
+      @item = @hold.item
       @appointment = create(:appointment, member: @member, holds: [@hold], starts_at: starts_at + 2.hours, ends_at: starts_at + 4.hours)
 
       sign_in_as_admin
@@ -70,6 +71,35 @@ module Admin
 
       assert @appointment.pulled_at?
       refute @appointment.completed_at?
+    end
+
+    test "an admin can check out an item that lacks accessories" do
+      @item.update!(accessories: [])
+      visit admin_appointment_path(@appointment)
+      assert_text @item.name
+      click_on "Check-out"
+      assert_text "1 Item checked-out."
+    end
+
+    test "an admin can see the accessories for an item that's to be checked out" do
+      @item.update!(accessories: ["foo", "bar", rand(100).to_s])
+      visit admin_appointment_path(@appointment)
+
+      assert_css "button[disabled][id='checkout-#{@hold.id}']"
+
+      @item.accessories.each do |accessory|
+        find("label", text: accessory).click # check checkbox
+      end
+
+      refute_css "button[disabled][id='checkout-#{@hold.id}']"
+
+      click_on "Check-out"
+      assert_text "1 Item checked-out."
+    end
+
+    test "an admin can see the accessories for an item that's to be returned" do
+      skip
+      @item.update!(accessories: ["foo", "bar", rand(100).to_s])
     end
   end
 end

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -11,7 +11,7 @@ class ItemsTest < ApplicationSystemTestCase
   end
 
   test "creating an item" do
-    @item = build(:item)
+    @item = build(:complete_item)
 
     visit admin_items_url
     click_on "New Item"
@@ -25,9 +25,24 @@ class ItemsTest < ApplicationSystemTestCase
     fill_in "Brand", with: @item.brand
     fill_in "Model", with: @item.model
     fill_in "Serial", with: @item.serial
-    click_on "Create Item"
+    fill_in "Accessories", with: @item.accessories.join("\n")
 
-    assert_text "Item was successfully created"
+    assert_difference("Item.count", 1) do
+      click_on "Create Item"
+      assert_text "Item was successfully created"
+    end
+
+    item = Item.last!
+
+    assert_equal @item.name, item.name
+    assert_equal @item.description.to_plain_text, item.description.to_plain_text
+    assert_equal "gas", item.power_source
+    assert_equal @item.size, item.size
+    assert_equal @item.strength, item.strength
+    assert_equal @item.brand, item.brand
+    assert_equal @item.model, item.model
+    assert_equal @item.serial, item.serial
+    assert_equal @item.accessories, item.accessories
   end
 
   test "updating an item" do
@@ -35,23 +50,35 @@ class ItemsTest < ApplicationSystemTestCase
       @item = create(:item)
     end
 
+    attributes = attributes_for(:complete_item)
+
     visit admin_item_url(@item)
     click_on "Edit"
 
     assert_maintenance_option_is_disabled
-    fill_in "Name", with: "Modified Name"
-    fill_in "Brand", with: "Modified Brand"
-    fill_in_rich_text_area "item_description", with: @item.description
+    fill_in "Name", with: attributes[:name]
+    fill_in "Brand", with: attributes[:brand]
+    fill_in "Strength", with: attributes[:strength]
     select "Solar", from: "Power source"
-    fill_in "Model", with: @item.model
-    fill_in "Serial", with: @item.serial
-    fill_in "Size", with: @item.size
+    fill_in "Model", with: attributes[:model]
+    fill_in "Serial", with: attributes[:serial]
+    fill_in "Size", with: attributes[:size]
+    fill_in "Accessories", with: attributes[:accessories].join("\n")
 
-    click_on "Update Item"
-
-    assert_text "Modified Name"
-    assert_text "Modified Brand"
-    assert_text "Item was successfully updated"
+    assert_difference("Item.count", 0) do
+      click_on "Update Item"
+      assert_text "Item was successfully updated"
+    end
+    puts attributes
+    @item.reload
+    assert_equal attributes[:name], @item.name
+    assert_equal "solar", @item.power_source
+    assert_equal attributes[:size], @item.size
+    assert_equal attributes[:strength], @item.strength
+    assert_equal attributes[:brand], @item.brand
+    assert_equal attributes[:model], @item.model
+    assert_equal attributes[:serial], @item.serial
+    assert_equal attributes[:accessories], @item.accessories
   end
 
   test "adding an image to an item and then deleting it" do

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -237,12 +237,17 @@ class ItemsTest < ApplicationSystemTestCase
     end
   end
 
-  test "viewing an item's status" do
-    item = create(:item, :active)
+  test "viewing an item" do
+    item = create(:complete_item, :active)
     create(:overdue_loan, item:)
 
     visit admin_item_url(item)
 
+    assert item.accessories?, "item must have accessories"
+    item.accessories.each do |accessory|
+      assert_text accessory
+    end
+    # statuses
     assert_text "Overdue"
     assert_text "Active"
   end

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -69,7 +69,7 @@ class ItemsTest < ApplicationSystemTestCase
       click_on "Update Item"
       assert_text "Item was successfully updated"
     end
-    puts attributes
+
     @item.reload
     assert_equal attributes[:name], @item.name
     assert_equal "solar", @item.power_source

--- a/test/system/admin/members_test.rb
+++ b/test/system/admin/members_test.rb
@@ -35,4 +35,39 @@ class Admin::MembersTest < ApplicationSystemTestCase
     assert_content "he/him"
     assert_no_content "she/her"
   end
+
+  test "admins can return an item for a member" do
+    item = create(:item)
+    create(:loan, :checked_out, item:, member: @member)
+
+    visit admin_member_url(@member)
+
+    assert_css "button[id='return-#{item.id}']"
+    refute_css "button[disabled][id='return-#{item.id}']"
+    refute_text "Undo return"
+
+    click_on "Return"
+
+    assert_text "Undo return"
+  end
+
+  test "admins can return an item with accessories for a member" do
+    item = create(:item, accessories: ["foo", "bar", rand(100).to_s])
+    create(:loan, :checked_out, item:, member: @member)
+
+    visit admin_member_url(@member)
+
+    assert_css "button[disabled][id='return-#{item.id}']"
+    refute_text "Undo return"
+
+    item.accessories.each do |accessory|
+      find("label", text: accessory).click # check checkbox
+    end
+
+    refute_css "button[disabled][id='return-#{item.id}']"
+
+    click_on "Return"
+
+    assert_text "Undo return"
+  end
 end

--- a/test/system/admin/members_test.rb
+++ b/test/system/admin/members_test.rb
@@ -70,4 +70,47 @@ class Admin::MembersTest < ApplicationSystemTestCase
 
     assert_text "Undo return"
   end
+
+  test "admins can lend an item to a member" do
+    item = create(:item)
+
+    visit admin_member_url(@member)
+
+    refute_css "#return-#{item.id}"
+
+    fill_in "Enter an item's number to loan it to this member", with: item.number
+
+    click_on "Lookup"
+
+    assert_text item.name
+
+    click_on "Lend"
+
+    assert_css "#return-#{item.id}"
+  end
+
+  test "admins can lend an item with accessories to a member" do
+    item = create(:item, accessories: ["foo", "bar", rand(100).to_s])
+
+    visit admin_member_url(@member)
+
+    refute_css "#return-#{item.id}"
+
+    fill_in "Enter an item's number to loan it to this member", with: item.number
+
+    click_on "Lookup"
+
+    assert_text item.name
+    assert_css "#lend-#{item.id}[disabled]"
+
+    item.accessories.each do |accessory|
+      find("label", text: accessory).click # check checkbox
+    end
+
+    refute_css "#lend-#{item.id}[disabled]"
+
+    click_on "Lend"
+
+    assert_css "#return-#{item.id}"
+  end
 end

--- a/test/system/admin/members_test.rb
+++ b/test/system/admin/members_test.rb
@@ -94,7 +94,7 @@ class Admin::MembersTest < ApplicationSystemTestCase
 
     visit admin_member_url(@member)
 
-    refute_css "#return-#{item.id}"
+    refute_text "Renew All"
 
     fill_in "Enter an item's number to loan it to this member", with: item.number
 
@@ -111,6 +111,6 @@ class Admin::MembersTest < ApplicationSystemTestCase
 
     click_on "Lend"
 
-    assert_css "#return-#{item.id}"
+    assert_text "Renew All"
   end
 end


### PR DESCRIPTION
# What it does

Allows librarians to add/edit/remove accessories from items and requires librarians to check off those accessories when lending or accepting a return.

# Why it is important

#1851 Helpful reminders for multipart items.

# UI Change Screenshot

Editing an item's accessories:
![edit accessories](https://github.com/user-attachments/assets/b8e9923e-dc5e-4a01-b90f-0cbf668a231f)

Librarian viewing an item's accessories:
![view accessories](https://github.com/user-attachments/assets/7500cca3-c989-4f9b-8d7f-964fdfd2ba02)

Checking out an item when none of the accessories are checked:
![checking in all unchecked](https://github.com/user-attachments/assets/664fe32e-6ee8-4c32-a6d4-9cdda4684a9c)

Checking out an item when some of the accessories are checked:
![checking in half checked](https://github.com/user-attachments/assets/4d0c18b3-70d6-47b0-8996-3ad5aa94d04c)

Checking out an item when all of the accessories are checked:
![checking in all checked](https://github.com/user-attachments/assets/6068c724-540c-4578-9ddb-f447522665b6)

After checking out an item with accessories:
![checked out](https://github.com/user-attachments/assets/3a972e63-93be-46c8-9fdf-aa72f4b56538)

Returning an item when the accessories are not checked:
![returning unchecked](https://github.com/user-attachments/assets/00ef31cf-97fb-4130-b04f-f19aef12969a)

Returning an item when the accessories are checked:
![returning checked](https://github.com/user-attachments/assets/73706743-7bde-4fb1-a8ee-62e8419624a9)

After returning an item:
![returned](https://github.com/user-attachments/assets/97d912b0-4bff-43e2-9744-5bc3e9c6e0d3)

# Implementation notes

I added the functionality when checking in/out items through an appointment, but the original issue says to add this to the lending UI and the appointment page. Am I missing something here?
