### PR TITLE
Fix timezone-dependent appointment notification tests

### DIFF
--- a/test/system/admin/appointments_notifications_test.rb
+++ b/test/system/admin/appointments_notifications_test.rb
@@ -40,35 +40,39 @@ module Admin
     end
 
     test "a pulled appointment and its late-added items are highlighted in the schedule" do
-      appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
-      appointment.appointment_holds.update_all(created_at: 3.minutes.ago)
-      appointment.update_column(:pulled_at, 2.minutes.ago)
-      late_hold = create(:hold, item: create(:item, name: "Circular Saw"))
-      create(:appointment_hold, appointment: appointment, hold: late_hold, created_at: Time.current)
-      original_pulled_at = appointment.pulled_at
+      Timecop.travel(Time.zone.today.at_noon) do
+        appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
+        appointment.appointment_holds.update_all(created_at: 3.minutes.ago)
+        appointment.update_column(:pulled_at, 2.minutes.ago)
+        late_hold = create(:hold, item: create(:item, name: "Circular Saw"))
+        create(:appointment_hold, appointment: appointment, hold: late_hold, created_at: Time.current)
+        original_pulled_at = appointment.pulled_at
 
-      visit admin_appointments_path(day: appointment.starts_at.to_date)
+        visit admin_appointments_path(day: appointment.starts_at.to_date)
 
-      within "tr.items-added-after-pull" do
-        assert_text "Circular Saw"
-        assert_selector ".label.label-error", text: "added after pull"
-        click_button "mark new items pulled"
+        within "tr.items-added-after-pull" do
+          assert_text "Circular Saw"
+          assert_selector ".label.label-error", text: "added after pull"
+          click_button "mark new items pulled"
+        end
+
+        refute_selector "tr.items-added-after-pull"
+        refute_selector ".label.label-error", text: "added after pull"
+        assert_operator appointment.reload.pulled_at, :>, original_pulled_at
       end
-
-      refute_selector "tr.items-added-after-pull"
-      refute_selector ".label.label-error", text: "added after pull"
-      assert_operator appointment.reload.pulled_at, :>, original_pulled_at
     end
 
     test "completed appointments with late-added items are not highlighted" do
-      appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
-      appointment.update_columns(pulled_at: Time.current, completed_at: Time.current)
-      create(:appointment_hold, appointment: appointment, created_at: 1.minute.from_now)
+      Timecop.travel(Time.zone.today.at_noon) do
+        appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
+        appointment.update_columns(pulled_at: Time.current, completed_at: Time.current)
+        create(:appointment_hold, appointment: appointment, created_at: 1.minute.from_now)
 
-      visit admin_appointments_path(day: appointment.starts_at.to_date)
+        visit admin_appointments_path(day: appointment.starts_at.to_date)
 
-      refute_selector "tr.items-added-after-pull"
-      refute_selector ".label.label-error", text: "added after pull"
+        refute_selector "tr.items-added-after-pull"
+        refute_selector ".label.label-error", text: "added after pull"
+      end
     end
   end
 end


### PR DESCRIPTION
# What it does

Pins the time-dependent appointment notification tests to noon so UTC and Chicago agree on the schedule date.

# Why it is important

The test failed on main between 7 p.m. and midnight Chicago time because its appointment landed on the previous local day.