### PR TITLE
Drop the description column from the items table

### DIFF
--- a/db/migrate/20250430195751_drop_item_description.rb
+++ b/db/migrate/20250430195751_drop_item_description.rb
@@ -1,0 +1,5 @@
+class DropItemDescription < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :items, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_10_163403) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_30_195751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -491,7 +491,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_163403) do
 
   create_table "items", force: :cascade do |t|
     t.string "name", null: false
-    t.string "description"
     t.string "size"
     t.string "brand"
     t.string "model"


### PR DESCRIPTION
# What it does

It removes the `description` column from `Item` since we use a rich text description for it instead.

# Why it is important

#1857 Kind of confusing to use `item.description` and to not be sure if you're getting the column or the rich text.

# Implementation notes

Tried to keep it easy-breezy.
