### PR TITLE
Don't show a borrow status for items in maintenance

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -180,7 +180,7 @@ module ItemsHelper
   end
 
   def borrow_status_label(item, tooltip: "borrow status")
-    return unless item.in_circulation?
+    return unless item.active?
 
     status_label item.borrow_status_name,
       css_class: "borrow-status #{Item::BORROW_STATUS_CSS_CLASSES[item.borrow_status]}",

--- a/app/models/concerns/item_statuses.rb
+++ b/app/models/concerns/item_statuses.rb
@@ -53,12 +53,6 @@ module ItemStatuses
     MEMBER_STATUS_NAMES[status]
   end
 
-  # Items that are part of the circulating inventory. Anything else has either
-  # not entered circulation yet or has left it, so its borrow status is moot.
-  def in_circulation?
-    active? || maintenance?
-  end
-
   def retired_reason_name
     RETIRED_REASON_NAMES[retired_reason]
   end

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -95,12 +95,12 @@ class ItemsHelperTest < ActionView::TestCase
       assert_equal "Checked Out", label_text(borrow_status_label(item.reload))
     end
 
-    test "the borrow status label is shown for items still in circulation" do
+    test "the borrow status label is shown for active items" do
       assert_equal "Available", label_text(borrow_status_label(create(:item)))
-      assert_equal "Available", label_text(borrow_status_label(create(:item, :maintenance)))
     end
 
-    test "the borrow status label is not shown for items out of circulation" do
+    test "the borrow status label is not shown for inactive items" do
+      assert_nil borrow_status_label(create(:item, :maintenance))
       assert_nil borrow_status_label(create(:item, status: :pending))
       assert_nil borrow_status_label(create(:item, status: :missing))
       assert_nil borrow_status_label(create(:item, :retired))


### PR DESCRIPTION
# What it does

Fixes #2230 by not showing a borrow status for items in maintenance.