### PR TITLE
Librarians should be able to grant access to C-Tools even when the member hasn't requested it

### DIFF
--- a/app/controllers/admin/borrow_policy_approvals_controller.rb
+++ b/app/controllers/admin/borrow_policy_approvals_controller.rb
@@ -21,6 +21,17 @@ module Admin
       redirect_to admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), status: :see_other, success: "Successfully updated Borrow Policy Approval"
     end
 
+    def create
+      @borrow_policy_approval = @borrow_policy.borrow_policy_approvals.create!(
+        status: "approved",
+        member_id: params[:member_id]
+      )
+      send_status_change_email
+      redirect_to request.referrer.presence || admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy),
+        status: :see_other,
+        success: "Successfully approved member to borrow #{@borrow_policy.name} items"
+    end
+
     private
 
     def send_status_change_email

--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -65,12 +65,24 @@
 
     <h6>Borrow Policy Approvals</h6>
     <ul class="member-stats">
-      <% member.borrow_policy_approvals.each do |borrow_policy_approval| %>
-        <li>
-          <%= link_to edit_admin_borrow_policy_borrow_policy_approval_path(borrow_policy_approval.borrow_policy, borrow_policy_approval) do %>
-            <%= borrow_policy_approval.borrow_policy.name %>: <%= borrow_policy_approval.status.capitalize %>
-          <% end %>
-        </li>
+      <% BorrowPolicy.where(requires_approval: true).order(:name).each do |borrow_policy| %>
+        <% borrow_policy_approval = member.borrow_policy_approvals.to_a.find { |approval| approval.borrow_policy_id == borrow_policy.id } %>
+        <% if borrow_policy_approval.present? %>
+          <li>
+            <%= link_to edit_admin_borrow_policy_borrow_policy_approval_path(borrow_policy_approval.borrow_policy, borrow_policy_approval) do %>
+              <%= borrow_policy_approval.borrow_policy.name %>: <%= borrow_policy_approval.status.capitalize %>
+            <% end %>
+          </li>
+        <% else %>
+          <li>
+            <%= button_to "Approve for #{borrow_policy.name}",
+                  admin_borrow_policy_borrow_policy_approvals_path(borrow_policy),
+                  class: "btn",
+                  params: {member_id: member.id},
+                  method: :post,
+                  form: {data: {"turbo-confirm" => "Are you sure?"}} %>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
     resources :organization_members, only: [:show, :edit, :update, :destroy]
     resources :documents, only: [:show, :edit, :update, :index]
     resources :borrow_policies, only: [:index, :edit, :update, :show] do
-      resources :borrow_policy_approvals, only: [:index, :edit, :update], path: :approvals
+      resources :borrow_policy_approvals, only: [:index, :edit, :update, :create], path: :approvals
     end
     resources :categories, except: :show
     resources :gift_memberships

--- a/test/controllers/admin/borrow_policy_approvals_controller_test.rb
+++ b/test/controllers/admin/borrow_policy_approvals_controller_test.rb
@@ -12,6 +12,31 @@ module Admin
       sign_in @user
     end
 
+    test "create creates a borrow policy approval that's approved" do
+      BorrowPolicyApproval.delete_all
+      assert_difference("BorrowPolicyApproval.count", 1) {
+        post admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), params: {member_id: @member.id}
+      }
+
+      approval = BorrowPolicyApproval.first!
+
+      assert_equal @member, approval.member
+      assert_equal @borrow_policy, approval.borrow_policy
+      assert_equal "approved", approval.status
+    end
+
+    test "create sends an approval email" do
+      BorrowPolicyApproval.delete_all
+      assert_emails(1) do
+        post admin_borrow_policy_borrow_policy_approvals_path(@borrow_policy), params: {member_id: @member.id}
+      end
+
+      mail = ActionMailer::Base.deliveries.last
+
+      assert_equal [@member.email], mail.to
+      assert_includes mail.subject, "have been approved to borrow"
+    end
+
     test "update sends an email when updating to approved" do
       assert_emails(1) do
         patch(

--- a/test/system/admin/borrow_policies_test.rb
+++ b/test/system/admin/borrow_policies_test.rb
@@ -144,7 +144,7 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
 
   test "viewing a member's borrow policy approvals" do
     audited_as_admin do
-      create(:borrow_policy, requires_approval: true) # ignored
+      @borrow_policy_without_approval = create(:borrow_policy, requires_approval: true)
       @borrow_policies = create_list(:borrow_policy, 4, requires_approval: true)
     end
 
@@ -156,12 +156,15 @@ class BorrowPoliciesTest < ApplicationSystemTestCase
 
     visit admin_member_path(member)
 
-    @borrow_policies.each do |borrow_policy|
-      assert_text borrow_policy.name
+    approvals.each do |approval|
+      assert_text "#{approval.borrow_policy.name}: #{approval.status.capitalize}"
     end
 
-    approvals.each do |approval|
-      assert_text approval.status.capitalize
-    end
+    assert_text "Approve for #{@borrow_policy_without_approval.name}"
+
+    accept_confirm { click_on "Approve for #{@borrow_policy_without_approval.name}" }
+
+    assert_text "Successfully approved member to borrow #{@borrow_policy_without_approval.name} items"
+    assert_text "#{@borrow_policy_without_approval.name}: Approved"
   end
 end


### PR DESCRIPTION
# What it does

Adds a button to the admin member show page that will approve a member to borrow tools under a borrow policy immediately.

# Why it is important

Requested by Tessa recently, captured in [#1999](https://github.com/chicago-tool-library/circulate/issues/1999)

# UI Change Screenshot

When a member hasn't requested approval:
<img width="1020" height="777" alt="Screenshot 2025-09-14 at 4 20 04 PM" src="https://github.com/user-attachments/assets/7a174fb3-6566-43db-a0ed-7d8754bc4572" />

After approving the member:
<img width="988" height="809" alt="Screenshot 2025-09-14 at 4 20 24 PM" src="https://github.com/user-attachments/assets/c585d713-06c2-4455-a3bd-74498c1c412c" />

# Implementation notes

It also sends an email to let the member know they've been approved