### PR TITLE
Limit C-tools per member across holds and loans

### DIFF
--- a/app/controllers/account/holds_controller.rb
+++ b/app/controllers/account/holds_controller.rb
@@ -1,5 +1,7 @@
 module Account
   class HoldsController < BaseController
+    LIMIT_MESSAGE_ITEM_COUNT = 5
+
     include Pagy::Backend
 
     def index
@@ -22,7 +24,12 @@ module Account
           @new_hold.start! if @new_hold.ready_for_pickup?
           redirect_to item_path(@item), success: "Hold placed.", status: :see_other
         else
-          redirect_to item_path(@item), error: "Something went wrong!", status: :see_other
+          error = if @new_hold.errors.of_kind?(:base, :maximum_items_per_member)
+            borrow_policy_limit_message(@new_hold)
+          else
+            @new_hold.errors.full_messages.to_sentence
+          end
+          redirect_to item_path(@item), error:, status: :see_other
         end
       end
     end
@@ -36,6 +43,29 @@ module Account
 
     def history
       @pagy, @holds = pagy(current_member.inactive_holds.recent_first.includes(:item))
+    end
+
+    private
+
+    def borrow_policy_limit_message(hold)
+      borrow_policy = hold.item.borrow_policy
+      tool_name = "#{borrow_policy.code}-Tool".pluralize(borrow_policy.maximum_items_per_member)
+      introduction = helpers.tag.p(
+        "You can have a maximum of #{borrow_policy.maximum_items_per_member} #{tool_name} checked out or on hold at one time. These items count toward your limit:"
+      )
+      counted_items = hold.existing_items_counted_toward_limit
+      items = counted_items.first(LIMIT_MESSAGE_ITEM_COUNT).map do |item_holder|
+        status = item_holder.is_a?(Loan) ? "checked out" : "on hold"
+        helpers.tag.li do
+          item_name = helpers.truncate(item_holder.item.complete_number_and_name, length: 100)
+          helpers.link_to(item_name, item_path(item_holder.item)) + " (#{status})"
+        end
+      end
+      remaining_item_count = counted_items.size - items.size
+      items << helpers.tag.li("and #{remaining_item_count} more") if remaining_item_count.positive?
+      next_step = helpers.tag.p("Return or cancel one before placing another hold.")
+
+      helpers.safe_join([introduction, helpers.tag.ul(helpers.safe_join(items)), next_step])
     end
   end
 end

--- a/app/controllers/admin/borrow_policies_controller.rb
+++ b/app/controllers/admin/borrow_policies_controller.rb
@@ -27,7 +27,7 @@ module Admin
     end
 
     def borrow_policy_params
-      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit, :member_renewable, :consumable, :rules, :requires_approval)
+      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit, :member_renewable, :consumable, :rules, :requires_approval, :maximum_items_per_member)
     end
   end
 end

--- a/app/models/borrow_policy.rb
+++ b/app/models/borrow_policy.rb
@@ -14,6 +14,8 @@ class BorrowPolicy < ApplicationRecord
     numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100}
   validates :renewal_limit,
     numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 52}
+  validates :maximum_items_per_member,
+    numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :code, inclusion: {in: "A".."ZZ", message: "must be 1 or 2 letters from A to ZZ"}, uniqueness: {scope: :library_id}
 
   validate :require_consumables_to_not_be_uniquely_numbered
@@ -35,6 +37,10 @@ class BorrowPolicy < ApplicationRecord
 
   def complete_name
     "#{name} (#{code})"
+  end
+
+  def limit_items_per_member?
+    maximum_items_per_member.positive?
   end
 
   def allow_multiple_holds_per_member?

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -31,7 +31,7 @@ class Hold < ApplicationRecord
     message: "is required when started_at is set"
   }, if: :started_at?
 
-  validate :ensure_items_are_holdable, on: :create
+  validate :ensure_items_are_holdable, :ensure_member_is_within_borrow_policy_limit, on: :create
 
   acts_as_tenant :library
 
@@ -121,6 +121,25 @@ class Hold < ApplicationRecord
     Hold.active.started.where(expires_at: ...date).update_all(expires_at: date)
   end
 
+  def existing_items_counted_toward_limit
+    return [] unless item && member
+
+    @existing_items_counted_toward_limit ||= begin
+      borrow_policy_id = item.borrow_policy_id
+      holds = member.active_holds
+        .joins(:item)
+        .where(items: {borrow_policy_id:})
+        .includes(item: :borrow_policy)
+      loans = member.loans
+        .checked_out
+        .joins(:item)
+        .where(items: {borrow_policy_id:})
+        .includes(item: :borrow_policy)
+
+      holds.to_a + loans.to_a
+    end
+  end
+
   def self.start_waiting_holds(now = Time.current, &block)
     started = 0
 
