### PR TITLE
allow searching by different number formats

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -76,7 +76,9 @@ class Item < ApplicationRecord
   scope :by_name, -> { order(name: :asc) }
 
   scope :search_and_order_by_availability, ->(query) {
-    item_scope = search_by_anything(query)
+    # allow searching for all number formats, e.g., "B-1234" -> "1234", or "B1234" -> "1234"
+    processed_query = if query.match(/^[A-Z]-?(\d+)$/i) then $1 else query end
+    item_scope = search_by_anything(processed_query)
       .with_pg_search_rank
       .with(active_hold_counts: Hold.active.group(:item_id).select(:item_id, "COUNT(*) as active_hold_count"))
       .joins(


### PR DESCRIPTION
# What it does

Fixes #1949. Currently, to find item B-1234 you would have to search "1234". "B-1234" or "B1234" would return no results. Now, any of those options will return tool B-1234.

# Why it is important

It's not that important, just a tiny user experience improvement. We have physical signs at the library saying you can search by number, but it isn't clear that you should exclude the letter so we occasionally get searches for "B-1234".

# Implementation notes

I just added one line to preprocess the query in the `search_and_order_by_availability` scope, but I don't know if that's the best approach. I just used regex to match the "X-####" or "X####" patterns.

**Potential problems/weirdness:**
* If there are any search terms that follow the pattern "X###" (one letter followed by some numbers) that match tool names or descriptions, this change will negatively impact those tools. I can't think of any examples but I haven't looked into the search logs.
* This solution doesn't require you to use the *right* letter. You could search "A-1234", "B-1234", or "Z-1234", and all of those would return tool B-1234. This is probably fine.
