### PR TITLE
1737: Add pinned notes to member profiles

### DIFF
--- a/app/controllers/admin/members/base_controller.rb
+++ b/app/controllers/admin/members/base_controller.rb
@@ -13,6 +13,7 @@ module Admin
 
       def load_member
         @member = Member.find(params[:member_id])
+        @notes = @member.notes.pinned_first
       end
     end
   end

--- a/app/controllers/admin/members/notes_controller.rb
+++ b/app/controllers/admin/members/notes_controller.rb
@@ -21,6 +21,9 @@ module Admin
         load_note
 
         if @note.update(note_params)
+          if @note.pinned?
+            @member.notes.where.not(id: @note.id).update_all(pinned: false)
+          end
           redirect_to [:admin, @member, anchor: dom_id(@note)], status: :see_other
         else
           render :edit, status: :unprocessable_entity
@@ -47,7 +50,7 @@ module Admin
       private
 
       def note_params
-        params.require(:note).permit(:body)
+        params.require(:note).permit(:body, :pinned)
       end
 
       def load_note

--- a/app/controllers/admin/members/notes_controller.rb
+++ b/app/controllers/admin/members/notes_controller.rb
@@ -11,6 +11,7 @@ module Admin
         if @note.save
           respond_to do |format|
             format.turbo_stream
+            format.html { redirect_to admin_member_path(@member) }
           end
         else
           render :new, status: :unprocessable_entity
@@ -21,7 +22,10 @@ module Admin
         load_note
 
         if @note.update(note_params)
-          redirect_to [:admin, @member, anchor: dom_id(@note)], status: :see_other
+          respond_to do |format|
+            format.turbo_stream
+            format.html { redirect_to admin_member_path(@member, anchor: dom_id(@note)), status: :see_other }
+          end
         else
           render :edit, status: :unprocessable_entity
         end
@@ -45,7 +49,7 @@ module Admin
 
         respond_to do |format|
           format.turbo_stream
-          format.html { redirect_to [:admin, @member], notice: "Note deleted." }
+          format.html { redirect_to admin_member_path(@member), notice: "Note deleted." }
         end
       end
 

--- a/app/controllers/admin/members/notes_controller.rb
+++ b/app/controllers/admin/members/notes_controller.rb
@@ -21,9 +21,6 @@ module Admin
         load_note
 
         if @note.update(note_params)
-          if @note.pinned?
-            @member.notes.where.not(id: @note.id).update_all(pinned: false)
-          end
           redirect_to [:admin, @member, anchor: dom_id(@note)], status: :see_other
         else
           render :edit, status: :unprocessable_entity
@@ -47,6 +44,13 @@ module Admin
         @note.destroy!
       end
 
+      def index
+        @notes = @member.notes.newest_first.with_all_rich_text
+        render layout: false if request.format.turbo_stream?
+      end
+      
+      
+      
       private
 
       def note_params

--- a/app/controllers/admin/members/notes_controller.rb
+++ b/app/controllers/admin/members/notes_controller.rb
@@ -42,6 +42,11 @@ module Admin
       def destroy
         load_note
         @note.destroy!
+
+        respond_to do |format|
+          format.turbo_stream
+          format.html { redirect_to [:admin, @member], notice: "Note deleted." }
+        end
       end
 
       def index

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -8,4 +8,5 @@ class Note < ApplicationRecord
 
   scope :by_creation_date, -> { order(created_at: :asc) }
   scope :newest_first, -> { order(created_at: :desc) }
+  scope :pinned_first, -> { order(pinned: :desc, created_at: :desc)}
 end

--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -44,6 +44,7 @@
       <% end %>
       <%= tab_link "Previous Loans", admin_member_loan_summaries_path(@member) %>
       <%= tab_link "Membership", admin_member_memberships_path(@member) %>
+      <%= tab_link "Notes", admin_member_notes_path(@member) %>
       <li class="tab-item tab-action">
         <div class="dropdown">
           <a href="#" class="dropdown-toggle" data-turbo="false" tabindex="0">

--- a/app/views/admin/members/notes/_form.html.erb
+++ b/app/views/admin/members/notes/_form.html.erb
@@ -4,6 +4,11 @@
 
     <%= form.rich_text_area :body, label: (note.new_record? ? "Add a note" : "Edit note") %>
 
