### PR TITLE
Added borrow policy approval statuses to the member profile page and added the ability to request approval

### DIFF
--- a/app/controllers/account/borrow_policy_approvals_controller.rb
+++ b/app/controllers/account/borrow_policy_approvals_controller.rb
@@ -8,7 +8,7 @@ module Account
         member: current_user.member
       )
 
-      redirect_to item_path(params[:item_id]), status: :see_other, success: "Approval requested."
+      redirect_to request.referrer.presence || root_path, status: :see_other, success: "Approval requested."
     end
   end
 end

--- a/app/controllers/account/members_controller.rb
+++ b/app/controllers/account/members_controller.rb
@@ -2,6 +2,7 @@ module Account
   class MembersController < BaseController
     def show
       @member = current_member
+      load_borrow_policies_and_approvals
     end
 
     def agreement
@@ -51,6 +52,21 @@ module Account
         :receive_newsletter,
         :volunteer_interest,
         pronouns: [])
+    end
+
+    def load_borrow_policies_and_approvals
+      @borrow_policies_and_approvals ||= begin
+        borrow_policies = BorrowPolicy.where(requires_approval: true).order(:code)
+        borrow_policy_approvals = current_member.borrow_policy_approvals
+
+        borrow_policy_approvals_by_borrow_policy_id = borrow_policy_approvals.each_with_object({}) do |approval, approvals|
+          approvals[approval.borrow_policy_id] = approval
+        end
+
+        borrow_policies.each_with_object({}) do |borrow_policy, borrow_policies_and_approvals|
+          borrow_policies_and_approvals[borrow_policy] = borrow_policy_approvals_by_borrow_policy_id[borrow_policy.id]
+        end
+      end
     end
   end
 end

--- a/app/views/account/members/show.html.erb
+++ b/app/views/account/members/show.html.erb
@@ -82,6 +82,18 @@
           <i class="form-icon"></i>I am interested in volunteering with the library
         <% end %>
       </dd>
+
+      <% @borrow_policies_and_approvals.each do |borrow_policy, approval| %>
+        <dt><%= borrow_policy.code %>-Tools:</dt>
+        <dd>
+          <% if approval.present? %>
+            <%= approval.status.capitalize %>
+          <% else %>
+            Never Requested
+            <%= button_to "Request approval", account_borrow_policy_approvals_path(borrow_policy_id: borrow_policy.id), class: "btn btn-secondary", remote: true, data: {disable_with: "Requesting..."} %>
+          <% end %>
+        </dd>
+      <% end %>
     </dl>
   </div>
 </div>

--- a/app/views/account/members/show.html.erb
+++ b/app/views/account/members/show.html.erb
@@ -87,7 +87,13 @@
         <dt><%= borrow_policy.code %>-Tools:</dt>
         <dd>
           <% if approval.present? %>
-            <%= approval.status.capitalize %>
+            <% if approval.rejected? %>
+              Not approved
+            <% elsif approval.revoked? %>
+              No longer approved
+            <% else %>
+              <%= approval.status.capitalize %>
+            <% end %>
           <% else %>
             Never Requested
             <%= button_to "Request approval", account_borrow_policy_approvals_path(borrow_policy_id: borrow_policy.id), class: "btn btn-secondary", remote: true, data: {disable_with: "Requesting..."} %>

--- a/test/controllers/account/borrow_policy_approvals_controller_test.rb
+++ b/test/controllers/account/borrow_policy_approvals_controller_test.rb
@@ -17,8 +17,6 @@ module Account
         post account_borrow_policy_approvals_url, params: {item_id: @item.id, borrow_policy_id: @borrow_policy.id}
       end
 
-      assert_redirected_to item_url(@item.id)
-
       borrow_policy_approval = BorrowPolicyApproval.last!
       assert_equal @member, borrow_policy_approval.member
       assert_equal @borrow_policy, borrow_policy_approval.borrow_policy
@@ -33,8 +31,6 @@ module Account
       assert_difference("BorrowPolicyApproval.count", 0) do
         post account_borrow_policy_approvals_url, params: {item_id: @item.id, borrow_policy_id: @borrow_policy.id}
       end
-
-      assert_redirected_to item_url(@item.id)
 
       assert flash[:success].present?
       assert flash[:error].blank?

--- a/test/system/member_profile_test.rb
+++ b/test/system/member_profile_test.rb
@@ -7,11 +7,55 @@ class MemberProfileTest < ApplicationSystemTestCase
     login_as @user
   end
 
+  def borrow_policy_code_name(borrow_policy)
+    "#{borrow_policy.code}-Tools"
+  end
+
   test "member can view profile" do
     visit account_member_url
 
     assert_content @member.full_name
     assert_content @member.number
