### PR TITLE
Show a banner to admin users when there are requested borrow policy approvals

### DIFF
--- a/app/views/admin/borrow_policies/index.html.erb
+++ b/app/views/admin/borrow_policies/index.html.erb
@@ -3,30 +3,37 @@
 <% end %>
 
 <% if @borrow_policies.any? %>
-  <div class="responsive-table eight-columns">
-    <%= tag.div "Name", class: "responsive-table-header" %>
-    <%= tag.div "Duration", class: "responsive-table-header" %>
-    <%= tag.div "Fine", class: "responsive-table-header" %>
-    <%= tag.div "Fine Period", class: "responsive-table-header" %>
-    <%= tag.div "Uniquely Numbered", class: "responsive-table-header" %>
-    <%= tag.div "Consumable", class: "responsive-table-header" %>
-    <%= tag.div "Default", class: "responsive-table-header" %>
-    <%= tag.div "Requires Approval", class: "responsive-table-header" %>
+  <table class="table">
+    <thead>
+      <th>Name</th>
+      <th>Duration</th>
+      <th>Fine</th>
+      <th>Fine Period</th>
+      <th>Uniquely Numbered</th>
+      <th>Consumable</th>
+      <th>Default</th>
+      <th>Requires Approval</th>
+      <th>Requested Approvals</th>
+    </thead>
+    <tbody>
+      <% @borrow_policies.each do |borrow_policy| %>
+        <tr>
+          <td>
+            <%= link_to "#{borrow_policy.code} #{borrow_policy.name}", admin_borrow_policy_path(borrow_policy) %>
+          </td>
 
-    <% @borrow_policies.each do |borrow_policy| %>
-      <%= tag.div class: "responsive-table-cell" do %>
-        <%= link_to "#{borrow_policy.code} #{borrow_policy.name}", admin_borrow_policy_path(borrow_policy) %>
+          <td><%= borrow_policy.duration %></td>
+          <td><%= borrow_policy.fine %></td>
+          <td><%= borrow_policy.fine_period %></td>
+          <td><%= borrow_policy.uniquely_numbered %></td>
+          <td><%= borrow_policy.consumable %></td>
+          <td><%= borrow_policy.default %></td>
+          <td><%= borrow_policy.requires_approval %></td>
+          <td><%= link_to borrow_policy.borrow_policy_approvals.requested.count, admin_borrow_policy_borrow_policy_approvals_path(borrow_policy) %></td>
+        </tr>
       <% end %>
-      <%= tag.div borrow_policy.duration, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.fine, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.fine_period, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.uniquely_numbered, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.consumable, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.default, class: "responsive-table-cell" %>
-      <%= tag.div borrow_policy.requires_approval, class: "responsive-table-cell" %>
-    <% end %>
-  </div>
-
+    </tbody>
+  </table>
 <% else %>
   <%= empty_state "There are no borrow policies." %>
 <% end %>

--- a/app/views/layouts/_requested_borrow_policy_approvals_banner.html.erb
+++ b/app/views/layouts/_requested_borrow_policy_approvals_banner.html.erb
@@ -1,0 +1,14 @@
+<% requested_borrow_policy_approvals_count = BorrowPolicyApproval.requested.count %>
+<% if requested_borrow_policy_approvals_count > 0 %>
+  <div class="app-banner">
+    <div class="header-header">
+      <div class="container grid-lg">
+        <p>
+          <%= link_to admin_borrow_policies_path do %>
+            There <%= "is".pluralize requested_borrow_policy_approvals_count %> <%= pluralize requested_borrow_policy_approvals_count, "requested borrow policy approval" %>.
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -229,6 +229,7 @@
     <% end %>
 
     <%= render partial: "layouts/unpulled_appointments_for_today_banner" %>
+    <%= render partial: "layouts/requested_borrow_policy_approvals_banner" %>
 
     <% if content_for? :header %>
       <div class="app-header">

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -7,6 +7,24 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
     sign_in_as_admin
   end
 
+  test "viewing borrow policies" do
+    borrow_policies = create_list(:borrow_policy, 3)
+
+    create_list(:borrow_policy_approval, 1, :approved, borrow_policy: borrow_policies.first)
+    create_list(:borrow_policy_approval, 2, :requested, borrow_policy: borrow_policies.first)
+    create_list(:borrow_policy_approval, 3, :requested, borrow_policy: borrow_policies.second)
+    create_list(:borrow_policy_approval, 1, :rejected, borrow_policy: borrow_policies.second)
+
+    visit admin_borrow_policies_path
+
+    borrow_policies.each do |borrow_policy|
+      assert_text borrow_policy.name
+    end
+
+    assert_text "2"
+    assert_text "3"
+  end
+
   test "updating a borrow_policy" do
     audited_as_admin do
       @borrow_policy = create(:borrow_policy)

--- a/test/system/admin/borrow_policy_approvals_notifications_test.rb
+++ b/test/system/admin/borrow_policy_approvals_notifications_test.rb
@@ -1,0 +1,34 @@
+require "application_system_test_case"
+
+module Admin
+  class BorrowPolicyApprovalsNotificationsTest < ApplicationSystemTestCase
+    include AdminHelper
+
+    setup do
+      sign_in_as_admin
+    end
+
+    test "the requested approvals notification message is not displayed when there aren't any requested approvals" do
+      create(:borrow_policy_approval, :approved)
+      create(:borrow_policy_approval, :rejected)
+      create(:borrow_policy_approval, :revoked)
+
+      # the specific path doesn't matter as long as it's in the admin interface
+      visit admin_organizations_path
+
+      refute_text "requested borrow policy approvals"
+    end
+
+    test "the requested approvals notification message is displayed when there are requested approvals" do
+      create(:borrow_policy_approval, :approved)
+      create(:borrow_policy_approval, :rejected)
+      create(:borrow_policy_approval, :revoked)
+      create_list(:borrow_policy_approval, 2, :requested)
+
+      # the specific path doesn't matter as long as it's in the admin interface
+      visit admin_organizations_path
+
+      assert_text "requested borrow policy approvals"
+    end
+  end
+end


### PR DESCRIPTION
# What it does

This adds a banner that librarians see when there's a requested borrow policy approval (like renewal requests). The banner itself links to the borrow policies index.

It also adds a "Requested Approvals" count to the borrow policies index that links to the manage approvals page for that borrow policy.

# Why it is important

Came up at the last stakeholders meeting ([issue](https://github.com/chicago-tool-library/circulate/issues/1964))

# UI Change Screenshot

Banner on the items page:
<img width="1026" height="291" alt="banner on items page" src="https://github.com/user-attachments/assets/d9af1a55-694f-45d4-9b40-c990ad0b70b1" />

Banner on the borrow policies index:
<img width="1006" height="561" alt="banner on borrow policies index" src="https://github.com/user-attachments/assets/e5434762-b796-495b-a153-5e9992f773c5" />

Borrow policies index without the banner:
<img width="1003" height="491" alt="borrow policies index without banner" src="https://github.com/user-attachments/assets/ac3e0fed-3b6a-4d5b-8a29-c0160d591f42" />

# Implementation notes

I converted the borrow policies index page to use an html table because the div-based table couldn't support any more columns.