+    <div>
+      <%= form.check_box :pinned %>
+      <%= form.label :pinned, "Pin this note" %>
+    </div>
+
     <%= form.actions do %>
       <%= form.submit class: "btn btn-primary" %>
 

--- a/app/views/admin/members/notes/_list.html.erb
+++ b/app/views/admin/members/notes/_list.html.erb
@@ -1,8 +1,15 @@
 <%= turbo_frame_tag "new-note" do %><% end %>
 
-  <div id="notes">
-  <% @member.notes.where(pinned: true).with_all_rich_text.each do |note| %>
-    <%= render partial: "admin/members/notes/note", locals: {note: note, member: @member} %>
+  <% if @member.notes.where(pinned: true).exists? %>
+    <% @member.notes.where(pinned: true).with_all_rich_text.order(created_at: :desc).each do |note| %>
+      <div class="card my-2 p-2">
+        <div class="d-flex justify-end">
+          <small class="text-gray"><%= display_date(note.created_at, :long_date) %></small>
+        </div>
+        <div class="mt-1">
+          <%= note.body.to_s.html_safe %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
-</div>
-
+  

--- a/app/views/admin/members/notes/_list.html.erb
+++ b/app/views/admin/members/notes/_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "new-note" do %><% end %>
 
   <div id="notes">
-  <% @member.notes.pinned_first.with_all_rich_text.each do |note| %>
+  <% @member.notes.where(pinned: true).with_all_rich_text.each do |note| %>
     <%= render partial: "admin/members/notes/note", locals: {note: note, member: @member} %>
   <% end %>
 </div>

--- a/app/views/admin/members/notes/_list.html.erb
+++ b/app/views/admin/members/notes/_list.html.erb
@@ -1,15 +1,16 @@
 <%= turbo_frame_tag "new-note" do %><% end %>
 
-  <% if @member.notes.where(pinned: true).exists? %>
-    <% @member.notes.where(pinned: true).with_all_rich_text.order(created_at: :desc).each do |note| %>
-      <div class="card my-2 p-2">
-        <div class="d-flex justify-end">
-          <small class="text-gray"><%= display_date(note.created_at, :long_date) %></small>
+  <%= turbo_frame_tag "pinned-notes" do %>
+    <% if @member.notes.where(pinned: true).exists? %>
+      <% @member.notes.where(pinned: true).with_all_rich_text.order(created_at: :desc).each do |note| %>
+        <div id="<%= dom_id(note) %>" class="card my-2 p-2">
+          <div class="d-flex justify-end">
+            <small class="text-gray"><%= display_date(note.created_at, :long_date) %></small>
+          </div>
+          <div class="mt-1">
+            <%= note.body.to_s.html_safe %>
+          </div>
         </div>
-        <div class="mt-1">
-          <%= note.body.to_s.html_safe %>
-        </div>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
-  

--- a/app/views/admin/members/notes/_list.html.erb
+++ b/app/views/admin/members/notes/_list.html.erb
@@ -1,7 +1,8 @@
 <%= turbo_frame_tag "new-note" do %><% end %>
 
-<div id="notes">
-  <% @member.notes.with_all_rich_text.by_creation_date.each do |note| %>
+  <div id="notes">
+  <% @member.notes.pinned_first.with_all_rich_text.each do |note| %>
     <%= render partial: "admin/members/notes/note", locals: {note: note, member: @member} %>
   <% end %>
 </div>
+

--- a/app/views/admin/members/notes/create.turbo_stream.erb
+++ b/app/views/admin/members/notes/create.turbo_stream.erb
@@ -4,6 +4,12 @@
   </template>
 </turbo-stream>
 
+<turbo-stream action="replace" target="pinned-notes">
+  <template>
+    <%= render partial: "admin/members/notes/list", formats: [:html], locals: {member: @member} %>
+  </template>
+</turbo-stream>
+
 <turbo-stream action="replace" target="new-note">
   <template>
     <%= turbo_frame_tag "new-note" do %><% end %>

--- a/app/views/admin/members/notes/destroy.turbo_stream.erb
+++ b/app/views/admin/members/notes/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<turbo-stream action="remove" target="<%= dom_id(@note) %>"></turbo-stream>
+
+<turbo-stream action="replace" target="pinned-notes">
+  <template>
+    <%= render partial: "admin/members/notes/list", formats: [:html], locals: {member: @member} %>
+  </template>
+</turbo-stream>

