### PR TITLE
Add optional limit to how much of an item pool can be reserved by a single reservation

### DIFF
--- a/app/controllers/admin/item_pools_controller.rb
+++ b/app/controllers/admin/item_pools_controller.rb
@@ -71,7 +71,7 @@ module Admin
     def item_pool_params
       params.require(:item_pool).permit(
         :name, :other_names, :description, :uniquely_numbered, :unnumbered_count,
-        :reservation_policy_id, :checkout_notice, category_ids: []
+        :reservation_policy_id, :checkout_notice, :max_reservable_percentage_points, category_ids: []
       )
     end
 

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -33,7 +33,6 @@ module Admin
       @reservation.submitted_by = current_user
 
       if @reservation.save
-        ReservationMailer.with(reservation: @reservation).reservation_requested.deliver_later
         redirect_to admin_reservation_url(@reservation), success: "Reservation was successfully created."
       else
         @item_pools = ItemPool.all

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -9,6 +9,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   include ActionView::Helpers::TagHelper
 
   alias_method :parent_text_field, :text_field
+  alias_method :parent_number_field, :number_field
   alias_method :parent_collection_select, :collection_select
   alias_method :parent_button, :button
 
@@ -25,6 +26,19 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
       @template.tag.div class: "input-group" do
         @template.tag.span("$", class: "input-group-addon") +
           parent_text_field(method, options)
+      end
+    end
+  end
+
+  def percent_field(method, options = {})
+    options[:class] = "form-input"
+
+    value_from_params = @template.request.params.dig @object.class.to_s.underscore, method
+    options[:value] = value_from_params || object.send(method)
+    sequence_layout(method, options) do
+      @template.tag.div class: "input-group" do
+        parent_number_field(method, options) +
+          @template.tag.span("%", class: "input-group-addon")
       end
     end
   end

--- a/app/models/item_pool.rb
+++ b/app/models/item_pool.rb
@@ -10,21 +10,38 @@ class ItemPool < ApplicationRecord
 
   validates :name, presence: true
   validate :unnumbered_has_no_items
+  validates :max_reservable_percentage_points, numericality: {only_integer: true, allow_nil: true, in: 1..100}
 
   scope :uniquely_numbered, -> { where(uniquely_numbered: true) }
   scope :not_uniquely_numbered, -> { where(uniquely_numbered: false) }
 
   acts_as_tenant :library
 
-  def max_reservable_quantity
-    if uniquely_numbered
+  def max_reservable_percentage_points=(value)
+    self.max_reservable_percent = value.present? ? value.to_f / 100 : nil
+  end
+
+  def max_reservable_percentage_points
+    (max_reservable_percent * 100).floor if max_reservable_percent
+  end
+
+  # Return how many total items are available for borrowing. If per_reservation is true, then
+  # the number returned is how many a single reservation can claim.
+  def max_reservable_quantity(per_reservation: false)
+    total_items = if uniquely_numbered
       reservable_items_count
     else
       unnumbered_count
     end
+
+    if per_reservation && max_reservable_percent.present?
+      (total_items * max_reservable_percent).floor
+    else
+      total_items
+    end
   end
 
-  ## Return a Hash of date => reserved quantity for every day in the range provided
+  # Return a Hash of date => reserved quantity for every day in the range provided
   def reserved_by_date(starts, ends, ignored_reservation_id: nil)
     totals_by_day = sum_reservations_by_day(starts, ends, ignored_reservation_id:)
     starts.to_date.upto(ends.to_date).each_with_object({}) do |date, hash|
@@ -34,8 +51,8 @@ class ItemPool < ApplicationRecord
 
   # Return the maximum number of items that are available for reservation for the entire duration
   # between starts and ends.
-  def max_available_between(starts, ends, ignored_reservation_id: nil)
-    total_items = max_reservable_quantity
+  def max_available_between(starts, ends, ignored_reservation_id: nil, per_reservation: false)
+    total_items = max_reservable_quantity(per_reservation:)
 
     totals_by_day = sum_reservations_by_day(starts, ends, ignored_reservation_id:)
 

