### PR TITLE
Revert square.rb version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "acts_as_list"
 gem "finite_machine"
 gem "ransack"
 
-gem "square.rb"
+gem "square.rb", "43.0.1.20250716"
 gem "aws-sdk-s3", require: false
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     spy (1.0.5)
-    square.rb (44.0.0.20250820)
+    square.rb (43.0.1.20250716)
       apimatic_core (~> 0.3.11)
       apimatic_core_interfaces (~> 0.2.1)
       apimatic_faraday_client_adapter (~> 0.1.4)
@@ -659,7 +659,7 @@ DEPENDENCIES
   scenic
   sprockets-rails
   spy
-  square.rb
+  square.rb (= 43.0.1.20250716)
   standard
   standard-rails
   stimulus-rails


### PR DESCRIPTION
# What it does

Reverts square.rb to prevent errors

# Why it is important

An recent dependabot update bumped square.rb but this creates an [ArgumentError](https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/3286/samples/timestamp/2025-09-15T14:22:49Z) in our implementation.