@@ -156,6 +175,25 @@ class Hold < ApplicationRecord
 
     unless borrow_policy_approval&.approved?
       errors.add(:borrow_policy, "requires approval")
+    end
+  end
+
+  def ensure_member_is_within_borrow_policy_limit
+    return unless item && member && creator
+    return if creator.has_role?(:staff)
+
+    borrow_policy = item.borrow_policy
+    return unless borrow_policy.limit_items_per_member?
+
+    member.lock!
+
+    if existing_items_counted_toward_limit.size >= borrow_policy.maximum_items_per_member
+      tool_name = "#{borrow_policy.code}-Tool".pluralize(borrow_policy.maximum_items_per_member)
+      errors.add(
+        :base,
+        :maximum_items_per_member,
+        message: "You can have a maximum of #{borrow_policy.maximum_items_per_member} #{tool_name} checked out or on hold at one time."
+      )
     end
   end
 end

--- a/app/nulls/null_borrow_policy.rb
+++ b/app/nulls/null_borrow_policy.rb
@@ -1,4 +1,12 @@
 class NullBorrowPolicy
+  def maximum_items_per_member
+    0
+  end
+
+  def limit_items_per_member?
+    false
+  end
+
   def renewal_limit
     0
   end

--- a/app/views/admin/borrow_policies/_form.html.erb
+++ b/app/views/admin/borrow_policies/_form.html.erb
@@ -6,6 +6,7 @@
   <%= form.text_area :description, hint: "What tools is this policy intended for?" %>
   <%= form.text_field :duration, label: "Loan length", hint: "How long can an item be kept when loaned?" %>
   <%= form.text_field :renewal_limit, hint: "How many times can an item be renewed?" %>
+  <%= form.number_field :maximum_items_per_member, min: 0, hint: "Maximum number a member may have checked out or on hold at one time. Use 0 for no limit." %>
   <%= form.money_field :fine, value: borrow_policy.fine || 0, hint: "Per fine period (see next field)" %>
   <%= form.text_field :fine_period, hint: "Days that pass before assigning the fine; 1 is every day after something is late, 7 is every week, etc." %>
   <%= form.check_box :uniquely_numbered, hint: "Is each item with this policy given a unique identification number?" %>

--- a/app/views/admin/borrow_policies/show.html.erb
+++ b/app/views/admin/borrow_policies/show.html.erb
@@ -31,6 +31,9 @@
 
           <dt>Requires Approval</dt>
           <dd><%= @borrow_policy.requires_approval %></dd>
+
+          <dt>Maximum Items Per Member</dt>
+          <dd><%= @borrow_policy.maximum_items_per_member.zero? ? "Unlimited" : @borrow_policy.maximum_items_per_member %></dd>
         </dl>
       </div>
     </div>

--- a/db/migrate/20260813000000_add_maximum_items_per_member_to_borrow_policies.rb
+++ b/db/migrate/20260813000000_add_maximum_items_per_member_to_borrow_policies.rb
@@ -1,0 +1,15 @@
+class AddMaximumItemsPerMemberToBorrowPolicies < ActiveRecord::Migration[8.0]
+  def up
+    add_column :borrow_policies, :maximum_items_per_member, :integer, null: false, default: 0
+
+    execute <<~SQL
+      UPDATE borrow_policies
+      SET maximum_items_per_member = 2
+      WHERE code = 'C'
+    SQL
+  end
+
+  def down
+    remove_column :borrow_policies, :maximum_items_per_member
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_150504) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -265,6 +265,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_150504) do
     t.string "fine_currency", default: "USD", null: false
     t.integer "fine_period", default: 1, null: false
     t.integer "library_id"
+    t.integer "maximum_items_per_member", default: 0, null: false
     t.boolean "member_renewable", default: false, null: false
     t.string "name", null: false
     t.integer "renewal_limit", default: 0, null: false

--- a/test/controllers/account/holds_controller_test.rb
+++ b/test/controllers/account/holds_controller_test.rb
@@ -44,5 +44,48 @@ module Account
       assert_redirected_to item_url(@item.id)
       assert_equal "Can't be placed on hold", flash[:error]
     end