--- a/app/models/reservation_hold.rb
+++ b/app/models/reservation_hold.rb
@@ -41,9 +41,9 @@ class ReservationHold < ApplicationRecord
   private
 
   def ensure_quantity_is_available
-    max_available = item_pool.max_available_between(started_at, ended_at, ignored_reservation_id: reservation_id)
+    max_available = item_pool.max_available_between(started_at, ended_at, ignored_reservation_id: reservation_id, per_reservation: true)
     unless quantity <= max_available
-      message = (max_available == 0) ? "none available" : "only #{max_available} available"
+      message = (max_available == 0) ? "none available" : "only #{max_available} available for this reservation"
       errors.add(:quantity, message)
     end
   end

--- a/app/views/admin/item_pools/_form.html.erb
+++ b/app/views/admin/item_pools/_form.html.erb
@@ -4,7 +4,14 @@
   <%= form.autocomplete_text_field :name, path: admin_ui_names_path(format: :json), autofocus: true,
         hint: "Generic name for the tool; e.g. Impact driver, Orchard ladder, Flathead screwdriver" %>
 
-  <%= form.select :reservation_policy_id, options_for_select(@reservation_policy_options, item_pool.reservation_policy_id), include_blank: "None" %>
+  <div class="columns">
+    <div class="column col-4 col-sm-12">
+      <%= form.select :reservation_policy_id, options_for_select(@reservation_policy_options, item_pool.reservation_policy_id), include_blank: "None" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.percent_field :max_reservable_percentage_points, label: "Reservation limit", hint: "Limit how many items a single reservation can claim. There are currently #{item_pool.max_reservable_quantity} items in this pool." %>
+    </div>
+  </div>
 
   <%= form.text_field :other_names, label: "Other names and keywords",
         hint: "Search terms that should return this item; typically slang or other names for the item" %>

--- a/app/views/admin/item_pools/_item_pool_panel.html.erb
+++ b/app/views/admin/item_pools/_item_pool_panel.html.erb
@@ -16,6 +16,9 @@
           <%= link_to item_pool.reservation_policy.name, admin_reservation_policy_path(item_pool.reservation_policy) %>
         <% end %>
       <% end %>
+      <%= icon_stat "pie-chart", title: "#{item_pool.max_reservable_percentage_points || "100"}%", placeholder: "No reservation limit" do %>
+        max of <%= pluralize item_pool.max_reservable_quantity(per_reservation: true), "item" %> per reservation
+      <% end %>
     </ul>
   </div>
 </div>

--- a/db/migrate/20250404163403_add_max_reservable_percent_to_item_pools.rb
+++ b/db/migrate/20250404163403_add_max_reservable_percent_to_item_pools.rb
@@ -1,0 +1,5 @@
+class AddMaxReservablePercentToItemPools < ActiveRecord::Migration[8.0]
+  def change
+    add_column :item_pools, :max_reservable_percent, :decimal, precision: 2, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,101 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_201009) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_04_163403) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
+
+  create_enum :adjustment_kind, [
+    "fine",
+    "membership",
+    "donation",
+    "payment",
+  ], force: :cascade
+
+  create_enum :adjustment_source, [
+    "cash",
+    "square",
+    "forgiveness",
+  ], force: :cascade
+
+  create_enum :answer_type, [
+    "text",
+    "integer",
+  ], force: :cascade
+
+  create_enum :borrow_policy_approval_status, [
+    "approved",
+    "rejected",
+    "requested",
+    "revoked",
+  ], force: :cascade
+
+  create_enum :item_attachment_kind, [
+    "manual",
+    "parts_list",
+    "other",
+  ], force: :cascade
+
+  create_enum :item_status, [
+    "pending",
+    "active",
+    "maintenance",
+    "retired",
+    "missing",
+  ], force: :cascade
+
+  create_enum :membership_type, [
+    "initial",
+    "renewal",
+  ], force: :cascade
+
+  create_enum :organization_member_role, [
+    "admin",
+    "member",
+  ], force: :cascade
+
+  create_enum :power_source, [
+    "solar",
+    "gas",
+    "air",
+    "electric (corded)",
+    "electric (battery)",
+  ], force: :cascade
+
+  create_enum :renewal_request_status, [
+    "requested",
+    "approved",
+    "rejected",
+  ], force: :cascade
+
+  create_enum :reservation_status, [
+    "pending",
+    "requested",
+    "approved",
+    "rejected",
+    "obsolete",
+    "building",
+    "ready",
+    "borrowed",
+    "returned",
+    "unresolved",
+    "cancelled",
+  ], force: :cascade
+
+  create_enum :ticket_status, [
+    "assess",
+    "parts",
+    "repairing",
+    "resolved",
+    "retired",
+  ], force: :cascade
+
+  create_enum :user_role, [
+    "staff",
+    "admin",
+    "member",
+    "super_admin",
+  ], force: :cascade
 
   create_enum :adjustment_kind, [
     "fine",
@@ -559,6 +651,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_201009) do
     t.text "plain_text_description"
     t.bigint "reservation_policy_id"
     t.string "checkout_notice"
