### PR TITLE
Added days until due labels to item show and index pages

### DIFF
--- a/app/assets/stylesheets/application_styles.scss
+++ b/app/assets/stylesheets/application_styles.scss
@@ -517,7 +517,8 @@ $min-width: variables.$size-md + 1;
 }
 
 .item-borrow-policy,
-.item-checkout-status {
+.item-checkout-status,
+.item-days-until-due {
   font-size: 0.8em;
   position: relative;
   top: -1px;

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -203,6 +203,19 @@ module ItemsHelper
     tag.span label, class: "label item-checkout-status #{class_name}"
   end
 
+  def days_until_due_label(item)
+    return unless show_days_until_due?(item)
+
+    days = (item.due_on - Time.zone.today).to_i
+    text = case days
+    when 0 then "Due today"
+    when 1 then "Due tomorrow"
+    else "Due in #{pluralize(days, "day")}"
+    end
+
+    tag.span text, class: "label item-days-until-due"
+  end
+
   def item_holds_label(item)
     if item.active?
       count = item.active_holds.size
@@ -237,5 +250,14 @@ module ItemsHelper
 
   def add_filter_param(param, value)
     (filter_params || {}).merge(param => value).sort.to_h
+  end
+
+  private
+
+  def show_days_until_due?(item)
+    item.checked_out_exclusive_loan.present? &&
+      item.holdable? &&
+      item.active_holds.empty? &&
+      !item.overdue?
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -104,6 +104,7 @@
                 <%= tag.div class: "item-info" do %>
                   <strong><%= link_to item.name, item_path(item, search_result_index: index), class: "item-name", id: "item-name-#{item.id}" %></strong>
                   <%= item_status_label(item) %>
+                  <%= days_until_due_label(item) %>
                   <% if item.borrow_policy.requires_approval? %>
                     <span class="label label-secondary item-borrow-policy"><%= item.borrow_policy.code %>-Tool</span>
                   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,6 +18,7 @@
   <h2>
     <strong><%= @item.complete_number %></strong>
     <%= item_status_label(@item) %>
+    <%= days_until_due_label(@item) %>
     <% if @item.active_holds.any? %>
       <span class="text-small"><%= pluralize @item.active_holds.count, "hold" %></span>
     <% end %>

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -157,6 +157,76 @@ class ItemsHelperTest < ActionView::TestCase
     end
   end
 
+  class DaysUntilDueLabelTest < ItemsHelperTest
+    def check_out(item, due_at:)
+      create(:loan, :checked_out, :exclusive, item: item, due_at: due_at)
+      item.reload
+    end
+
+    setup do
+      travel_to Time.zone.local(2026, 8, 16, 10, 0, 0)
+    end
+
+    test "it counts the days until an item is due" do
+      item = create(:item)
+      check_out(item, due_at: 3.days.from_now)
+
+      assert_dom_equal %(<span class="label item-days-until-due">Due in 3 days</span>), days_until_due_label(item)
+    end
+
+    test "it says tomorrow for an item due in one day" do
+      item = create(:item)
+      check_out(item, due_at: 1.day.from_now)
+
+      assert_dom_equal %(<span class="label item-days-until-due">Due tomorrow</span>), days_until_due_label(item)
+    end
+
+    test "it says today for an item due today" do
+      item = create(:item)
+      check_out(item, due_at: Time.zone.now.end_of_day)
+
+      assert_dom_equal %(<span class="label item-days-until-due">Due today</span>), days_until_due_label(item)
+    end
+
+    test "it is nothing for an item that isn't checked out" do
+      assert_nil days_until_due_label(create(:item))
+    end
+
+    test "it is nothing for an overdue item" do
+      item = create(:item)
+      create(:overdue_loan, item: item)
+      item.reload
+
+      assert_nil days_until_due_label(item)
+    end
+
+    test "it is nothing for an item with an active hold" do
+      item = create(:item)
+      check_out(item, due_at: 3.days.from_now)
+      create(:hold, :active, item: item)
+      item.reload
+
+      assert_nil days_until_due_label(item)
+    end
+
+    test "it is nothing for an item that can't be held" do
+      item = create(:item, holds_enabled: false)
+      check_out(item, due_at: 3.days.from_now)
+
+      assert_nil days_until_due_label(item)
+    end
+
+    [:maintenance, :retired, :pending, :missing].each do |status|
+      test "it is nothing for an item with status #{status}" do
+        item = create(:item)
+        check_out(item, due_at: 3.days.from_now)
+        item.update_columns(status: Item.statuses[status])
+
+        assert_nil days_until_due_label(item.reload)
+      end
+    end
+  end
+
   class ItemStatusOptionsTest < ItemsHelperTest
     test "it is all item statuses and descriptions" do
       assert_includes item_status_options, ["Pending (just acquired; not ready to loan)", "pending"]

--- a/test/system/item_due_date_test.rb
+++ b/test/system/item_due_date_test.rb
@@ -1,0 +1,52 @@
+require "application_system_test_case"
+
+class ItemDueDateTest < ApplicationSystemTestCase
+  def setup
+    @due_soon = create(:item, name: "Due Soon Drill")
+    create(:loan, :checked_out, :exclusive, item: @due_soon, due_at: 3.days.from_now)
+
+    @on_hold = create(:item, name: "Spoken For Sander")
+    create(:loan, :checked_out, :exclusive, item: @on_hold, due_at: 3.days.from_now)
+    create(:hold, :active, item: @on_hold)
+
+    @overdue = create(:item, name: "Tardy Tablesaw")
+    create(:overdue_loan, item: @overdue)
+  end
+
+  test "the item list shows the days until a checked out item is due" do
+    visit items_url
+
+    within("#item-#{@due_soon.id}") do
+      assert_content "Checked Out"
+      assert_content "Due in 3 days"
+    end
+  end
+
+  test "the item list hides the countdown for items with holds or that are overdue" do
+    visit items_url
+
+    within("#item-#{@on_hold.id}") do
+      assert_content "1 hold"
+      refute_content "Due in"
+    end
+
+    within("#item-#{@overdue.id}") do
+      assert_content "Overdue"
+      refute_content "Due in"
+    end
+  end
+
+  test "the item show page shows the days until the item is due" do
+    visit item_url(@due_soon)
+
+    assert_content "Due in 3 days"
+  end
+
+  test "the item show page hides the countdown for items with holds or that are overdue" do
+    visit item_url(@on_hold)
+    refute_content "Due in"
+
+    visit item_url(@overdue)
+    refute_content "Due in"
+  end
+end


### PR DESCRIPTION
# What it does

This adds labels that let users know how long until an item is due.

# Why it is important

This will help folks plan their borrowing.

# UI Change Screenshot

index page:
<img width="1045" height="812" alt="index page" src="https://github.com/user-attachments/assets/6d059d91-5d41-4637-8a24-5e586d58ce5f" />

show page with the label:
<img width="605" height="366" alt="due today" src="https://github.com/user-attachments/assets/ed077701-94fc-42f4-b28f-8e4b7dc000be" />
<img width="519" height="260" alt="due tomorrow" src="https://github.com/user-attachments/assets/c6fedfea-3a31-4eb2-a494-74018a33390b" />
<img width="565" height="387" alt="due in 3 days" src="https://github.com/user-attachments/assets/cbeb53ce-0ae4-43b3-a9a9-5163ef09d9fc" />
<img width="551" height="326" alt="due in 7 days" src="https://github.com/user-attachments/assets/eacad3fb-154f-4a2c-b1d3-5d5c9f982261" />

show page without the label: 
<img width="582" height="422" alt="available" src="https://github.com/user-attachments/assets/3cee8d7f-db43-46e9-b4db-4f2b1d1e6406" />




# Implementation notes

Feedback is always appreciated!
