### PR TITLE
Add tags select and tag creation to maintenance tickets

### DIFF
--- a/app/controllers/admin/items/tickets_controller.rb
+++ b/app/controllers/admin/items/tickets_controller.rb
@@ -57,7 +57,7 @@ module Admin
       end
 
       def ticket_params
-        params.require(:ticket).permit(:title, :body, :status, :tag_list).merge(creator_id: current_user.id)
+        params.require(:ticket).permit(:title, :body, :status, tag_list: []).merge(creator_id: current_user.id)
       end
     end
   end

--- a/app/javascript/controllers/tag_editor_controller.js
+++ b/app/javascript/controllers/tag_editor_controller.js
@@ -6,10 +6,15 @@ require('@selectize/selectize')
 export default class extends Controller {
   static targets = ['input']
 
+  initialize() {
+    //Allows users to add new tags based on data-create attribute.
+    this.createEnabled = (this.element.dataset.create === 'true')
+  }
+
   connect() {
     this.selectize = jquery(this.inputTarget).selectize({
       copyClassesToDropdown: false,
-      // create: true,
+      create: this.createEnabled,
       plugins: ['remove_button'], // 'restore_on_backspace'
     })
   }

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -66,6 +66,19 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
     end
   end
 
+  # tag select input that works with acts-as-taggable-on type attributes
+  def tag_list_select(method, tag_list)
+    options = {
+      data: {"tag-editor-target": "input"},
+      multiple: true
+    }
+    @template.tag.div(data: {create: "true", controller: "tag-editor"}) do
+      sequence_layout(method, options) do
+        parent_collection_select method, tag_list, :name, :name, {}, options.merge(data: {target: "tag-editor.input"})
+      end
+    end
+  end
+
   def summarized_collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
     options[:wrapper_options] = {data: {controller: "multi-select"}}
     html_options[:data] = {"multi-select-target": "control", action: "multi-select#change"}

--- a/app/views/admin/items/tickets/_form.html.erb
+++ b/app/views/admin/items/tickets/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.text_field :title %>
   <%= form.rich_text_area :body %>
   <%= form.select :status, options_for_select(ticket_status_options, ticket.status), label: "Ticket Status" %>
-  <%= form.text_field :tag_list, label: "Tags", value: ticket.tag_list.join(", "), hint: "Comma separated e.g. 'Urgent, Quick Fix, etc'" %>
+  <%= form.tag_list_select :tag_list, ActsAsTaggableOn::Tag.most_used %>
 
   <%= form.actions do %>
     <%= form.submit %>

--- a/test/controllers/admin/items/tickets_controller_test.rb
+++ b/test/controllers/admin/items/tickets_controller_test.rb
@@ -31,10 +31,10 @@ module Admin
         status = "assess"
         title = "A ticket title"
         body = "A ticket body"
-        tags = ["a", "b", "c"]
+        tag_list = ["a", "b", "c"]
 
         assert_difference("Ticket.count") do
-          post admin_item_tickets_url(@item), params: {ticket: {status:, title:, body:, tag_list: tags.join(", ")}}
+          post admin_item_tickets_url(@item), params: {ticket: {status:, title:, body:, tag_list: }}
         end
 
         assert_redirected_to admin_item_ticket_url(@item, Ticket.last)
@@ -44,7 +44,7 @@ module Admin
         assert_equal status, ticket.status
         assert_equal title, ticket.title
         assert_equal body, ticket.body.to_plain_text
-        assert_equal tags, ticket.tag_list
+        assert_equal tag_list, ticket.tag_list
       end
 
       test "creating a ticket with any status besides 'retired' updates the ticket's status to 'maintenance'" do
@@ -96,16 +96,16 @@ module Admin
         @ticket = create(:ticket, item: @item, tag_list: %w[foo bar])
         status = "parts"
         body = "Waiting on parts"
-        tags = ["a", "b", "c"]
+        tag_list = ["a", "b", "c"]
 
-        patch admin_item_ticket_url(@item, @ticket), params: {ticket: {status:, body:, tag_list: tags.join(", ")}}
+        patch admin_item_ticket_url(@item, @ticket), params: {ticket: {status:, body:, tag_list:}}
 
         assert_redirected_to admin_item_ticket_url(@item, @ticket)
 
         @ticket.reload
         assert_equal status, @ticket.status
         assert_equal body, @ticket.body.to_plain_text
-        assert_equal tags, @ticket.tag_list
+        assert_equal tag_list, @ticket.tag_list
       end
 
       test "updating a ticket to retired makes the item retired" do


### PR DESCRIPTION
# What it does

Uses the `tags_editor_controller` we use for Item categories to select tags for maintenance tickets. I also changed the tags_editor_controller slightly to use the "create" setting from selectize as well. 

# Why it is important

ref: #1840 

It's nice to be able to reuse tags easily to be more consistent!

# UI Change Screenshot
Current form:
<img width="526" alt="Screenshot 2025-06-24 at 2 22 40 PM" src="https://github.com/user-attachments/assets/8b9719e5-6af0-446c-a6f4-fb20d11a81bb" />

New form:

https://github.com/user-attachments/assets/a3462aff-0c30-458c-b411-fa7ce4dd53c1

# Implementation notes

I think the tag_list_select name is a little clunky/open to suggestions about how to distinguish between the tag_select method that's used for item categories! 
