### PR TITLE
Add ability for member to view Documents agreed to

### DIFF
--- a/app/controllers/account/members_controller.rb
+++ b/app/controllers/account/members_controller.rb
@@ -4,6 +4,18 @@ module Account
       @member = current_member
     end
 
+    def agreement
+      @document = Document.where(code: 'agreement').last
+    end
+
+    def code_of_conduct
+      @document = Document.where(code: 'code_of_conduct').last
+    end
+    
+    def borrow_policy
+      @document = Document.where(code: 'borrow_policy').last
+    end
+
     def edit
     end
 

--- a/app/controllers/account/members_controller.rb
+++ b/app/controllers/account/members_controller.rb
@@ -5,15 +5,15 @@ module Account
     end
 
     def agreement
-      @document = Document.where(code: 'agreement').last
+      @document = Document.where(code: "agreement").last
     end
 
     def code_of_conduct
-      @document = Document.where(code: 'code_of_conduct').last
+      @document = Document.where(code: "code_of_conduct").last
     end
-    
+
     def borrow_policy
-      @document = Document.where(code: 'borrow_policy').last
+      @document = Document.where(code: "borrow_policy").last
     end
 
     def edit

--- a/app/views/account/members/agreement.html.erb
+++ b/app/views/account/members/agreement.html.erb
@@ -1,0 +1,10 @@
+<div class="columns">
+  <div class="column col-8 col-sm-12 col-mx-auto">
+
+    <h2><%= @document.name %></h2>
+
+    <div class="rich-text">
+      <%= @document.body %>
+    </div>
+  </div>
+</div>

--- a/app/views/account/members/borrow_policy.html.erb
+++ b/app/views/account/members/borrow_policy.html.erb
@@ -1,0 +1,10 @@
+<div class="columns">
+  <div class="column col-8 col-sm-12 col-mx-auto">
+
+    <h2><%= @document.name %></h2>
+
+    <div class="rich-text">
+      <%= @document.body %>
+    </div>
+  </div>
+</div>

--- a/app/views/account/members/code_of_conduct.html.erb
+++ b/app/views/account/members/code_of_conduct.html.erb
@@ -1,0 +1,10 @@
+<div class="columns">
+  <div class="column col-8 col-sm-12 col-mx-auto">
+
+    <h2><%= @document.name %></h2>
+
+    <div class="rich-text">
+      <%= @document.body %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,6 +33,9 @@
         <ul aria-labelledby="nav-membership-label">
           <% if user_signed_in? %>
             <%= navbar_link_to "Profile", account_member_path %>
+            <%= navbar_link_to "Agreement", account_agreement_path %>
+            <%= navbar_link_to "Code of Conduct", account_code_of_conduct_path %>
+            <%= navbar_link_to "Borrow Policy", account_borrow_policy_path %>
             <% if current_user.admin? %>
               <%= navbar_link_to "Librarian View", admin_dashboard_path %>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
       post :renew_all, to: "loans#renew_all", on: :collection
     end
     resource :member, only: [:show, :edit, :update]
+    get :agreement, to: "members#agreement"
+    get :code_of_conduct, to: "members#code_of_conduct"
+    get :borrow_policy, to: "members#borrow_policy"
     resource :password, only: [:edit, :update]
     resources :renewals, only: :create
     resources :renewal_requests, only: :create


### PR DESCRIPTION
# What it does

Resolves #874: feat: Add ability for a member to view the most recent Document `'agreement'`, `'code_of_conduct'`, and `'borrow_policy'`.

# Why it is important

There is currently no way for members to view the policies they agree to when they sign up for a membership.

# UI Change Screenshot

<img width="790" alt="Screenshot 2025-06-11 at 21 28 24" src="https://github.com/user-attachments/assets/f86998f2-84bc-461d-afbd-43f30d173b28" />

# Implementation notes

There is no way to tie a particular Document to a Member agreeing, so we're unable to provide a member with when they agreed to a particular document (or a version of a document) for now, but that would be a good enhancement in the future.

The view/controller method are very similar currently, but opted to leave them distinct so that iteration on each version can be done without affecting other versions.