+    t.decimal "max_reservable_percent", precision: 2, scale: 2
     t.index ["creator_id"], name: "index_item_pools_on_creator_id"
     t.index ["library_id"], name: "index_item_pools_on_library_id"
     t.index ["reservation_policy_id"], name: "index_item_pools_on_reservation_policy_id"

--- a/test/models/item_pool_test.rb
+++ b/test/models/item_pool_test.rb
@@ -6,6 +6,20 @@ class ItemPoolTest < ActiveSupport::TestCase
     @ends = Time.zone.parse("2024-02-22")
   end
 
+  test "max_reservable_percentage_points is calculated" do
+    item_pool = create(:item_pool, max_reservable_percent: 0.7)
+
+    assert_equal 70, item_pool.max_reservable_percentage_points
+  end
+
+  test "max_reservable_percentage_points= sets max_reservable_percent" do
+    item_pool = create(:item_pool)
+    item_pool.max_reservable_percentage_points = 56
+
+    assert_equal 0.56, item_pool.max_reservable_percent
+    assert item_pool.valid?
+  end
+
   test "no items available with no reservable items" do
     item_pool = create(:item_pool)
 
@@ -111,5 +125,16 @@ class ItemPoolTest < ActiveSupport::TestCase
     create(:reservation_hold, reservation: reservation3, item_pool: item_pool, quantity: 1)
 
     assert_equal 1, reservable_item.item_pool.max_available_between(@starts, @ends)
+  end
+
+  test "limits how many items can be on a reservation using max_reservable_percent" do
+    item_pool = create(:item_pool, max_reservable_percent: 0.5)
+    8.times { create(:reservable_item, item_pool: item_pool) }
+
+    assert_equal 4, item_pool.max_reservable_quantity(per_reservation: true)
+
+    # make sure we're rounding down
+    item_pool.reservable_items.last.destroy!
+    assert_equal 3, item_pool.max_reservable_quantity(per_reservation: true)
   end
 end


### PR DESCRIPTION
# What it does

Fixes #1530 by allowing staff to set a percentage limit on how much of a given item pool can be claimed by a single reservation.

# Why it is important

We don't want a single reservation to use the entire inventory of a given item type.

# UI Change Screenshot

There is a new field on the ItemPool edit form to set this value:
![Screenshot 2025-04-04 at 4 26 56 PM](https://github.com/user-attachments/assets/7a27a731-ca2e-44f9-9579-1cd28f6be6ba)

When set, this limit is shown on the ItemPool show page
![Screenshot 2025-04-04 at 4 26 45 PM](https://github.com/user-attachments/assets/9b776566-eefd-45de-9da3-45ddf88839f5)

Here's an example of the validation working to limit how many items can be reserved:
![Screenshot 2025-04-04 at 4 26 35 PM](https://github.com/user-attachments/assets/8c997190-5da3-4daf-bff4-b272b69c5de7)

# Implementation notes

* I thought about storing a number of items as an integer instead of a percentage as specified in the ticket, but decided ultimately that a percentage is better since it will automatically scale with the number of items (so if we get more items, we don't have to go in and adjust it). I think that's a feature, but it's worth confirming this with staff.