+  end
+
+  test "a member can see their approval statuses for borrow policies that require approval" do
+    no_approval_borrow_policy = create(:borrow_policy, requires_approval: false)
+    requires_approval_borrow_policy = create(:borrow_policy, :requires_approval)
+
+    approved = create(:borrow_policy_approval, :approved, member: @member)
+    rejected = create(:borrow_policy_approval, :rejected, member: @member)
+    requested = create(:borrow_policy_approval, :requested, member: @member)
+    revoked = create(:borrow_policy_approval, :revoked, member: @member)
+
+    visit account_member_url
+
+    refute_content borrow_policy_code_name(no_approval_borrow_policy)
+    assert_content(/#{borrow_policy_code_name(approved.borrow_policy)}:\s+Approved/)
+    assert_content(/#{borrow_policy_code_name(rejected.borrow_policy)}:\s+Rejected/)
+    assert_content(/#{borrow_policy_code_name(requested.borrow_policy)}:\s+Requested/)
+    assert_content(/#{borrow_policy_code_name(revoked.borrow_policy)}:\s+Revoked/)
+    assert_content(/#{borrow_policy_code_name(requires_approval_borrow_policy)}:\s+Never Requested/)
+  end
+
+  test "a member can request approval for a borrow policy" do
+    borrow_policy = create(:borrow_policy, :requires_approval)
+
+    visit account_member_url
+
+    assert_content(/#{borrow_policy_code_name(borrow_policy)}:\s+Never Requested/)
+
+    assert_difference("BorrowPolicyApproval.count", 1) do
+      click_on "Request approval"
+      assert_text "Approval requested."
+      assert_content(/#{borrow_policy_code_name(borrow_policy)}:\s+Requested/)
+      refute_text "Request approval"
+    end
+
+    borrow_policy_approval = BorrowPolicyApproval.first!
+
+    assert_equal borrow_policy, borrow_policy_approval.borrow_policy
+    assert_equal @member, borrow_policy_approval.member
+    assert_equal "requested", borrow_policy_approval.status
   end
 
   test "member can edit profile" do

--- a/test/system/member_profile_test.rb
+++ b/test/system/member_profile_test.rb
@@ -31,9 +31,9 @@ class MemberProfileTest < ApplicationSystemTestCase
 
     refute_content borrow_policy_code_name(no_approval_borrow_policy)
     assert_content(/#{borrow_policy_code_name(approved.borrow_policy)}:\s+Approved/)
-    assert_content(/#{borrow_policy_code_name(rejected.borrow_policy)}:\s+Rejected/)
+    assert_content(/#{borrow_policy_code_name(rejected.borrow_policy)}:\s+Not approved/)
     assert_content(/#{borrow_policy_code_name(requested.borrow_policy)}:\s+Requested/)
-    assert_content(/#{borrow_policy_code_name(revoked.borrow_policy)}:\s+Revoked/)
+    assert_content(/#{borrow_policy_code_name(revoked.borrow_policy)}:\s+No longer approved/)
     assert_content(/#{borrow_policy_code_name(requires_approval_borrow_policy)}:\s+Never Requested/)
   end
 


### PR DESCRIPTION
# What it does

Adds the approval statuses for all borrow policies that require approval to the member's profile page and provides a button for them to request approval if they haven't previously.

# Why it is important

#1984 

# UI Change Screenshot

When no approval request exists:
<img width="991" height="742" alt="Screenshot 2025-08-16 at 1 18 13 PM" src="https://github.com/user-attachments/assets/f0ebcfb2-6b77-41b9-91e2-b6ed40c60a9b" />

Requested:
<img width="990" height="787" alt="Screenshot 2025-08-16 at 1 14 54 PM" src="https://github.com/user-attachments/assets/5dbcd202-7766-40db-8f74-31c7ca2ffcde" />

Revoked:
<img width="1003" height="734" alt="Screenshot 2025-08-16 at 1 16 26 PM" src="https://github.com/user-attachments/assets/2de7e32d-805a-4e34-bbb4-db893d35dd66" />

Rejected:
<img width="1012" height="730" alt="Screenshot 2025-08-16 at 1 16 07 PM" src="https://github.com/user-attachments/assets/2ba3f6c7-2b2f-4f45-b438-fea4796d292d" />

Approved:
<img width="1027" height="734" alt="Screenshot 2025-08-16 at 1 15 45 PM" src="https://github.com/user-attachments/assets/1f96a345-f74b-4508-a46f-c50bed9b3766" />


# Implementation notes

I accidentally committed and pushed this straight to `main`, reverted that, and now this is reverting the revert commit 😅 

I removed a couple of assertions around where requesting approval redirects to since now it will just redirect to the referrer (or root if there is not referrer).
