### PR TITLE
Phinze/dust off nix on mac

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,8 +5,7 @@
 # For details on the Nix development setup, see NIX.md.
 #
 ## shellcheck shell=bash
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+if has nix; then
+  watch_file .ruby-version
+  use flake
 fi
-watch_file .ruby-version
-use flake

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "omniauth-rails_csrf_protection"
 # Calendar syncing
 gem "googleauth"
 
-gem "image_processing", "~> 1.14"
+gem "image_processing", "~> 1.14", require: "image_processing/vips"
 gem "mini_magick"
 
 gem "barnes"

--- a/bin/setup
+++ b/bin/setup
@@ -20,7 +20,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing yarn packages =="
   system!("yarn install")
 
-  if ENV["USING_NIX"] == "1"
+  if ENV["PLAYWRIGHT_CHROME_BINARY"]
     # Nix cannot execute misc downloaded binaries so it brings its own browser
     puts "== (Skipping playwright browser install for Nix setup) =="
   else

--- a/flake.nix
+++ b/flake.nix
@@ -26,59 +26,71 @@
       };
     in {
       devShell = with pkgs;
-        mkShell {
-          buildInputs = [
-            ruby
-            foreman
-            nodejs_20
+        mkShell ({
+            buildInputs = [
+              ruby
+              foreman
+              nodejs_20
 
-            # Make sure yarn uses the version-specific node package specified
-            # above
-            (yarn.override {nodejs = nodejs_20;})
+              # Make sure yarn uses the version-specific node package specified
+              # above
+              (yarn.override {nodejs = nodejs_20;})
 
-            # needed to build pg gem, even though we'll run the db from Docker
-            postgresql_15
+              # needed to build pg gem, even though we'll run the db from Docker
+              postgresql_15
 
-            # lib/certificate/generator.rb shells out to convert
-            # ghostscript override fixes issue with with convert being unable
-            # to find a font, workaround copied from
-            # https://github.com/NixOS/nixpkgs/pull/246444
-            (imagemagick.override {ghostscriptSupport = true;})
+              # lib/certificate/generator.rb shells out to convert
+              # ghostscript override fixes issue with with convert being unable
+              # to find a font, workaround copied from
+              # https://github.com/NixOS/nixpkgs/pull/246444
+              (imagemagick.override {ghostscriptSupport = true;})
 
-            # for system tests
-            chromium
+              # install chromium for system tests on non-mac platforms
+              (lib.optional (!stdenv.isDarwin) chromium)
 
-            # for linters and git hooks
-            lefthook
+              # for linters and git hooks
+              lefthook
 
-            # for deployment
-            heroku
+              # for deployment
+              heroku
 
-            # needed to build psych gem, which is in the dependency tree as of rails 7.1
-            libyaml
+              # needed to build psych gem, which is in the dependency tree as of rails 7.1
+              libyaml
 
-            # needed for vips ffi to work
-            glib
-            vips
-          ];
+              # needed for vips ffi to work
+              glib
+              vips
+            ];
 
-          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [glib vips]}";
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [glib vips]}";
 
-          # Keep gems installed in a subdirectory
-          BUNDLE_PATH = "./vendor/bundle";
+            # Keep gems installed in a subdirectory
+            BUNDLE_PATH = "./vendor/bundle";
 
-          # Point to Docker-hosted db server, using the same settings as
-          # config/docker.env
-          DATABASE_URL = "postgres://localhost:5435";
-          PGUSER = "postgres";
+            # Point to Docker-hosted db server, using the same settings as
+            # config/docker.env
+            DATABASE_URL = "postgres://localhost:5435";
+            PGUSER = "postgres";
 
-          # We'll run system tests in headless mode
-          HEADLESS = "true";
-          PARALLEL_WORKERS = "3";
-          PLAYWRIGHT_CHROME_BINARY = "${pkgs.chromium}/bin/chromium";
+            # We'll run system tests in headless mode
+            HEADLESS = "true";
+            PARALLEL_WORKERS = "3";
 
-          # Set a general env variable that other setup code can use.
-          USING_NIX = "1";
-        };
+            NIX_IS_DARWIN =
+              if stdenv.isDarwin
+              then "true"
+              else "false";
+          }
+          // (lib.optionalAttrs (stdenv.isDarwin) {
+            # Work around occasional segfault on MacOS, see https://github.com/rails/rails/issues/38560#issuecomment-1881733872
+            PGGSSENCMODE = "disable";
+
+            # Fix Fontconfig warning: Cannot load default config file: No such file: (null)
+            FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+          })
+          // (lib.optionalAttrs (!stdenv.isDarwin) {
+            # On non-mac hosts, use installed chromium binary
+            PLAYWRIGHT_CHROME_BINARY = "${pkgs.chromium}/bin/chromium";
+          }));
     });
 }


### PR DESCRIPTION
# What it does

Makes the Nix development setup work on Darwin machines again

# Why it is important

Not very important! Just allows me to hop between Linux and Mac machines. Also we had one other person try out the Nix setup and note that it was failing on Chromium issues

# Implementation Notes

The only non-nix-specific code change here is to eager load vips for the image_processing gem. I think this should be safe, and I'll make sure it's working ok on staging before rolling it out.