+
+    test "explains when the member has reached the borrow policy limit" do
+      borrow_policy = create(:borrow_policy, maximum_items_per_member: 2)
+      @item.update!(borrow_policy:)
+      checked_out_item = create(:item, borrow_policy:, name: "Cordless Drill")
+      held_item = create(:item, borrow_policy:, name: "Folding Table")
+      create(:loan, member: @member, item: checked_out_item)
+      create(:hold, member: @member, creator: @user, item: held_item)
+
+      assert_no_difference("@item.holds.count") do
+        post account_holds_url, params: {item_id: @item.id}
+      end
+
+      assert_redirected_to item_url(@item.id)
+      follow_redirect!
+
+      assert_select ".toast-error", /You can have a maximum of 2 #{borrow_policy.code}-Tools checked out or on hold at one time\./
+      assert_select ".toast-error ul li", 2
+      assert_select ".toast-error a[href=?]", item_path(checked_out_item), text: /#{checked_out_item.complete_number}.*Cordless Drill/
+      assert_select ".toast-error a[href=?]", item_path(held_item), text: /#{held_item.complete_number}.*Folding Table/
+      assert_select ".toast-error li", /checked out/
+      assert_select ".toast-error li", /on hold/
+      assert_select ".toast-error", /Return or cancel one before placing another hold/
+    end
+
+    test "limits the items listed in the borrow policy limit message" do
+      borrow_policy = create(:borrow_policy, maximum_items_per_member: 1)
+      @item.update!(borrow_policy:)
+      staff = create(:staff_user)
+      7.times do
+        create(:hold, member: @member, creator: staff, item: create(:item, borrow_policy:))
+      end
+
+      assert_no_difference("@item.holds.count") do
+        post account_holds_url, params: {item_id: @item.id}
+      end
+
+      follow_redirect!
+
+      assert_select ".toast-error ul li a", 5
+      assert_select ".toast-error ul li", 6
+      assert_select ".toast-error ul li:last-child", text: "and 2 more"
+    end
   end
 end

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -30,7 +30,7 @@ module Admin
 
     test "should update borrow_policy" do
       @borrow_policy = create(:default_borrow_policy)
-      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true, requires_approval: true}}
+      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true, requires_approval: true, maximum_items_per_member: 2}}
 
       @borrow_policy.reload
       assert_equal 10, @borrow_policy.duration
@@ -40,6 +40,7 @@ module Admin
       assert_equal "Q", @borrow_policy.code
       assert_equal true, @borrow_policy.member_renewable
       assert_equal true, @borrow_policy.requires_approval
+      assert_equal 2, @borrow_policy.maximum_items_per_member
     end
   end
 end

--- a/test/controllers/admin/members/holds_controller_test.rb
+++ b/test/controllers/admin/members/holds_controller_test.rb
@@ -69,6 +69,17 @@ module Admin
         assert_redirected_to admin_member_holds_url(member, anchor: "checkout")
         assert_equal "Holds are disabled for this item", flash[:checkout_error]
       end
+
+      test "places a hold beyond the member's borrow policy limit" do
+        member = create(:verified_member)
+        borrow_policy = create(:borrow_policy, maximum_items_per_member: 1)
+        create(:loan, member:, item: create(:item, borrow_policy:))
+        item = create(:item, borrow_policy:)
+
+        assert_difference("member.holds.active.count") do
+          post admin_member_holds_url(member), params: {hold: {item_id: item.id}}
+        end
+      end
     end
   end
 end

--- a/test/factories/borrow_policies.rb
+++ b/test/factories/borrow_policies.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     fine_currency { "USD" }
     fine_period { 1 }
     renewal_limit { 2 }
+    maximum_items_per_member { 0 }
     description { "What this policy is used for" }
     uniquely_numbered { true }
     member_renewable { false }

--- a/test/models/borrow_policy_test.rb
+++ b/test/models/borrow_policy_test.rb
@@ -25,6 +25,18 @@ class BorrowPolicyTest < ActiveSupport::TestCase
     refute old_policy.reload.default
   end
 
+  test "limits items per member only when maximum_items_per_member is positive" do
+    refute BorrowPolicy.new(maximum_items_per_member: 0).limit_items_per_member?
+    assert BorrowPolicy.new(maximum_items_per_member: 2).limit_items_per_member?
+  end
+
+  test "maximum_items_per_member cannot be negative" do
+    policy = build(:borrow_policy, maximum_items_per_member: -1)
+
+    refute policy.valid?
+    assert_equal ["must be greater than or equal to 0"], policy.errors[:maximum_items_per_member]
+  end
+
   test "allow_multiple_holds_per_member? is true when uniquely_numbered is false" do
     policy = BorrowPolicy.new(uniquely_numbered: false)
 

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -1,6 +1,60 @@
 require "test_helper"
 
 class HoldTest < ActiveSupport::TestCase
