### PR TITLE
Added a staff approval required filter link to items search

### DIFF
--- a/app/assets/stylesheets/partials/_items_index.scss
+++ b/app/assets/stylesheets/partials/_items_index.scss
@@ -86,4 +86,14 @@
       }
     }
   }
+
+  .staff-approval-required-link-container {
+    margin-top: 0.5rem;
+    padding-left: 1.2rem;
+
+    @media all and (max-width: 640px) {
+      font-size: 0.9rem;
+      padding-left: 1.4rem;
+    }
+  }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
     item_scope = filter_by_category(item_scope) if filter_params[:category].present?
     item_scope = filter_by_query(item_scope) if filter_params[:query].present?
     item_scope = filter_by_available(item_scope) if filter_params[:available].present?
+    item_scope = filter_by_staff_approval_required(item_scope) if filter_params[:staff_approval_required].present?
 
     # One of the filtering methods above may have already redirected
     return if performed?
@@ -44,7 +45,7 @@ class ItemsController < ApplicationController
   private
 
   def filter_params
-    @filter_params ||= params.permit(:sort, :category, :query, :available).to_h.each_with_object({}) do |(k, v), filtered|
+    @filter_params ||= params.permit(:sort, :category, :query, :available, :staff_approval_required).to_h.each_with_object({}) do |(k, v), filtered|
       value = v&.to_s&.strip&.presence
 
       next unless value
@@ -90,6 +91,10 @@ class ItemsController < ApplicationController
 
   def filter_by_available(item_scope)
     item_scope.available_now
+  end
+
+  def filter_by_staff_approval_required(item_scope)
+    item_scope.where(borrow_policy: BorrowPolicy.where(requires_approval: true))
   end
 
   def filter_failed(failed_param, error_message)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,6 +7,10 @@
     <div class="categories" data-collapse-target="content">
       <h5>Categories</h5>
       <%= category_tree_nav(@categories, @category) %>
+      <div class="staff-approval-required-link-container">
+        <%= link_to "Staff Approval Required", add_filter_param(:staff_approval_required, true),
+              class: @filter_params[:staff_approval_required] ? "text-bold" : "" %>
+      </div>
     </div>
   </div>
 
@@ -38,9 +42,19 @@
               <span class="chip">
                 <%= @category.name %>
                 <%= link_to "", items_path(params: @filter_params.except(:category)), class: "btn btn-clear",
-                      "aria-label": "Clear filter", role: "button", title: "Clear query filter" %>
+                      "aria-label": "Clear category filter", role: "button", title: "Clear category filter" %>
               </span>
             <% end %>
+          </div>
+        <% end %>
+
+        <% if @filter_params[:staff_approval_required] %>
+          <div>
+            <span class="chip">
+              Staff Approval Required
+              <%= link_to "", items_path(params: @filter_params.except(:staff_approval_required)), class: "btn btn-clear",
+                    "aria-label": "Clear staff approval required filter", role: "button", title: "Clear staff approval required filter" %>
+            </span>
           </div>
         <% end %>
 


### PR DESCRIPTION
# What it does

Adds a "Staff Approval Required" link below the categories when searching for items.

# Why it is important

#1978 

# UI Change Screenshot

With the filter inactive:
<img width="1009" height="697" alt="Screenshot 2025-08-16 at 12 26 51 PM" src="https://github.com/user-attachments/assets/26ee917c-7b8e-46cb-806a-3ac1d26cdc5f" />


With the filter active:
<img width="1011" height="688" alt="Screenshot 2025-08-16 at 12 27 00 PM" src="https://github.com/user-attachments/assets/9f7e5658-844a-4d99-ba04-b0811be453de" />

# Implementation notes

The url path looks like `/items?query=miter+saw&staff_approval_required=true` when active. If someone were to type in `false` instead of `true` the filter would still be active since it's based on the presence of the filter and not it's actual value. I don't think that's really an issue but figured I'd call it out.
