### PR TITLE
Refactor Document model to use 'enum' for 'code'

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -35,7 +35,7 @@ module Admin
 
     # Use callbacks to share common setup or constraints between actions.
     def set_document
-      @document = Document.coded(params[:id]).first!
+      @document = Document.where(code: params[:id]).first!
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/renewal/acceptances_controller.rb
+++ b/app/controllers/renewal/acceptances_controller.rb
@@ -10,7 +10,7 @@ module Renewal
         redirect_to renewal_confirmation_url, status: :see_other
       else
         activate_step(:agreement)
-        @document = Document.agreement
+        @document = Document.agreement.first!
         render "renewal/documents/agreement", status: :unprocessable_entity
       end
     end

--- a/app/controllers/renewal/base_controller.rb
+++ b/app/controllers/renewal/base_controller.rb
@@ -10,7 +10,7 @@ module Renewal
     private
 
     def load_steps
-      agreement = Document.agreement
+      agreement = Document.agreement.first!
       @steps = if @current_library.allow_payments?
         [
           Step.new(:rules, name: "Rules"),

--- a/app/controllers/renewal/documents_controller.rb
+++ b/app/controllers/renewal/documents_controller.rb
@@ -1,12 +1,12 @@
 module Renewal
   class DocumentsController < BaseController
     def rules
-      @document = Document.borrow_policy
+      @document = Document.borrow_policy.first!
       activate_step(:rules)
     end
 
     def agreement
-      @document = Document.agreement
+      @document = Document.agreement.first!
       @acceptance = AgreementAcceptance.new
       activate_step(:agreement)
     end

--- a/app/controllers/signup/acceptances_controller.rb
+++ b/app/controllers/signup/acceptances_controller.rb
@@ -10,7 +10,7 @@ module Signup
         redirect_to signup_confirmation_url, status: :see_other
       else
         activate_step(:agreement)
-        @document = Document.agreement
+        @document = Document.agreement.first!
         render "signup/documents/agreement", status: :unprocessable_entity
       end
     end

--- a/app/controllers/signup/base_controller.rb
+++ b/app/controllers/signup/base_controller.rb
@@ -28,7 +28,7 @@ module Signup
     end
 
     def load_steps
-      agreement = Document.agreement
+      agreement = Document.agreement.first!
       @steps = if @current_library.allow_payments?
         [
           Step.new(:rules, name: "Rules"),

--- a/app/controllers/signup/documents_controller.rb
+++ b/app/controllers/signup/documents_controller.rb
@@ -4,12 +4,12 @@ module Signup
     before_action :is_membership_enabled?
 
     def rules
-      @document = Document.borrow_policy
+      @document = Document.borrow_policy.first!
       activate_step(:rules)
     end
 
     def agreement
-      @document = Document.agreement
+      @document = Document.agreement.first!
       @acceptance = AgreementAcceptance.new
       activate_step(:agreement)
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,8 +9,6 @@ class Document < ApplicationRecord
     borrow_policy: "borrow_policy",
   }, validate: true
 
-  scope :coded, ->(code) { where(code: code) }
-
   acts_as_tenant :library
 
   def to_param

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,7 +6,7 @@ class Document < ApplicationRecord
   enum :code, {
     agreement: "agreement",
     code_of_conduct: "code_of_conduct",
-    borrow_policy: "borrow_policy",
+    borrow_policy: "borrow_policy"
   }, validate: true
 
   acts_as_tenant :library

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,19 +3,17 @@ class Document < ApplicationRecord
 
   validates :name, :summary, presence: true
 
+  enum :code, {
+    agreement: "agreement",
+    code_of_conduct: "code_of_conduct",
+    borrow_policy: "borrow_policy",
+  }, validate: true
+
   scope :coded, ->(code) { where(code: code) }
 
   acts_as_tenant :library
 
   def to_param
     code
-  end
-
-  def self.borrow_policy
-    coded("borrow_policy").first!
-  end
-
-  def self.agreement
-    coded("agreement").first!
   end
 end

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     end
     body { "Body for #{name}" }
     summary { "Summary for #{name}" }
-    code { name.underscore }
+    code { "borrow_policy" }
 
     factory :agreement_document do
       code { "agreement" }


### PR DESCRIPTION
# What it does

Replaces some existing logic around the `code` field to use the Rails `enum` helper. This gives extra functionality in terms of scopes and value checkers.

# Why it is important

Rather than needing individual methods added for each Document `code` type, `enum` will give us the methods for free.

# UI Change Screenshot

n/a

# Implementation notes

This is not a requested feature, but was something I encountered working on https://github.com/chicago-tool-library/circulate/issues/874 and so thought I would raise for review.
