### PR TITLE
Added pill to mark tools that require approval in the search results

### DIFF
--- a/app/assets/stylesheets/application_styles.scss
+++ b/app/assets/stylesheets/application_styles.scss
@@ -494,6 +494,7 @@ $min-width: variables.$size-md + 1;
   margin-top: 1em;
 }
 
+.item-borrow-policy,
 .item-checkout-status {
   font-size: 0.8em;
   position: relative;

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -74,7 +74,7 @@
       <section>
         <ul class="items-list">
           <% @items.each.with_index do |item, index| %>
-            <li class="item-container" tabindex="0" aria-labelledby="item-name-<%= item.id %>">
+            <li id="item-<%= item.id %>" class="item-container" tabindex="0" aria-labelledby="item-name-<%= item.id %>">
               <%= tag.div class: "item-image" do %>
                 <% if item.image.attached? %>
                   <%= link_to item_path(item, search_result_index: index) do %>
@@ -90,6 +90,9 @@
                 <%= tag.div class: "item-info" do %>
                   <strong><%= link_to item.name, item_path(item, search_result_index: index), class: "item-name", id: "item-name-#{item.id}" %></strong>
                   <%= item_status_label(item) %>
+                  <% if item.borrow_policy.requires_approval? %>
+                    <span class="label label-secondary item-borrow-policy"><%= item.borrow_policy.code %>-Tool</span>
+                  <% end %>
                   <% if item.active_holds.any? %>
                     <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
                   <% end %>

--- a/test/system/items_requiring_approval_test.rb
+++ b/test/system/items_requiring_approval_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class ItemsRequiringApprovalTest < ApplicationSystemTestCase
+  def setup
+    borrow_policy = create(:borrow_policy, :requires_approval)
+
+    @item_requiring_approval = create(:item, borrow_policy:)
+    @item_not_requiring_approval = create(:item, borrow_policy: create(:borrow_policy, requires_approval: false))
+  end
+
+  def borrow_policy_code_name(borrow_policy)
+    "#{borrow_policy.code}-Tool"
+  end
+
+  test "items requiring approval are labeled in the search results" do
+    visit items_path
+
+    within("#item-#{@item_not_requiring_approval.id}") do
+      refute_text borrow_policy_code_name(@item_not_requiring_approval.borrow_policy)
+      refute_text borrow_policy_code_name(@item_requiring_approval.borrow_policy)
+    end
+
+    within("#item-#{@item_requiring_approval.id}") do
+      assert_text borrow_policy_code_name(@item_requiring_approval.borrow_policy)
+    end
+  end
+end


### PR DESCRIPTION
# What it does

It adds a pill to let people know if a tool requires approval in the search results

# Why it is important

#1977 

# UI Change Screenshot

Here are a few screenshots to show how the wrapping works out:

<img width="1008" height="736" alt="Screenshot 2025-08-16 at 11 52 06 AM" src="https://github.com/user-attachments/assets/ca0d6a2e-9ec2-4d5f-ad9e-0e4882d4e09f" />

<img width="995" height="646" alt="Screenshot 2025-08-16 at 11 51 33 AM" src="https://github.com/user-attachments/assets/e03dfde5-c0f6-4da6-8d0c-968e1dfac3c2" />

<img width="998" height="541" alt="Screenshot 2025-08-16 at 11 51 17 AM" src="https://github.com/user-attachments/assets/d0a646d7-8b7c-4f90-9f2c-4d506d462e73" />

# Implementation notes

Since we're going with C-Tools as the messaging, I decided to build the pill using the `borrow_policy.code` since the name of the borrow policy is "Special." Also, if we add another borrow policy that requires approval this will distinguish them from one another.
