### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -64,11 +64,11 @@ jobs:
       - name: Install libvips
         run: sudo apt-get install -y libvips
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: "package.json"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -80,7 +80,7 @@ jobs:
       - name: Cache Playwright Chromium browser
         if: matrix.test == 'system'
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -117,7 +117,7 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
       #   if: ${{ matrix.test == 'system' && failure() }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ matrix.test == 'system' && failure() }}
         with:
           path: |
@@ -145,13 +145,13 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version-file: "package.json"
 
@@ -184,11 +184,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version-file: "package.json"
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ruby/setup-ruby@v1
       with:
@@ -215,7 +215,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
# What it does

Brings CI onto supported GitHub Actions runtimes.

# Why it is important

GitHub currently forces our Node 20 actions onto Node 24 and warns on every job.