### PR TITLE
Link to borrow policy approvals on the member show page

### DIFF
--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -1,6 +1,6 @@
 <div class="panel member-panel">
   <div class="panel-header">
-  <h6><%= link_to preferred_or_default_name(member), admin_member_path(member) %></h6>
+    <h6><%= link_to preferred_or_default_name(member), admin_member_path(member) %></h6>
   </div>
   <div class="panel-body">
     <ul class="member-stats member">
@@ -58,6 +58,17 @@
           <%= feather_icon "key" %>
           <%= link_to admin_member_memberships_path(member) do %>
             Pending membership
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+
+    <h6>Borrow Policy Approvals</h6>
+    <ul class="member-stats">
+      <% member.borrow_policy_approvals.each do |borrow_policy_approval| %>
+        <li>
+          <%= link_to edit_admin_borrow_policy_borrow_policy_approval_path(borrow_policy_approval.borrow_policy, borrow_policy_approval) do %>
+            <%= borrow_policy_approval.borrow_policy.name %>: <%= borrow_policy_approval.status.capitalize %>
           <% end %>
         </li>
       <% end %>

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -122,4 +122,27 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
     assert_equal "approved", bpa_requested.status
     assert_equal status_reason, bpa_requested.status_reason
   end
+
+  test "viewing a member's borrow policy approvals" do
+    audited_as_admin do
+      create(:borrow_policy, requires_approval: true) # ignored
+      @borrow_policies = create_list(:borrow_policy, 4, requires_approval: true)
+    end
+
+    member = create(:verified_member)
+
+    approvals = @borrow_policies.zip(%w[approved rejected requested revoked]).map do |(borrow_policy, status)|
+      create(:borrow_policy_approval, borrow_policy:, status:, member:)
+    end
+
+    visit admin_member_path(member)
+
+    @borrow_policies.each do |borrow_policy|
+      assert_text borrow_policy.name
+    end
+
+    approvals.each do |approval|
+      assert_text approval.status.capitalize
+    end
+  end
 end


### PR DESCRIPTION
# What it does

Adds all of a member's borrow policy approvals and their current status to the admin member's show page and links to the approval edit page.

# Why it is important

#1893 Makes borrow policy approvals (aka "C" tools) much easier for librarians to administrate.

# UI Change Screenshot

![Screenshot 2025-04-27 at 4 56 40 PM](https://github.com/user-attachments/assets/aee6fdd7-1fec-4588-bb1c-76188ccb733a)

# Implementation notes

For now I just put them in the side panel but maybe they would be better in one of the tabs on that page. I wanted to hold off on that because it seems like a bigger push and I think we want to surface these to start with. Maybe if we add something like changing their statuses from the member page it'd make more sense to put them behind a tab. 