+  test "a member cannot exceed a borrow policy's combined hold and loan limit" do
+    member = create(:verified_member, :with_user)
+    borrow_policy = create(:borrow_policy, maximum_items_per_member: 2)
+    create(:hold, member:, creator: member.user, item: create(:item, borrow_policy:))
+    create(:loan, member:, item: create(:item, borrow_policy:))
+
+    hold = build(:hold, member:, creator: member.user, item: create(:item, borrow_policy:))
+
+    refute hold.save
+    assert_equal ["You can have a maximum of 2 #{borrow_policy.code}-Tools checked out or on hold at one time."], hold.errors[:base]
+    assert hold.errors.of_kind?(:base, :maximum_items_per_member)
+    assert_equal 2, hold.existing_items_counted_toward_limit.size
+  end
+
+  test "locks the member before counting items toward the limit" do
+    member = create(:verified_member, :with_user)
+    borrow_policy = create(:borrow_policy, maximum_items_per_member: 1)
+    hold = build(:hold, member:, creator: member.user, item: create(:item, borrow_policy:))
+    member_locked = false
+
+    member.stub(:lock!, -> { member_locked = true }) do
+      assert hold.save
+    end
+
+    assert member_locked
+  end
+
+  test "inactive holds and returned loans do not count toward the limit" do
+    member = create(:verified_member, :with_user)
+    borrow_policy = create(:borrow_policy, maximum_items_per_member: 2)
+    create(:ended_hold, member:, creator: member.user, item: create(:item, borrow_policy:))
+    create(:ended_loan, member:, item: create(:item, borrow_policy:))
+
+    assert build(:hold, member:, creator: member.user, item: create(:item, borrow_policy:)).save
+  end
+
+  test "items governed by other borrow policies do not count toward the limit" do
+    member = create(:verified_member, :with_user)
+    limited_policy = create(:borrow_policy, maximum_items_per_member: 1)
+    other_policy = create(:borrow_policy, maximum_items_per_member: 1)
+    create(:hold, member:, creator: member.user, item: create(:item, borrow_policy: other_policy))
+
+    assert build(:hold, member:, creator: member.user, item: create(:item, borrow_policy: limited_policy)).save
+  end
+
+  test "staff can create a hold beyond the member's limit" do
+    member = create(:verified_member)
+    staff = create(:staff_user)
+    borrow_policy = create(:borrow_policy, maximum_items_per_member: 1)
+    create(:loan, member:, item: create(:item, borrow_policy:))
+
+    assert build(:hold, member:, creator: staff, item: create(:item, borrow_policy:)).save
+  end
+
   test "#upcoming_appointment should call its member.upcoming_appointment_of with itself" do
     member_double = Minitest::Mock.new
     hold = create(:hold)

--- a/test/nulls/null_borrow_policy_test.rb
+++ b/test/nulls/null_borrow_policy_test.rb
@@ -7,5 +7,7 @@ class NullBorrowPolicyTest < ActiveSupport::TestCase
 
   test "borrow policy API" do
     assert_equal false, @policy.member_renewable?
+    assert_equal 0, @policy.maximum_items_per_member
+    refute @policy.limit_items_per_member?
   end
 end


### PR DESCRIPTION
# What it does

Limits members to two C-tools total across active holds and checked-out loans. When someone reaches the limit, the blocked hold message links to the C-tools currently counting toward it and says whether each one is checked out or on hold.

The limit is configurable per borrow policy, with `0` meaning unlimited. This migration sets C-tools to 2 and leaves other policies unlimited. Librarian-created holds remain exempt for special cases.

# Why it is important

Members could reserve more C-tools than the lending policy allows, then only find out when librarians reviewed the day's orders. Enforcing the simple “2 C-tools at a time” rule when a member places a hold prevents that surprise without adding a second appointment-level rule.

Closes #1850.

# UI Change Screenshot

<img width="1440" height="1100" alt="c-tool-hold-limit-updated" src="https://github.com/user-attachments/assets/a3476588-0099-44a0-a569-5c52e0db86cf" />


# Implementation notes

The validation counts active holds and checked-out loans using the item's borrow policy. Returned loans, inactive holds, and items under other policies do not count. Renewals keep the same loan in place and do not change the total.

Member hold creation locks the member row while checking the limit, so simultaneous requests cannot both slip through. The flash lists at most five items and summarizes any remainder to keep the cookie-backed session bounded.

Staff bypass is based on the hold creator's role, so holds placed through the librarian workflow can exceed the configured limit.