--- a/app/views/admin/members/notes/index.html.erb
+++ b/app/views/admin/members/notes/index.html.erb
@@ -11,7 +11,7 @@
 
       <tbody>
         <% @notes.each do |note| %>
-          <tr>
+          <tr id="<%= dom_id(note) %>" >
             <td><%= note.body.to_plain_text.truncate(100) %></td>
             <td><%= display_date(note.created_at, :long_date) %></td>
             <td>

--- a/app/views/admin/members/notes/index.html.erb
+++ b/app/views/admin/members/notes/index.html.erb
@@ -1,11 +1,30 @@
 <%= render "admin/members/profile" do %>
+  <% if @notes.any? %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Note</th>
+          <th>Date</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
 
-  <% if @member.notes.any? %>
-    <% @member.notes.pinned_first.with_all_rich_text.each do |note| %>
-      <%= render partial: "admin/members/notes/note", locals: {note: note, member: @member} %>
-    <% end %>
+      <tbody>
+        <% @notes.each do |note| %>
+          <tr>
+            <td><%= note.body.to_plain_text.truncate(100) %></td>
+            <td><%= display_date(note.created_at, :long_date) %></td>
+            <td>
+              <%= link_to "Edit", edit_admin_member_note_path(@member, note), class: "btn btn-sm" %>
+              <%= button_to "Delete", admin_member_note_path(@member, note), method: :delete,
+                            data: { turbo_confirm: "Are you sure you want to delete this note?" },
+                            class: "btn btn-sm btn-link text-error" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   <% else %>
-    <p>No notes added yet.</p>
+    <%= empty_state "No notes yet for this member.", icon: "mail" %>
   <% end %>
-
 <% end %>

--- a/app/views/admin/members/notes/index.html.erb
+++ b/app/views/admin/members/notes/index.html.erb
@@ -1,0 +1,11 @@
+<%= render "admin/members/profile" do %>
+
+  <% if @member.notes.any? %>
+    <% @member.notes.pinned_first.with_all_rich_text.each do |note| %>
+      <%= render partial: "admin/members/notes/note", locals: {note: note, member: @member} %>
+    <% end %>
+  <% else %>
+    <p>No notes added yet.</p>
+  <% end %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,13 @@ Rails.application.routes.draw do
         resources :notifications, only: :index
 
         resources :loan_summaries, only: :index
-        resources :notes
+
+        resources :notes do
+          collection do
+            get :all
+          end
+        end
+
         resource :password, only: [:edit, :update]
       end
 

--- a/db/migrate/20250423201733_add_pinned_to_notes.rb
+++ b/db/migrate/20250423201733_add_pinned_to_notes.rb
@@ -1,0 +1,5 @@
+class AddPinnedToNotes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notes, :pinned, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_10_163403) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_23_201733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -625,6 +625,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_163403) do
     t.bigint "creator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "pinned"
     t.index ["creator_id"], name: "index_notes_on_creator_id"
     t.index ["notable_type", "notable_id"], name: "index_notes_on_notable_type_and_notable_id"
   end


### PR DESCRIPTION
# What it does

Implements support for pinning notes to the top of a member’s profile. Pinned notes are shown in a high-visibility section above the Notes tab, with all notes (pinned and unpinned) accessible within the tabbed table view.

# Why it is important

- Highlights critical member information at the top of the profile
- Adds a checkbox to allow pinning when creating or editing a note
- Organizes all member notes in a clean, structured tabbed layout for easier access

# UI Change Screenshot

<img width="1440" alt="Screenshot 2025-04-29 at 5 32 47 PM" src="https://github.com/user-attachments/assets/cbbf81b8-db97-490d-94e8-d679c731dd13" />


# Implementation notes

Updated the NotesController to support both Turbo Stream and full HTML fallback responses.
Created Turbo Stream templates to dynamically update the pinned notes section after creating or deleting a note.

<!-- Any open questions you have about the PR or areas where you'd like specific feedback. -->
- Known limitation: the Notes tab does not currently auto-refresh after note creation/deletion; requires manual page refresh.
